### PR TITLE
Fixed break off auto_cq bug

### DIFF
--- a/src/callinput.c
+++ b/src/callinput.c
@@ -634,6 +634,7 @@ char callinput(void)
 	case 141:		/* F12 */
 	    {
 		x = auto_cq();
+		break;
 	    }
 	case '?':
             {


### PR DESCRIPTION
When Tlf sends CQ in auto mode, and op press the first letter of callsign, that will be lost, only the second letter will visible and will stored.