### PR TITLE
Seek to the end of the gMFSK.log when Tlf starts

### DIFF
--- a/src/rtty.c
+++ b/src/rtty.c
@@ -44,6 +44,7 @@ static char ry_term[5][50] = { "", "", "", "", "" };
 int init_controller()
 {
     extern char controllerport[];
+    extern int keyerport;
 
     struct termios termattribs;
 
@@ -68,6 +69,9 @@ int init_controller()
 
     tcsetattr(fdcont, TCSANOW, &termattribs);	/* Set the serial port */
 
+    if (keyerport == GMFSK) {
+       lseek(fdcont, 0, SEEK_END);
+    }
     showstring(controllerport, " opened...\n");
 
     return (fdcont);		// return file descriptor


### PR DESCRIPTION
If Tlf configured for digimode, and uses gMFSK.log to read the output of modem, then it must to wait till Tlf reads the full file (when the "miniterm" is opened). Now Tlf seeks to the end of the gMFSK.log.
