### PR TITLE
First crack at finding ncurses header files in ncurses directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,9 +20,18 @@ PKG_CHECK_MODULES(GLIB, glib-2.0)
 AC_CHECK_LIB([m], [atan])
 AC_CHECK_LIB([pthread], [pthread_create])
 ACX_PTHREAD
-AC_CHECK_LIB([ncurses], [initscr],,AC_MSG_ERROR([needs ncurses library]))
-AC_CHECK_LIB([panel], [update_panels],,
-		AC_MSG_ERROR([needs ncurses panel library]))
+
+
+dnl Order matters as -lpanel should be before -lncurses and
+dnl AC_SEARCH_LIBS prepends found libraries to @LIBS@ so search
+dnl for the panel library after ncurses to get the correct order.
+AC_SEARCH_LIBS([initscr], [ncurses],,[AC_MSG_ERROR([needs ncurses library])])
+AC_SEARCH_LIBS([update_panels], [panel],,
+	[AC_MSG_ERROR([needs ncurses panel library])
+])
+
+dnl Ncurses libraries have been found, now look for the headers.
+AC_CHECK_HEADERS([ncurses.h curses.h ncurses/ncurses.h ncurses/curses.h panel.h ncurses/panel.h])
 
 # Checks for header files.
 AC_HEADER_STDC

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -29,14 +29,22 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
-#include "addmult.h"
-#include "globalvars.h"		// Includes glib.h and tlf.h
-
 #ifdef HAVE_CONFIG_H
 # include <config.h>
 #endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
+
+#include "addmult.h"
+#include "globalvars.h"		// Includes glib.h and tlf.h
 
 #define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))
 

--- a/src/addspot.c
+++ b/src/addspot.c
@@ -31,7 +31,19 @@
 #include <string.h>
 #include <time.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "get_time.h"
 #include "lancode.h"

--- a/src/audio.c
+++ b/src/audio.c
@@ -32,15 +32,23 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "audio.h"
 #include "tlf.h"
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/autocq.c
+++ b/src/autocq.c
@@ -26,7 +26,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "clear_display.h"
 #include "cw_utils.h"

--- a/src/background_process.c
+++ b/src/background_process.c
@@ -23,7 +23,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "fldigixmlrpc.h"
 #include "getctydata.h"

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -25,7 +25,19 @@
 #include <stdio.h>
 #include <sys/time.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "bandmap.h"
 #include "qtcutil.h"

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -26,7 +26,19 @@
 
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "getctydata.h"
 #include "searchlog.h"		// Includes glib.h

--- a/src/changefreq.c
+++ b/src/changefreq.c
@@ -20,15 +20,23 @@
 
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "freq_display.h"
 #include "time_update.h"
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -31,7 +31,19 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "audio.h"
 #include "changepars.h"
@@ -58,10 +70,6 @@
 #include "ui_utils.h"
 #include "writecabrillo.h"
 #include "writeparas.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/checklogfile.c
+++ b/src/checklogfile.c
@@ -34,7 +34,20 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
+
 #include <glib.h>
 
 #include "startmsg.h"

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -23,7 +23,19 @@
 	 *--------------------------------------------------------------*/
 
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "tlf.h"
 #include "ui_utils.h"

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -27,7 +27,19 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "cw_utils.h"
 #include "get_time.h"

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -29,7 +29,19 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "clear_display.h"
 #include "deleteqso.h"

--- a/src/displayit.c
+++ b/src/displayit.c
@@ -26,7 +26,20 @@
 
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
+
 #include <glib.h>
 
 #include "clear_display.h"

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -28,7 +28,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "logview.h"

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -29,7 +29,19 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "clear_display.h"
 #include "scroll_log.h"

--- a/src/focm.c
+++ b/src/focm.c
@@ -18,7 +18,20 @@
  */
 
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
+
 #include <glib.h>
 
 #include "displayit.h"

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -29,7 +29,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "addspot.h"
 #include "cw_utils.h"

