### PR TITLE
Added new feature: calculate the QRG in different modulations, as FSK and LSB/USB

### DIFF
--- a/doc/README.RTTY
+++ b/doc/README.RTTY
@@ -1,0 +1,99 @@
+Tlf RTTY howto
+
+2015, Ervin Hegedus, HA2OS
+
+This is a guide for Tlf, how to use it with Fldigi in RTTY mode,
+especially in FSK, LSB or USB modulations.
+
+To work in RTTY, you need to solve two problems: read and demodulate
+RTTY signals (RX), and send your messages (TX). To demodulate the
+signals, we use the Fldigi, the most popular software for digital
+modes. Fldigi also can modulate, but there are several solutions,
+eg. MFJ 1278, or any other modems, which can be work through serial
+port.
+
+
+Let's see, how works the TX direction with Fldigi.
+
+Important: if you set up your Fldigi instance, don't set up your
+RIG! Tlf needs to handle the RIG, because it needs to tune the VFO,
+to use the bandmap.
+
+First, you have to create some files in your $HOME directory:
+
+~$ touch TLFfldigi
+~$ touch gmfsk_autofile
+
+The TLFfldigi file indicates to Fldigi, that it needs to listen
+the gmfsk_autofile file. Tlf writes its RTTY messages to
+gmfsk_autofile file, and Fldigi can reads that. If you want to look
+that file, when Fldigi runs, then you can't find it - after the
+Fldigi reads RTTY lines from that, then removes it. So, when Tlf
+wants to send a message again, it creates a new one, and Fldigi
+reads that and removes again - so don't worry, if you don't find it.
+
+Now in your logcfg.dat, you have to set up these variables:
+
+RTTYMODE
+GMFSK=/home/YOURUSER/gMFSK.log
+DIGIMODEM=/home/YOURUSER/gmfsk_autofile
+
+Note, that GMFSK directive tells to Tlf, that it can be read the
+output of modem, and it can be shows it in its own modem window.
+(The miniterm window opens when you type the ":miniterm" command
+in callsign field.)
+
+If you want to use a serial port driven FSK modem, just replace
+the DIGIMODEM value for your modem path. Eg. I've build an FSK
+modem with the Arduino board, which reads the serial port of my
+PC. So, I've set it up like this:
+
+DIGIMODEM=/dev/ttyS0
+
+The TX direction of RTTY mode only is that - you don't need to do
+anything in Tlf config - of course, you have to set up your Fldigi
+instance, eg. sound device, etc...
+
+
+The RX mode is a slightly difficult. I don't want to expose that
+here, I suppose that anybody knows that, if works in RTTY. I had
+a "big" problem with Tlf: when I've worked in AFSK, and I moved the
+Fldigi carrier, I could't know exactly, what is the correct QRG of
+my RIG. And it was the problem, because I could't use the cluster
+info, moreover the grabbed spots! So, when I grabbed a station, TLF
+stored it to the currently QRG, but it didn't stored the Fldigi
+carrier shift! So, now the Tlf follows this philosophy below.
+
+The "native" mode is FSK. If you turn on your RIG, and switch to
+FSK mode, tune the VFO to an RTTY station. If you want to see its
+signals in Fldigi, you have to move the Fldigi carrier to 2210Hz.
+Note, that 2210Hz calculated from the space and mark frequency. The
+space is 2125Hz, the mark is 2295Hz. 2295-2125 = 170, 170/2 = 85,
+and 2125+85 = 2210. This value is indicated at bottom-middle of
+Fldigi window.
+
+Note, that you have to swith the Fldigi to reverse mode, so you need
+to push the [Rv] button.
+
+From now on if you find a station on the bandmap, and press the
+CTRL-G (grab the spot), Tlf will tune to VFO that frequency, and
+you can hear the station. That's it. Almost :). In FSK mode, there
+isn't too easy to tune the VFO to the correct QRG. But if Tlf can
+detect, that your RIG is in FSK mode (through CAT system), then
+if you move the Fldigi carrier to an another station (which exists
+eg. on 1000Hz), then Tlf calculates the new VFO frequency, tune the
+RIG to there, and tune Fldigi's carrier to back, 2210Hz.
+
+If you're working in AFSK, then the used modulation is LSB (or USB).
+In this case, you can move the Fldigi's carrier anywhere you want
+(from 85Hz to 2915Hz), Tlf only catch's the Fldigi carrrier's value,
+and calculates the accurate QRG, which indicated on left-middle part
+in Tlf window. If you want to grab a spot (with CTRL-G), then leave
+the Fldigi carrier's as it exists, and grab the next spot. Tlf will
+calculates the requested QRG from the different of the spot and
+Fldigi carrier's frequency, and tune the RIG. That's it.
+
+
+73, Ervin
+HA2OS
+

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -21,6 +21,7 @@
 
 
 #include "startmsg.h"
