### PR TITLE
Ncurses search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 Makefile
 Makefile.in
 *.[oa]

--- a/config.h.in
+++ b/config.h.in
@@ -6,6 +6,9 @@
 /* Define to 1 if you have the `bzero' function. */
 #undef HAVE_BZERO
 
+/* Define to 1 if you have the <curses.h> header file. */
+#undef HAVE_CURSES_H
+
 /* Define to 1 if you have the <fcntl.h> header file. */
 #undef HAVE_FCNTL_H
 
@@ -57,11 +60,26 @@
 /* Define to 1 if you have the `mkfifo' function. */
 #undef HAVE_MKFIFO
 
+/* Define to 1 if you have the <ncurses/curses.h> header file. */
+#undef HAVE_NCURSES_CURSES_H
+
+/* Define to 1 if you have the <ncurses.h> header file. */
+#undef HAVE_NCURSES_H
+
+/* Define to 1 if you have the <ncurses/ncurses.h> header file. */
+#undef HAVE_NCURSES_NCURSES_H
+
+/* Define to 1 if you have the <ncurses/panel.h> header file. */
+#undef HAVE_NCURSES_PANEL_H
+
 /* Define to 1 if you have the <netdb.h> header file. */
 #undef HAVE_NETDB_H
 
 /* Define to 1 if you have the <netinet/in.h> header file. */
 #undef HAVE_NETINET_IN_H
+
+/* Define to 1 if you have the <panel.h> header file. */
+#undef HAVE_PANEL_H
 
 /* Define if you have POSIX threads libraries and header files. */
 #undef HAVE_PTHREAD
@@ -198,3 +216,21 @@
 
 /* Define to `int' if <sys/types.h> does not define. */
 #undef ssize_t