--- a/src/getmessages.c
+++ b/src/getmessages.c
@@ -29,7 +29,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "checklogfile.h"
 #include "dxcc.h"

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -25,15 +25,23 @@
 
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "fldigixmlrpc.h"
 #include "gettxinfo.h"
 #include "tlf.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/getwwv.c
+++ b/src/getwwv.c
@@ -22,7 +22,19 @@
 #include <string.h>
 #include <time.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "tlf.h"
 #include "dxcc.h"

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -20,7 +20,19 @@
 
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "bandmap.h"
 #include "fldigixmlrpc.h"
@@ -28,10 +40,6 @@
 #include "searchlog.h"		// Includes glib.h
 #include "showinfo.h"
 #include "tlf.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -28,7 +28,15 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <panel.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_PANEL_H
+# include <ncurses/panel.h>
+#elif HAVE_PANEL_H
+# include <panel.h>
+#endif
 
 #include "clear_display.h"
 #include "netkeyer.h"

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -31,7 +31,19 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "lancode.h"
 #include "tlf.h"

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -29,7 +29,19 @@
 #include <pthread.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "addcall.h"
 #include "addspot.h"
@@ -41,10 +53,6 @@
 #include "score.h"
 #include "store_qso.h"
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/logit.c
+++ b/src/logit.c
@@ -26,7 +26,19 @@
 
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "tlf.h"
 #include "callinput.h"

--- a/src/logview.c
+++ b/src/logview.c
@@ -25,7 +25,19 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "clear_display.h"
 #include "tlf.h"

--- a/src/main.c
+++ b/src/main.c
@@ -27,7 +27,15 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <panel.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_PANEL_H
+# include <ncurses/panel.h>
+#elif HAVE_PANEL_H
+# include <panel.h>
+#endif
 
 #include "addmult.h"
 #include "background_process.h"
@@ -59,10 +67,6 @@
 #include "splitscreen.h"
 #include "startmsg.h"
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/muf.c
+++ b/src/muf.c
@@ -23,7 +23,15 @@
 #include <string.h>
 #include <time.h>
 
-#include <panel.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_PANEL_H
+# include <ncurses/panel.h>
+#elif HAVE_PANEL_H
+# include <panel.h>
+#endif
 
 #include "dxcc.h"
 #include "get_time.h"

--- a/src/netkeyer.c
+++ b/src/netkeyer.c
@@ -22,7 +22,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "tlf.h"
 #include "netkeyer.h"

--- a/src/nicebox.h
+++ b/src/nicebox.h
@@ -21,7 +21,19 @@
 #ifndef NICEBOX_H
 #define NICEBOX_H
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 void wnicebox(WINDOW *win, int y, int x, int height, int width, char *boxname);
 void nicebox(int y, int x, int height, int width, char *boxname);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -26,7 +26,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "bandmap.h"
 #include "cw_utils.h"
@@ -38,10 +50,6 @@
 #include "qtcvars.h"		// Includes globalvars.h
 #include "setcontest.h"
 #include "startmsg.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/printcall.c
+++ b/src/printcall.c
@@ -23,7 +23,19 @@
 	 *--------------------------------------------------------------*/
 
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "tlf.h"
 #include "ui_utils.h"

--- a/src/qtc_log.c
+++ b/src/qtc_log.c
@@ -26,7 +26,19 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "lancode.h"
 #include "qtc_log.h"

--- a/src/qtcutil.c
+++ b/src/qtcutil.c
@@ -25,7 +25,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -27,7 +27,15 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <panel.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_PANEL_H
+# include <ncurses/panel.h>
+#elif HAVE_PANEL_H
+# include <panel.h>
+#endif
 
 #include "callinput.h"
 #include "cw_utils.h"

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -28,7 +28,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "addmult.h"
 #include "addpfx.h"

--- a/src/readctydata.c
+++ b/src/readctydata.c
@@ -28,15 +28,24 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
+
 #include <glib.h>
 
 #include "dxcc.h"
 #include "tlf.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 
 int readctydata(void)

