### PR TITLE
Rtty fixup for CQWW contest, W/VE stations

### DIFF
--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -465,6 +465,7 @@ int getexchange(void)
 		        refreshp();
 			break;
 		    }
+		    x = 0;
 		}
 		else {
 		    refreshp();


### PR DESCRIPTION
- There was a bug in getexchange.c: if W/VE user goes to exchange field, and wants to go back without fills this field, Tlf doesn't allow that.