+
+
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
+
+#ifdef HAVE_NCURSES_PANEL_H
+# include <ncurses/panel.h>
+#elif HAVE_PANEL_H
+# include <panel.h>
+#endif
+

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_INIT([Tlf],
 	[tlf],
 	[https://github.com/Tlf/tlf])
 AM_INIT_AUTOMAKE
-AC_CONFIG_SRCDIR([config.h.in])
+AC_CONFIG_SRCDIR([src/tlf.h])
 AC_CONFIG_HEADERS([config.h])
 
 dnl Clean compilation output makes compiler warnings more visible

--- a/configure.ac
+++ b/configure.ac
@@ -20,9 +20,13 @@ PKG_CHECK_MODULES(GLIB, glib-2.0)
 AC_CHECK_LIB([m], [atan])
 AC_CHECK_LIB([pthread], [pthread_create])
 ACX_PTHREAD
-AC_CHECK_LIB([ncurses], [initscr],,AC_MSG_ERROR([needs ncurses library]))
+
+AC_CHECK_LIB([ncurses], [initscr],,[AC_MSG_ERROR([needs ncurses library])])
 AC_CHECK_LIB([panel], [update_panels],,
-		AC_MSG_ERROR([needs ncurses panel library]))
+	[AC_MSG_ERROR([needs ncurses panel library])])
+
+dnl Ncurses libraries have been found, now look for the headers.
+AC_CHECK_HEADERS([ncurses.h curses.h ncurses/ncurses.h ncurses/curses.h panel.h ncurses/panel.h])
 
 # Checks for header files.
 AC_HEADER_STDC
@@ -116,5 +120,23 @@ AC_CONFIG_FILES([Makefile
 	share/Makefile
 	src/Makefile
 	tlf.1])
+
+AH_BOTTOM([
+#ifdef HAVE_NCURSES_NCURSES_H
+# include <ncurses/ncurses.h>
+#elif defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#endif
+
+#ifdef HAVE_NCURSES_PANEL_H
+# include <ncurses/panel.h>
+#elif HAVE_PANEL_H
+# include <panel.h>
+#endif
+])
 
 AC_OUTPUT

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -24,19 +24,15 @@
  *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "addmult.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))
 

--- a/src/addspot.c
+++ b/src/addspot.c
@@ -26,12 +26,12 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-
-#include <curses.h>
 
 #include "get_time.h"
 #include "lancode.h"

--- a/src/audio.c
+++ b/src/audio.c
@@ -24,6 +24,8 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <fcntl.h>
 #include <dirent.h>
 #include <errno.h>
@@ -32,15 +34,9 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 
-#include <curses.h>
-
 #include "audio.h"
 #include "tlf.h"
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/autocq.c
+++ b/src/autocq.c
@@ -23,10 +23,10 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "clear_display.h"
 #include "cw_utils.h"

--- a/src/background_process.c
+++ b/src/background_process.c
@@ -19,11 +19,11 @@
  */
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "fldigixmlrpc.h"
 #include "getctydata.h"

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -18,14 +18,14 @@
  */
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <ctype.h>
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/time.h>
-
-#include <curses.h>
 
 #include "bandmap.h"
 #include "qtcutil.h"

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -24,9 +24,9 @@
      *--------------------------------------------------------------*/
 
 
-#include <string.h>
+#include <config.h>		// Includes found ncurses.h
 
-#include <curses.h>
+#include <string.h>
 
 #include "getctydata.h"
 #include "searchlog.h"		// Includes glib.h

--- a/src/changefreq.c
+++ b/src/changefreq.c
@@ -18,17 +18,13 @@
  */
 
 
-#include <unistd.h>
+#include <config.h>		// Includes found ncurses.h
 
-#include <curses.h>
+#include <unistd.h>
 
 #include "freq_display.h"
 #include "time_update.h"
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -24,14 +24,14 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <ctype.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <termios.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "audio.h"
 #include "changepars.h"
@@ -58,10 +58,6 @@
 #include "ui_utils.h"
 #include "writecabrillo.h"
 #include "writeparas.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/checklogfile.c
+++ b/src/checklogfile.c
@@ -26,6 +26,8 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <errno.h>
 #include <ctype.h>
 #include <fcntl.h>
@@ -34,7 +36,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <curses.h>
 #include <glib.h>
 
 #include "startmsg.h"

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -23,7 +23,7 @@
 	 *--------------------------------------------------------------*/
 
 
-#include <curses.h>
+#include <config.h>		// Includes found ncurses.h
 
 #include "tlf.h"
 #include "ui_utils.h"

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -24,10 +24,10 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <string.h>
-
-#include <curses.h>
 
 #include "cw_utils.h"
 #include "get_time.h"

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -24,12 +24,12 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
-
-#include <curses.h>
 
 #include "clear_display.h"
 #include "deleteqso.h"

--- a/src/displayit.c
+++ b/src/displayit.c
@@ -24,9 +24,10 @@
 ---------------------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <string.h>
 
-#include <curses.h>
 #include <glib.h>
 
 #include "clear_display.h"

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -23,12 +23,12 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "logview.h"

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -23,13 +23,13 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
-
-#include <curses.h>
 
 #include "clear_display.h"
 #include "scroll_log.h"

--- a/src/focm.c
+++ b/src/focm.c
@@ -18,7 +18,8 @@
  */
 
 
-#include <curses.h>
+#include <config.h>		// Includes found ncurses.h
+
 #include <glib.h>
 
 #include "displayit.h"

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -25,11 +25,11 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "addspot.h"
 #include "cw_utils.h"

--- a/src/getmessages.c
+++ b/src/getmessages.c
@@ -24,12 +24,12 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "checklogfile.h"
 #include "dxcc.h"

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -23,17 +23,13 @@
 	 *--------------------------------------------------------------*/
 
 
-#include <unistd.h>
+#include <config.h>		// Includes found ncurses.h
 
-#include <curses.h>
+#include <unistd.h>
 
 #include "fldigixmlrpc.h"
 #include "gettxinfo.h"
 #include "tlf.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/getwwv.c
+++ b/src/getwwv.c
@@ -18,11 +18,11 @@
  */
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-
-#include <curses.h>
 
 #include "tlf.h"
 #include "dxcc.h"

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -18,9 +18,9 @@
  */
 
 
-#include <string.h>
+#include <config.h>		// Includes found ncurses.h
 
-#include <curses.h>
+#include <string.h>
 
 #include "bandmap.h"
 #include "fldigixmlrpc.h"
@@ -28,10 +28,6 @@
 #include "searchlog.h"		// Includes glib.h
 #include "showinfo.h"
 #include "tlf.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -25,10 +25,10 @@
 ------------------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found panel.h
+
 #include <stdlib.h>
 #include <string.h>
-
-#include <panel.h>
 
 #include "clear_display.h"
 #include "netkeyer.h"

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -19,6 +19,8 @@
  */
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -30,8 +32,6 @@
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-
-#include <curses.h>
 
 #include "lancode.h"
 #include "tlf.h"

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -25,11 +25,11 @@
 ------------------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <string.h>
 #include <pthread.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "addcall.h"
 #include "addspot.h"
@@ -41,10 +41,6 @@
 #include "score.h"
 #include "store_qso.h"
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/logit.c
+++ b/src/logit.c
@@ -24,9 +24,9 @@
  ------------------------------------------------------------------------*/
 
 
-#include <string.h>
+#include <config.h>		// Includes found ncurses.h
 
-#include <curses.h>
+#include <string.h>
 
 #include "tlf.h"
 #include "callinput.h"

--- a/src/logview.c
+++ b/src/logview.c
@@ -22,10 +22,10 @@
  	*--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdlib.h>
 #include <string.h>
-
-#include <curses.h>
 
 #include "clear_display.h"
 #include "tlf.h"

--- a/src/main.c
+++ b/src/main.c
@@ -20,14 +20,14 @@
  */
 
 
+#include <config.h>		// Includes found panel.h
+
 #include <ctype.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
 #include <termios.h>
 #include <unistd.h>
-
-#include <panel.h>
 
 #include "addmult.h"
 #include "background_process.h"
@@ -59,10 +59,6 @@
 #include "splitscreen.h"
 #include "startmsg.h"
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/muf.c
+++ b/src/muf.c
@@ -19,11 +19,11 @@
  */
 
 
+#include <config.h>		// Includes found panel.h
+
 #include <math.h>
 #include <string.h>
 #include <time.h>
-
-#include <panel.h>
 
 #include "dxcc.h"
 #include "get_time.h"

--- a/src/netkeyer.c
+++ b/src/netkeyer.c
@@ -18,11 +18,11 @@
  */
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <netdb.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "tlf.h"
 #include "netkeyer.h"

--- a/src/nicebox.h
+++ b/src/nicebox.h
@@ -21,7 +21,7 @@
 #ifndef NICEBOX_H
 #define NICEBOX_H
 
-#include <curses.h>
+#include <config.h>		// Includes found ncurses.h
 
 void wnicebox(WINDOW *win, int y, int x, int height, int width, char *boxname);
 void nicebox(int y, int x, int height, int width, char *boxname);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -21,12 +21,12 @@
 */
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "bandmap.h"
 #include "cw_utils.h"
@@ -38,10 +38,6 @@
 #include "qtcvars.h"		// Includes globalvars.h
 #include "setcontest.h"
 #include "startmsg.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #ifdef HAVE_LIBHAMLIB
 # include <hamlib/rig.h>

--- a/src/printcall.c
+++ b/src/printcall.c
@@ -23,7 +23,7 @@
 	 *--------------------------------------------------------------*/
 
 
-#include <curses.h>
+#include <config.h>		// Includes found ncurses.h
 
 #include "tlf.h"
 #include "ui_utils.h"

--- a/src/qtc_log.c
+++ b/src/qtc_log.c
@@ -23,10 +23,10 @@
 ------------------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdlib.h>
 #include <string.h>
-
-#include <curses.h>
 
 #include "lancode.h"
 #include "qtc_log.h"

--- a/src/qtcutil.c
+++ b/src/qtcutil.c
@@ -22,10 +22,10 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -22,12 +22,12 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found panel.h
+
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <panel.h>
 
 #include "callinput.h"
 #include "cw_utils.h"

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -23,12 +23,12 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "addmult.h"
 #include "addpfx.h"

--- a/src/readctydata.c
+++ b/src/readctydata.c
@@ -23,20 +23,17 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
 #include <glib.h>
 
 #include "dxcc.h"
 #include "tlf.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 
 int readctydata(void)

--- a/src/readqtccalls.c
+++ b/src/readqtccalls.c
@@ -22,12 +22,12 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h

--- a/src/recall_exchange.c
+++ b/src/recall_exchange.c
@@ -19,9 +19,9 @@
  */
 
 
-#include <string.h>
+#include <config.h>		// Includes found ncurses.h
 
-#include <curses.h>
+#include <string.h>
 
 #include "initial_exchange.h"
 #include "tlf.h"

--- a/src/rtty.c
+++ b/src/rtty.c
@@ -24,14 +24,14 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <ctype.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
 #include <termios.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "printcall.h"
 #include "qtcvars.h"		// Includes globalvars.h

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -22,12 +22,12 @@
 ---------------------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "qsonr_to_str.h"

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -23,11 +23,11 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found panel.h
+
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <panel.h>
 
 #include "dxcc.h"
 #include "getctydata.h"
@@ -39,10 +39,6 @@
 #include "searchlog.h"		// Includes glib.h
 #include "ui_utils.h"
 #include "zone_nr.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 
 GPtrArray *callmaster = NULL;

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -23,12 +23,12 @@
 ---------------------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <curses.h>
 #include <glib.h>
 
 #include "displayit.h"

--- a/src/setparameters.c
+++ b/src/setparameters.c
@@ -23,10 +23,10 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "clear_display.h"
 #include "checklogfile.h"

--- a/src/show_help.c
+++ b/src/show_help.c
@@ -24,17 +24,14 @@
 	 */
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <curses.h>
 #include <glib/gstdio.h>
 
 #include "clear_display.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 #define new_help 	/* new implementation */
 #ifdef new_help

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -31,11 +31,11 @@
  */
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-
-#include <curses.h>
 
 #include "dxcc.h"
 #include "qrb.h"

--- a/src/showpxmap.c
+++ b/src/showpxmap.c
@@ -22,9 +22,9 @@
 	 *--------------------------------------------------------------*/
 
 
-#include <string.h>
+#include <config.h>		// Includes found ncurses.h
 
-#include <curses.h>
+#include <string.h>
 
 #include "dxcc.h"
 #include "focm.h"

--- a/src/sockserv.c
+++ b/src/sockserv.c
@@ -23,14 +23,14 @@
 /* Written by N2RJT - Dave Brown */
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <errno.h>
 #include <netdb.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "sockserv.h"
 

--- a/src/speedupndown.c
+++ b/src/speedupndown.c
@@ -20,10 +20,11 @@
 
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <unistd.h>
 
-#include <curses.h>
 #include <glib.h>
 
 #include "clear_display.h"

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -25,6 +25,8 @@
 
 #define VERSIONSPLIT "V1.4.1 5/18/96 - N2RJT"
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdlib.h>
@@ -32,8 +34,6 @@
 #include <termios.h>
 #include <unistd.h>
 #include <sys/stat.h>
-
-#include <curses.h>
 
 #include "bandmap.h"
 #include "clear_display.h"

--- a/src/startmsg.c
+++ b/src/startmsg.c
@@ -18,9 +18,9 @@
  */
 
 
-#include <unistd.h>
+#include <config.h>		// Includes found ncurses.h
 
-#include <curses.h>
+#include <unistd.h>
 
 #include "tlf.h"
 

--- a/src/stoptx.c
+++ b/src/stoptx.c
@@ -22,7 +22,7 @@
  	*--------------------------------------------------------------*/
 
 
-#include <curses.h>
+#include <config.h>		// Includes found ncurses.h
 
 #include "clear_display.h"
 #include "netkeyer.h"

--- a/src/store_qso.c
+++ b/src/store_qso.c
@@ -22,11 +22,11 @@
  	*--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <curses.h>
 
 #include "globalvars.h"		// Includes glib.h and tlf.h
 

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -25,9 +25,9 @@
 	 *--------------------------------------------------------------*/
 
 
-#include <string.h>
+#include <config.h>		// Includes found ncurses.h
 
-#include <curses.h>
+#include <string.h>
 
 #include "bandmap.h"
 #include "clusterinfo.h"

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -20,7 +20,7 @@
 /* User Interface helpers for ncurses based user interface */
 
 
-#include <curses.h>
+#include <config.h>		// Includes found ncurses.h
 
 #include "stoptx.h"
 

--- a/src/write_keyer.c
+++ b/src/write_keyer.c
@@ -18,12 +18,12 @@
  */
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "clear_display.h"
 #include "netkeyer.h"

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -26,20 +26,16 @@
 #define _XOPEN_SOURCE 500
 #define _GNU_SOURCE
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "getsummary.h"
 #include "qtcvars.h"		// Includes globalvars.h
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
 
 
 extern char call[];

--- a/src/writeparas.c
+++ b/src/writeparas.c
@@ -22,12 +22,12 @@
 	 *--------------------------------------------------------------*/
 
 
+#include <config.h>		// Includes found ncurses.h
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-#include <curses.h>
 
 #include "cw_utils.h"
 #include "tlf.h"


### PR DESCRIPTION
I hope this looks better than my prior attempt.  In this patch set the CPP ifdef boilerplate is copied to the generated config.h file.  Source files needing to include [n]curses.h or panel.h will get the proper file simply by Including config.h.

Also, since the AC_CONFIG_HEADERS macro will generate config.h.in automatically, there is no need to carry it in the Git repository so the last patch removes it and sets the AC_CONFIG_SRCDIR to look for the tlf.h file to assure the build system is in the correct archive.

This patch set is to resolve issue #51.