--- a/src/readqtccalls.c
+++ b/src/readqtccalls.c
@@ -27,7 +27,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h

--- a/src/recall_exchange.c
+++ b/src/recall_exchange.c
@@ -21,7 +21,19 @@
 
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "initial_exchange.h"
 #include "tlf.h"

--- a/src/rtty.c
+++ b/src/rtty.c
@@ -31,7 +31,19 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "printcall.h"
 #include "qtcvars.h"		// Includes globalvars.h

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -27,7 +27,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "qsonr_to_str.h"

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -27,7 +27,15 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <panel.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_PANEL_H
+# include <ncurses/panel.h>
+#elif HAVE_PANEL_H
+# include <panel.h>
+#endif
 
 #include "dxcc.h"
 #include "getctydata.h"
@@ -39,10 +47,6 @@
 #include "searchlog.h"		// Includes glib.h
 #include "ui_utils.h"
 #include "zone_nr.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 
 GPtrArray *callmaster = NULL;

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -28,7 +28,20 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
+
 #include <glib.h>
 
 #include "displayit.h"

--- a/src/setparameters.c
+++ b/src/setparameters.c
@@ -26,7 +26,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "clear_display.h"
 #include "checklogfile.h"

--- a/src/show_help.c
+++ b/src/show_help.c
@@ -27,14 +27,23 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <curses.h>
-#include <glib/gstdio.h>
-
-#include "clear_display.h"
-
 #ifdef HAVE_CONFIG_H
 # include <config.h>
 #endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
+
+#include <glib/gstdio.h>
+
+#include "clear_display.h"
 
 #define new_help 	/* new implementation */
 #ifdef new_help

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -35,7 +35,19 @@
 #include <string.h>
 #include <time.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "dxcc.h"
 #include "qrb.h"

--- a/src/showpxmap.c
+++ b/src/showpxmap.c
@@ -24,7 +24,19 @@
 
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "dxcc.h"
 #include "focm.h"

--- a/src/sockserv.c
+++ b/src/sockserv.c
@@ -30,7 +30,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "sockserv.h"
 

--- a/src/speedupndown.c
+++ b/src/speedupndown.c
@@ -23,7 +23,20 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
+
 #include <glib.h>
 
 #include "clear_display.h"

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -33,7 +33,19 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "bandmap.h"
 #include "clear_display.h"

--- a/src/startmsg.c
+++ b/src/startmsg.c
@@ -20,7 +20,19 @@
 
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "tlf.h"
 

--- a/src/stoptx.c
+++ b/src/stoptx.c
@@ -22,7 +22,19 @@
  	*--------------------------------------------------------------*/
 
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "clear_display.h"
 #include "netkeyer.h"

--- a/src/store_qso.c
+++ b/src/store_qso.c
@@ -26,7 +26,19 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "globalvars.h"		// Includes glib.h and tlf.h
 

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -27,7 +27,19 @@
 
 #include <string.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "bandmap.h"
 #include "clusterinfo.h"

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -20,7 +20,19 @@
 /* User Interface helpers for ncurses based user interface */
 
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "stoptx.h"
 

--- a/src/write_keyer.c
+++ b/src/write_keyer.c
@@ -23,7 +23,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "clear_display.h"
 #include "netkeyer.h"

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -31,15 +31,23 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "getsummary.h"
 #include "qtcvars.h"		// Includes globalvars.h
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 
 extern char call[];

--- a/src/writeparas.c
+++ b/src/writeparas.c
@@ -27,7 +27,19 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
 
 #include "cw_utils.h"
 #include "tlf.h"


### PR DESCRIPTION
Some systems, OpenSuSE LEAP 42.1, for example, put the ncurses header files under /usr/include/ncurses.  This patch set modifies the build system to look for the ncurses headers in either /usr/include or /usr/include/ncurses and when found sets constants in config.h.  Then use CPP tests to load the found file.

This references issue #51
