### PR TITLE
Changed lenght of line, which comes through LAN

### DIFF
--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -83,16 +83,16 @@ int log_to_disk(int from_lan)
 
     } else {			// qso from lan
 
-	strncpy(lan_logline, lan_message + 2, 80);
+	strncpy(lan_logline, lan_message + 2, 87);
 	strcat(lan_logline,
 	       "                                                                              ");
 
 	if (cqwwm2 == 1) {
 	    if (lan_logline[0] != thisnode)
-		lan_logline[79] = '*';
+		lan_logline[86] = '*';
 	}
 
-	lan_logline[80] = '\0';
+	lan_logline[87] = '\0';
 
 	score2();
 	addcall2();


### PR DESCRIPTION
Signed-off-by: airween airween@gmail.com

Tom, Nate,

here is a small modification - I've tested the LAN features of Tlf, specially send log through LAN, and looks like the current version cuts the line after 80 characters, which comes from LAN. It's not a big problem, but when this line has been logged (writed to log to disk), Tlf every time detects (wrongly) the logfile is old, and need to update it.

73:
Ervin