+#include <stdlib.h>	// need for abs()
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>
@@ -31,9 +32,17 @@
 # include <xmlrpc-c/client.h>
 #endif
 
+#ifdef HAVE_LIBHAMLIB
+# include <hamlib/rig.h>
+#endif
+
 #define NAME "Tlf"
 #define XMLRPCVERSION "1.0"
 
+#define CENTER_FREQ 2210	// low: 2125Hz, high: 2295Hz, shift: 170Hz, 2125+(170/2) = 2210Hz
+#define MAXSHIFT 20		// max shift value in Fldigi, when Tlf set it back to RIG carrier
+
+extern RIG *my_rig;
 
 int fldigi_var_carrier = 0;
 
@@ -43,13 +52,19 @@ int fldigi_xmlrpc_get_carrier() {
     return 0;
 #else
 
+    extern int rigmode;
+    extern int trx_control;
     xmlrpc_env env;
     xmlrpc_value * result;
     xmlrpc_int32 sum;
     xmlrpc_env_init(&env);
+    freq_t rigfreq;
+    int retval;
 
     static int errflg;
     static int trycnt;
+    int signum = -1;
+    int modeshift = 0;
 
     /* if some call timed outs/breaks, we will suspend the call */
     if (errflg > 0 && trycnt < 1000) {
@@ -61,6 +76,7 @@ int fldigi_xmlrpc_get_carrier() {
     trycnt = 0;
     const char * const serverUrl = "http://localhost:7362/RPC2";
     const char * const methodName = "modem.get_carrier";
+    const char * const setmethodName = "modem.set_carrier";
 
     xmlrpc_client_init2(&env, XMLRPC_CLIENT_NO_FLAGS, NAME, XMLRPCVERSION, NULL, 0);
     if (env.fault_occurred) {
@@ -84,6 +100,43 @@ int fldigi_xmlrpc_get_carrier() {
 	return -1;
     }
     fldigi_var_carrier = (int)sum;
+
+#ifdef HAVE_LIBHAMLIB
+    if (trx_control > 0) {
+
+	if (rigmode == RIG_MODE_RTTY || rigmode == RIG_MODE_RTTYR) {
+	    if (fldigi_var_carrier != CENTER_FREQ && abs(CENTER_FREQ - fldigi_var_carrier) > MAXSHIFT) {
+		result = xmlrpc_client_call(&env, serverUrl, setmethodName,
+					"(ii)", (xmlrpc_int32) CENTER_FREQ, (xmlrpc_int32) 7);
+		retval = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);
+		rigfreq += (freq_t)(CENTER_FREQ-fldigi_var_carrier);
+		retval = rig_set_freq(my_rig, RIG_VFO_CURR, rigfreq);
+	    }
+	}
+
+	if (rigmode != RIG_MODE_NONE) {
+	    switch (rigmode) {
+		case RIG_MODE_USB:	signum = 1;
+					break;
+					modeshift = 0;
+		case RIG_MODE_LSB:	signum = -1;
+					break;
+					modeshift = 0;
+		case RIG_MODE_RTTY:	signum = 0;
+					modeshift = -100; // on my TS850, in FSK mode, the QRG is differ by 100Hz up
+							  // possible need to check in other rigs
+					break;
+		case RIG_MODE_RTTYR:	signum = 0;	// not checked - I don't have RTTY-REV mode on my RIG
+					modeshift = -100;
+					break;
+		default:		signum = 0;	// this is the "normal"
+					modeshift = 0;
+	    }
+	    fldigi_var_carrier = ((signum)*fldigi_var_carrier)+modeshift;
+	}
+
+    }
+#endif
 
     xmlrpc_DECREF(result);
     xmlrpc_env_clean(&env);

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -100,6 +100,7 @@ extern int highqsonr;
 
 
 extern int trxmode;
+extern int rigmode;
 extern char lastqsonr[];
 extern int cqwwm2;
 extern char thisnode;

--- a/src/main.c
+++ b/src/main.c
@@ -192,6 +192,7 @@ char exchange_list[40] = "";
 int timeoffset = 0;
 int multi = 0;			/* 0 = SO , 1 = MOST, 2 = MM */
 int trxmode = CWMODE;
+int rigmode = 0;		/* RIG_MODE_NONE in hamlib/rig.h, but if hamlib not compiled, then no dependecy */
 int mixedmode = 0;
 char his_rst[4] = "599";
 char my_rst[4] = "599";


### PR DESCRIPTION
Hi Thomas,
this is a modified version of my previous fldigixmlrpc code. Now Tlf can be distinguished the modes (FSK, LSB/USB), if RIG can tells the mode (with rig_get_mode()). If RIG works in FSK mode, then Tlf set the Fldigi's carrier to 2210Hz always, if user moves it to an another station, and tune the VFO to the calculated QRG. If RIG is in LSB/USB mode, then Fldigi's carrier stay as is, Tlf calculates the accurate QRG, and also tune the VFO.
I've also attached a short RTTY mode README.