### PR TITLE
Cleanup scripts/soundlog

### DIFF
--- a/scripts/soundlog
+++ b/scripts/soundlog
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-while [[ -f $HOME/.VRlock ]]
+while [ -f $HOME/.VRlock ]
 do
 		filename="$HOME/tlf/soundlogs/"`eval date +%d%H%M`".au"
 		if test -f $filename
 		then
-			sleep 10s
+			sleep 10
 		else
 			rec -w  -r 8000 $filename > /dev/null 2> /dev/null
 		fi


### PR DESCRIPTION
The first two changes were taken from a [patch](http://sources.debian.net/src/tlf/1.1.5-1/debian/patches/soundlog.patch/) of the Debian package.
The other change removes two bashisms, so that it can also run under a different shell (which seems to be intended with /bin/sh).
