### PR TITLE
Adjust tests in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,25 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_PROG_CC
 AC_PROG_INSTALL
 
+# Checks for header files.
+AC_HEADER_STDC
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h \
+	sys/ioctl.h sys/socket.h sys/time.h syslog.h termios.h])
+
+# Checks for typedefs, structures, and compiler characteristics.
+dnl needed? AC_HEADER_STDBOOL
+AC_TYPE_MODE_T
+AC_TYPE_PID_T
+AC_TYPE_SIZE_T
+AC_TYPE_SSIZE_T
+
+# Checks for library functions.
+dnl obsolescent AC_PROG_GCC_TRADITIONAL
+dnl obsolescent AC_FUNC_STRFTIME
+AC_CHECK_FUNCS([bzero floor ftruncate gethostbyname memset mkfifo putenv \
+	select socket sqrt strcasecmp strchr strcspn strdup strpbrk strspn \
+	strstr])
+
 # Checks for libraries.
 PKG_CHECK_MODULES(GLIB, glib-2.0)
 AC_CHECK_LIB([m], [atan])
@@ -23,10 +42,6 @@ ACX_PTHREAD
 AC_CHECK_LIB([ncurses], [initscr],,AC_MSG_ERROR([needs ncurses library]))
 AC_CHECK_LIB([panel], [update_panels],,
 		AC_MSG_ERROR([needs ncurses panel library]))
-
-# Checks for header files.
-AC_HEADER_STDC
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h memory.h netdb.h netinet/in.h stdlib.h string.h sys/ioctl.h sys/socket.h sys/time.h syslog.h termios.h unistd.h])
 
 dnl Check if we want to link the Hamradio control libraries (hamlib)
 AC_ARG_ENABLE([hamlib],
@@ -86,18 +101,6 @@ if test "${ac_cv_c_compiler_gnu}" = "yes"; then
 fi
 
 
-
-# Checks for typedefs, structures, and compiler characteristics.
-AC_HEADER_STDBOOL
-AC_TYPE_MODE_T
-AC_TYPE_PID_T
-AC_TYPE_SIZE_T
-AC_TYPE_SSIZE_T
-
-# Checks for library functions.
-AC_PROG_GCC_TRADITIONAL
-AC_FUNC_STRFTIME
-AC_CHECK_FUNCS([bzero floor ftruncate gethostbyname memset mkfifo putenv select socket sqrt strcasecmp strchr strcspn strdup strpbrk strspn strstr])
 
 # Set PACKAGE_DATA_DIR in config.h.
 if test "x${prefix}" = "xNONE"; then

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_INIT([Tlf],
 	[https://github.com/Tlf/tlf])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([src/tlf.h])
+AC_CONFIG_MACRO_DIR([macros])
 AC_CONFIG_HEADERS([config.h])
 
 dnl Clean compilation output makes compiler warnings more visible
@@ -39,9 +40,22 @@ PKG_CHECK_MODULES(GLIB, glib-2.0)
 AC_CHECK_LIB([m], [atan])
 AC_CHECK_LIB([pthread], [pthread_create])
 ACX_PTHREAD
-AC_CHECK_LIB([ncurses], [initscr],,AC_MSG_ERROR([needs ncurses library]))
-AC_CHECK_LIB([panel], [update_panels],,
-		AC_MSG_ERROR([needs ncurses panel library]))
+
+
+# ncurses and panel required, if not found exit with error message.
+
+dnl macros/ax_with_curses.m4
+AX_WITH_CURSES
+
+AS_IF([test "x$ax_cv_curses" != xyes || test "x$ax_cv_curses_color" != xyes],
+	[AC_MSG_ERROR([a Curses library with color support is required])])
+
+dnl macros/ax_with_curses_extra.m4
+AX_WITH_CURSES_PANEL
+
+AS_IF([test "x$ax_cv_panel" != xyes],
+	[AC_MSG_ERROR([the Curses Panel library is required])])
+
 
 dnl Check if we want to link the Hamradio control libraries (hamlib)
 AC_ARG_ENABLE([hamlib],

--- a/macros/ax_with_curses.m4
+++ b/macros/ax_with_curses.m4
@@ -1,0 +1,526 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_with_curses.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_WITH_CURSES
+#
+# DESCRIPTION
+#
+#   This macro checks whether a SysV or X/Open-compatible Curses library is
+#   present, along with the associated header file.  The NcursesW
+#   (wide-character) library is searched for first, followed by Ncurses,
+#   then the system-default plain Curses.  The first library found is the
+#   one returned.
+#
+#   The following options are understood: --with-ncursesw, --with-ncurses,
+#   --without-ncursesw, --without-ncurses.  The "--with" options force the
+#   macro to use that particular library, terminating with an error if not
+#   found.  The "--without" options simply skip the check for that library.
+#   The effect on the search pattern is:
+#
+#     (no options)                           - NcursesW, Ncurses, Curses
+#     --with-ncurses     --with-ncursesw     - NcursesW only [*]
+#     --without-ncurses  --with-ncursesw     - NcursesW only [*]
+#                        --with-ncursesw     - NcursesW only [*]
+#     --with-ncurses     --without-ncursesw  - Ncurses only [*]
+#     --with-ncurses                         - NcursesW, Ncurses [**]
+#     --without-ncurses  --without-ncursesw  - Curses only
+#                        --without-ncursesw  - Ncurses, Curses
+#     --without-ncurses                      - NcursesW, Curses
+#
+#   [*]  If the library is not found, abort the configure script.
+#
+#   [**] If the second library (Ncurses) is not found, abort configure.
+#
+#   The following preprocessor symbols may be defined by this macro if the
+#   appropriate conditions are met:
+#
+#     HAVE_CURSES             - if any SysV or X/Open Curses library found
+#     HAVE_CURSES_ENHANCED    - if library supports X/Open Enhanced functions
+#     HAVE_CURSES_COLOR       - if library supports color (enhanced functions)
+#     HAVE_CURSES_OBSOLETE    - if library supports certain obsolete features
+#     HAVE_NCURSESW           - if NcursesW (wide char) library is to be used
+#     HAVE_NCURSES            - if the Ncurses library is to be used
+#
+#     HAVE_CURSES_H           - if <curses.h> is present and should be used
+#     HAVE_NCURSESW_H         - if <ncursesw.h> should be used
+#     HAVE_NCURSES_H          - if <ncurses.h> should be used
+#     HAVE_NCURSESW_CURSES_H  - if <ncursesw/curses.h> should be used
+#     HAVE_NCURSES_CURSES_H   - if <ncurses/curses.h> should be used
+#
+#   (These preprocessor symbols are discussed later in this document.)
+#
+#   The following output variable is defined by this macro; it is precious
+#   and may be overridden on the ./configure command line:
+#
+#     CURSES_LIB  - library to add to xxx_LDADD
+#
+#   The library listed in CURSES_LIB is NOT added to LIBS by default. You
+#   need to add CURSES_LIB to the appropriate xxx_LDADD line in your
+#   Makefile.am.  For example:
+#
+#     prog_LDADD = @CURSES_LIB@
+#
+#   If CURSES_LIB is set on the configure command line (such as by running
+#   "./configure CURSES_LIB=-lmycurses"), then the only header searched for
+#   is <curses.h>.  The user may use the CPPFLAGS precious variable to
+#   override the standard #include search path.  If the user needs to
+#   specify an alternative path for a library (such as for a non-standard
+#   NcurseW), the user should use the LDFLAGS variable.
+#
+#   The following shell variables may be defined by this macro:
+#
+#     ax_cv_curses           - set to "yes" if any Curses library found
+#     ax_cv_curses_enhanced  - set to "yes" if Enhanced functions present
+#     ax_cv_curses_color     - set to "yes" if color functions present
+#     ax_cv_curses_obsolete  - set to "yes" if obsolete features present
+#
+#     ax_cv_ncursesw      - set to "yes" if NcursesW library found
+#     ax_cv_ncurses       - set to "yes" if Ncurses library found
+#     ax_cv_plaincurses   - set to "yes" if plain Curses library found
+#     ax_cv_curses_which  - set to "ncursesw", "ncurses", "plaincurses" or "no"
+#
+#   These variables can be used in your configure.ac to determine the level
+#   of support you need from the Curses library.  For example, if you must
+#   have either Ncurses or NcursesW, you could include:
+#
+#     AX_WITH_CURSES
+#     if test "x$ax_cv_ncursesw" != xyes && test "x$ax_cv_ncurses" != xyes; then
+#         AC_MSG_ERROR([requires either NcursesW or Ncurses library])
+#     fi
+#
+#   If any Curses library will do (but one must be present and must support
+#   color), you could use:
+#
+#     AX_WITH_CURSES
+#     if test "x$ax_cv_curses" != xyes || test "x$ax_cv_curses_color" != xyes; then
+#         AC_MSG_ERROR([requires an X/Open-compatible Curses library with color])
+#     fi
+#
+#   Certain preprocessor symbols and shell variables defined by this macro
+#   can be used to determine various features of the Curses library.  In
+#   particular, HAVE_CURSES and ax_cv_curses are defined if the Curses
+#   library found conforms to the traditional SysV and/or X/Open Base Curses
+#   definition.  Any working Curses library conforms to this level.
+#
+#   HAVE_CURSES_ENHANCED and ax_cv_curses_enhanced are defined if the
+#   library supports the X/Open Enhanced Curses definition.  In particular,
+#   the wide-character types attr_t, cchar_t and wint_t, the functions
+#   wattr_set() and wget_wch() and the macros WA_NORMAL and _XOPEN_CURSES
+#   are checked.  The Ncurses library does NOT conform to this definition,
+#   although NcursesW does.
+#
+#   HAVE_CURSES_COLOR and ax_cv_curses_color are defined if the library
+#   supports color functions and macros such as COLOR_PAIR, A_COLOR,
+#   COLOR_WHITE, COLOR_RED and init_pair().  These are NOT part of the
+#   X/Open Base Curses definition, but are part of the Enhanced set of
+#   functions.  The Ncurses library DOES support these functions, as does
+#   NcursesW.
+#
+#   HAVE_CURSES_OBSOLETE and ax_cv_curses_obsolete are defined if the
+#   library supports certain features present in SysV and BSD Curses but not
+#   defined in the X/Open definition.  In particular, the functions
+#   getattrs(), getcurx() and getmaxx() are checked.
+#
+#   To use the HAVE_xxx_H preprocessor symbols, insert the following into
+#   your system.h (or equivalent) header file:
+#
+#     #if defined HAVE_NCURSESW_CURSES_H
+#     #  include <ncursesw/curses.h>
+#     #elif defined HAVE_NCURSESW_H
+#     #  include <ncursesw.h>
+#     #elif defined HAVE_NCURSES_CURSES_H
+#     #  include <ncurses/curses.h>
+#     #elif defined HAVE_NCURSES_H
+#     #  include <ncurses.h>
+#     #elif defined HAVE_CURSES_H
+#     #  include <curses.h>
+#     #else
+#     #  error "SysV or X/Open-compatible Curses header file required"
+#     #endif
+#
+#   For previous users of this macro: you should not need to change anything
+#   in your configure.ac or Makefile.am, as the previous (serial 10)
+#   semantics are still valid.  However, you should update your system.h (or
+#   equivalent) header file to the fragment shown above. You are encouraged
+#   also to make use of the extended functionality provided by this version
+#   of AX_WITH_CURSES, as well as in the additional macros
+#   AX_WITH_CURSES_PANEL, AX_WITH_CURSES_MENU and AX_WITH_CURSES_FORM.
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Mark Pulford <mark@kyne.com.au>
+#   Copyright (c) 2009 Damian Pietras <daper@daper.net>
+#   Copyright (c) 2012 Reuben Thomas <rrt@sc3d.org>
+#   Copyright (c) 2011 John Zaitseff <J.Zaitseff@zap.org.au>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 15
+
+AU_ALIAS([MP_WITH_CURSES], [AX_WITH_CURSES])
+AC_DEFUN([AX_WITH_CURSES], [
+    AC_ARG_VAR([CURSES_LIB], [linker library for Curses, e.g. -lcurses])
+
+dnl As Ncurses is required for Tlf, comment out the AC_ARG_WITH macros
+dnl    AC_ARG_WITH([ncurses], [AS_HELP_STRING([--with-ncurses],
+dnl        [force the use of Ncurses or NcursesW])],
+dnl        [], [with_ncurses=check])
+dnl    AC_ARG_WITH([ncursesw], [AS_HELP_STRING([--without-ncursesw],
+dnl        [do not use NcursesW (wide character support)])],
+dnl        [], [with_ncursesw=check])
+
+dnl Now set the variables to force search for ncurses and ignoring
+dnl ncursesw at this time.
+
+    with_ncursesw=no
+    with_ncurses=yes
+
+    ax_saved_LIBS=$LIBS
+    AS_IF([test "x$with_ncurses" = xyes || test "x$with_ncursesw" = xyes],
+        [ax_with_plaincurses=no], [ax_with_plaincurses=check])
+
+    ax_cv_curses_which=no
+
+    # Test for NcursesW
+
+    AS_IF([test "x$CURSES_LIB" = x && test "x$with_ncursesw" != xno], [
+        LIBS="$ax_saved_LIBS -lncursesw"
+
+        AC_CACHE_CHECK([for NcursesW wide-character library], [ax_cv_ncursesw], [
+            AC_LINK_IFELSE([AC_LANG_CALL([], [initscr])],
+                [ax_cv_ncursesw=yes], [ax_cv_ncursesw=no])
+        ])
+        AS_IF([test "x$ax_cv_ncursesw" = xno && test "x$with_ncursesw" = xyes], [
+            AC_MSG_ERROR([--with-ncursesw specified but could not find NcursesW library])
+        ])
+
+        AS_IF([test "x$ax_cv_ncursesw" = xyes], [
+            ax_cv_curses=yes
+            ax_cv_curses_which=ncursesw
+            CURSES_LIB="-lncursesw"
+            AC_DEFINE([HAVE_NCURSESW], [1], [Define to 1 if the NcursesW library is present])
+            AC_DEFINE([HAVE_CURSES],   [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
+
+            AC_CACHE_CHECK([for working ncursesw/curses.h], [ax_cv_header_ncursesw_curses_h], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@define _XOPEN_SOURCE_EXTENDED 1
+                        @%:@include <ncursesw/curses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        chtype c = COLOR_PAIR(1) & A_COLOR;
+                        attr_t d = WA_NORMAL;
+                        cchar_t e;
+                        wint_t f;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                        init_pair(1, COLOR_WHITE, COLOR_RED);
+                        wattr_set(stdscr, d, 0, NULL);
+                        wget_wch(stdscr, &f);
+                    ]])],
+                    [ax_cv_header_ncursesw_curses_h=yes],
+                    [ax_cv_header_ncursesw_curses_h=no])
+            ])
+            AS_IF([test "x$ax_cv_header_ncursesw_curses_h" = xyes], [
+                ax_cv_curses_enhanced=yes
+                ax_cv_curses_color=yes
+                ax_cv_curses_obsolete=yes
+                AC_DEFINE([HAVE_CURSES_ENHANCED],   [1], [Define to 1 if library supports X/Open Enhanced functions])
+                AC_DEFINE([HAVE_CURSES_COLOR],      [1], [Define to 1 if library supports color (enhanced functions)])
+                AC_DEFINE([HAVE_CURSES_OBSOLETE],   [1], [Define to 1 if library supports certain obsolete features])
+                AC_DEFINE([HAVE_NCURSESW_CURSES_H], [1], [Define to 1 if <ncursesw/curses.h> is present])
+            ])
+
+            AC_CACHE_CHECK([for working ncursesw.h], [ax_cv_header_ncursesw_h], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@define _XOPEN_SOURCE_EXTENDED 1
+                        @%:@include <ncursesw.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        chtype c = COLOR_PAIR(1) & A_COLOR;
+                        attr_t d = WA_NORMAL;
+                        cchar_t e;
+                        wint_t f;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                        init_pair(1, COLOR_WHITE, COLOR_RED);
+                        wattr_set(stdscr, d, 0, NULL);
+                        wget_wch(stdscr, &f);
+                    ]])],
+                    [ax_cv_header_ncursesw_h=yes],
+                    [ax_cv_header_ncursesw_h=no])
+            ])
+            AS_IF([test "x$ax_cv_header_ncursesw_h" = xyes], [
+                ax_cv_curses_enhanced=yes
+                ax_cv_curses_color=yes
+                ax_cv_curses_obsolete=yes
+                AC_DEFINE([HAVE_CURSES_ENHANCED], [1], [Define to 1 if library supports X/Open Enhanced functions])
+                AC_DEFINE([HAVE_CURSES_COLOR],    [1], [Define to 1 if library supports color (enhanced functions)])
+                AC_DEFINE([HAVE_CURSES_OBSOLETE], [1], [Define to 1 if library supports certain obsolete features])
+                AC_DEFINE([HAVE_NCURSESW_H],      [1], [Define to 1 if <ncursesw.h> is present])
+            ])
+
+            AC_CACHE_CHECK([for working ncurses.h], [ax_cv_header_ncurses_h_with_ncursesw], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@define _XOPEN_SOURCE_EXTENDED 1
+                        @%:@include <ncurses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        chtype c = COLOR_PAIR(1) & A_COLOR;
+                        attr_t d = WA_NORMAL;
+                        cchar_t e;
+                        wint_t f;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                        init_pair(1, COLOR_WHITE, COLOR_RED);
+                        wattr_set(stdscr, d, 0, NULL);
+                        wget_wch(stdscr, &f);
+                    ]])],
+                    [ax_cv_header_ncurses_h_with_ncursesw=yes],
+                    [ax_cv_header_ncurses_h_with_ncursesw=no])
+            ])
+            AS_IF([test "x$ax_cv_header_ncurses_h_with_ncursesw" = xyes], [
+                ax_cv_curses_enhanced=yes
+                ax_cv_curses_color=yes
+                ax_cv_curses_obsolete=yes
+                AC_DEFINE([HAVE_CURSES_ENHANCED], [1], [Define to 1 if library supports X/Open Enhanced functions])
+                AC_DEFINE([HAVE_CURSES_COLOR],    [1], [Define to 1 if library supports color (enhanced functions)])
+                AC_DEFINE([HAVE_CURSES_OBSOLETE], [1], [Define to 1 if library supports certain obsolete features])
+                AC_DEFINE([HAVE_NCURSES_H],       [1], [Define to 1 if <ncurses.h> is present])
+            ])
+
+            AS_IF([test "x$ax_cv_header_ncursesw_curses_h" = xno && test "x$ax_cv_header_ncursesw_h" = xno && test "x$ax_cv_header_ncurses_h_with_ncursesw" = xno], [
+                AC_MSG_WARN([could not find a working ncursesw/curses.h, ncursesw.h or ncurses.h])
+            ])
+        ])
+    ])
+
+    # Test for Ncurses
+
+    AS_IF([test "x$CURSES_LIB" = x && test "x$with_ncurses" != xno && test "x$ax_cv_curses_which" = xno], [
+        LIBS="$ax_saved_LIBS -lncurses"
+
+        AC_CACHE_CHECK([for Ncurses library], [ax_cv_ncurses], [
+            AC_LINK_IFELSE([AC_LANG_CALL([], [initscr])],
+                [ax_cv_ncurses=yes], [ax_cv_ncurses=no])
+        ])
+        AS_IF([test "x$ax_cv_ncurses" = xno && test "x$with_ncurses" = xyes], [
+            AC_MSG_ERROR([--with-ncurses specified but could not find Ncurses library])
+        ])
+
+        AS_IF([test "x$ax_cv_ncurses" = xyes], [
+            ax_cv_curses=yes
+            ax_cv_curses_which=ncurses
+            CURSES_LIB="-lncurses"
+            AC_DEFINE([HAVE_NCURSES], [1], [Define to 1 if the Ncurses library is present])
+            AC_DEFINE([HAVE_CURSES],  [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
+
+            AC_CACHE_CHECK([for working ncurses/curses.h], [ax_cv_header_ncurses_curses_h], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@include <ncurses/curses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        chtype c = COLOR_PAIR(1) & A_COLOR;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                        init_pair(1, COLOR_WHITE, COLOR_RED);
+                    ]])],
+                    [ax_cv_header_ncurses_curses_h=yes],
+                    [ax_cv_header_ncurses_curses_h=no])
+            ])
+            AS_IF([test "x$ax_cv_header_ncurses_curses_h" = xyes], [
+                ax_cv_curses_color=yes
+                ax_cv_curses_obsolete=yes
+                AC_DEFINE([HAVE_CURSES_COLOR],     [1], [Define to 1 if library supports color (enhanced functions)])
+                AC_DEFINE([HAVE_CURSES_OBSOLETE],  [1], [Define to 1 if library supports certain obsolete features])
+                AC_DEFINE([HAVE_NCURSES_CURSES_H], [1], [Define to 1 if <ncurses/curses.h> is present])
+            ])
+
+            AC_CACHE_CHECK([for working ncurses.h], [ax_cv_header_ncurses_h], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@include <ncurses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        chtype c = COLOR_PAIR(1) & A_COLOR;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                        init_pair(1, COLOR_WHITE, COLOR_RED);
+                    ]])],
+                    [ax_cv_header_ncurses_h=yes],
+                    [ax_cv_header_ncurses_h=no])
+            ])
+            AS_IF([test "x$ax_cv_header_ncurses_h" = xyes], [
+                ax_cv_curses_color=yes
+                ax_cv_curses_obsolete=yes
+                AC_DEFINE([HAVE_CURSES_COLOR],    [1], [Define to 1 if library supports color (enhanced functions)])
+                AC_DEFINE([HAVE_CURSES_OBSOLETE], [1], [Define to 1 if library supports certain obsolete features])
+                AC_DEFINE([HAVE_NCURSES_H],       [1], [Define to 1 if <ncurses.h> is present])
+            ])
+
+            AS_IF([test "x$ax_cv_header_ncurses_curses_h" = xno && test "x$ax_cv_header_ncurses_h" = xno], [
+                AC_MSG_WARN([could not find a working ncurses/curses.h or ncurses.h])
+            ])
+        ])
+    ])
+
+    # Test for plain Curses (or if CURSES_LIB was set by user)
+
+    AS_IF([test "x$with_plaincurses" != xno && test "x$ax_cv_curses_which" = xno], [
+        AS_IF([test "x$CURSES_LIB" != x], [
+            LIBS="$ax_saved_LIBS $CURSES_LIB"
+        ], [
+            LIBS="$ax_saved_LIBS -lcurses"
+        ])
+
+        AC_CACHE_CHECK([for Curses library], [ax_cv_plaincurses], [
+            AC_LINK_IFELSE([AC_LANG_CALL([], [initscr])],
+                [ax_cv_plaincurses=yes], [ax_cv_plaincurses=no])
+        ])
+
+        AS_IF([test "x$ax_cv_plaincurses" = xyes], [
+            ax_cv_curses=yes
+            ax_cv_curses_which=plaincurses
+            AS_IF([test "x$CURSES_LIB" = x], [
+                CURSES_LIB="-lcurses"
+            ])
+            AC_DEFINE([HAVE_CURSES], [1], [Define to 1 if a SysV or X/Open compatible Curses library is present])
+
+            # Check for base conformance (and header file)
+
+            AC_CACHE_CHECK([for working curses.h], [ax_cv_header_curses_h], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@include <curses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        initscr();
+                    ]])],
+                    [ax_cv_header_curses_h=yes],
+                    [ax_cv_header_curses_h=no])
+            ])
+            AS_IF([test "x$ax_cv_header_curses_h" = xyes], [
+                AC_DEFINE([HAVE_CURSES_H], [1], [Define to 1 if <curses.h> is present])
+
+                # Check for X/Open Enhanced conformance
+
+                AC_CACHE_CHECK([for X/Open Enhanced Curses conformance], [ax_cv_plaincurses_enhanced], [
+                    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                            @%:@define _XOPEN_SOURCE_EXTENDED 1
+                            @%:@include <curses.h>
+                            @%:@ifndef _XOPEN_CURSES
+                            @%:@error "this Curses library is not enhanced"
+                            "this Curses library is not enhanced"
+                            @%:@endif
+                        ]], [[
+                            chtype a = A_BOLD;
+                            int b = KEY_LEFT;
+                            chtype c = COLOR_PAIR(1) & A_COLOR;
+                            attr_t d = WA_NORMAL;
+                            cchar_t e;
+                            wint_t f;
+                            initscr();
+                            init_pair(1, COLOR_WHITE, COLOR_RED);
+                            wattr_set(stdscr, d, 0, NULL);
+                            wget_wch(stdscr, &f);
+                        ]])],
+                        [ax_cv_plaincurses_enhanced=yes],
+                        [ax_cv_plaincurses_enhanced=no])
+                ])
+                AS_IF([test "x$ax_cv_plaincurses_enhanced" = xyes], [
+                    ax_cv_curses_enhanced=yes
+                    ax_cv_curses_color=yes
+                    AC_DEFINE([HAVE_CURSES_ENHANCED], [1], [Define to 1 if library supports X/Open Enhanced functions])
+                    AC_DEFINE([HAVE_CURSES_COLOR],    [1], [Define to 1 if library supports color (enhanced functions)])
+                ])
+
+                # Check for color functions
+
+                AC_CACHE_CHECK([for Curses color functions], [ax_cv_plaincurses_color], [
+                    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@define _XOPEN_SOURCE_EXTENDED 1
+                        @%:@include <curses.h>
+                        ]], [[
+                            chtype a = A_BOLD;
+                            int b = KEY_LEFT;
+                            chtype c = COLOR_PAIR(1) & A_COLOR;
+                            initscr();
+                            init_pair(1, COLOR_WHITE, COLOR_RED);
+                        ]])],
+                        [ax_cv_plaincurses_color=yes],
+                        [ax_cv_plaincurses_color=no])
+                ])
+                AS_IF([test "x$ax_cv_plaincurses_color" = xyes], [
+                    ax_cv_curses_color=yes
+                    AC_DEFINE([HAVE_CURSES_COLOR], [1], [Define to 1 if library supports color (enhanced functions)])
+                ])
+
+                # Check for obsolete functions
+
+                AC_CACHE_CHECK([for obsolete Curses functions], [ax_cv_plaincurses_obsolete], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                        @%:@include <curses.h>
+                    ]], [[
+                        chtype a = A_BOLD;
+                        int b = KEY_LEFT;
+                        int g = getattrs(stdscr);
+                        int h = getcurx(stdscr) + getmaxx(stdscr);
+                        initscr();
+                    ]])],
+                    [ax_cv_plaincurses_obsolete=yes],
+                    [ax_cv_plaincurses_obsolete=no])
+                ])
+                AS_IF([test "x$ax_cv_plaincurses_obsolete" = xyes], [
+                    ax_cv_curses_obsolete=yes
+                    AC_DEFINE([HAVE_CURSES_OBSOLETE], [1], [Define to 1 if library supports certain obsolete features])
+                ])
+            ])
+
+            AS_IF([test "x$ax_cv_header_curses_h" = xno], [
+                AC_MSG_WARN([could not find a working curses.h])
+            ])
+        ])
+    ])
+
+    AS_IF([test "x$ax_cv_curses"          != xyes], [ax_cv_curses=no])
+    AS_IF([test "x$ax_cv_curses_enhanced" != xyes], [ax_cv_curses_enhanced=no])
+    AS_IF([test "x$ax_cv_curses_color"    != xyes], [ax_cv_curses_color=no])
+    AS_IF([test "x$ax_cv_curses_obsolete" != xyes], [ax_cv_curses_obsolete=no])
+
+    LIBS=$ax_saved_LIBS
+])dnl

--- a/macros/ax_with_curses_extra.m4
+++ b/macros/ax_with_curses_extra.m4
@@ -173,7 +173,8 @@ AC_DEFUN([_AX_WITH_CURSES_CHECKEXTRA], [
         AC_DEFINE([_AX_WITH_CURSES_CHECKEXTRA_have_var],        [1], [Define to 1 if the Curses $2 library is present])
         AC_DEFINE([_AX_WITH_CURSES_CHECKEXTRA_have_header_var], [1], [Define to 1 if <$4> is present])
     ], [
-        _AX_WITH_CURSES_CHECKEXTRA_cv_var=no
+        AS_IF([test "x$[]_AX_WITH_CURSES_CHECKEXTRA_cv_var" = xyes], [],
+            [_AX_WITH_CURSES_CHECKEXTRA_cv_var=no])
     ])
     LIBS=$ax_saved_LIBS
 

--- a/macros/ax_with_curses_extra.m4
+++ b/macros/ax_with_curses_extra.m4
@@ -1,0 +1,231 @@
+# ===========================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_with_curses_extra.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_WITH_CURSES_PANEL
+#   AX_WITH_CURSES_MENU
+#   AX_WITH_CURSES_FORM
+#
+# DESCRIPTION
+#
+#   These macros try to find additional libraries that often come with
+#   SysV-compatible Curses.  In particular, the Panel, Menu and Form
+#   libraries are searched, along with their header files.  These macros
+#   depend on AX_WITH_CURSES.
+#
+#   The following preprocessor symbols may be defined by these macros:
+#
+#     By AX_WITH_CURSES_PANEL:
+#
+#     HAVE_PANEL              - if the Panel library is present
+#     HAVE_PANEL_H            - if <panel.h> is present and should be used
+#     HAVE_NCURSES_PANEL_H    - if <ncurses/panel.h> should be used
+#     HAVE_NCURSESW_PANEL_H   - if <ncursesw/panel.h> should be used
+#
+#     By AX_WITH_CURSES_MENU:
+#
+#     HAVE_MENU               - if the Menu library is present
+#     HAVE_MENU_H             - if <menu.h> is present and should be used
+#     HAVE_NCURSES_MENU_H     - if <ncurses/menu.h> should be used
+#     HAVE_NCURSESW_MENU_H    - if <ncursesw/menu.h> should be used
+#
+#     By AX_WITH_CURSES_FORM:
+#
+#     HAVE_FORM               - if the Form library is present
+#     HAVE_FORM_H             - if <form.h> is present and should be used
+#     HAVE_NCURSES_FORM_H     - if <ncurses/form.h> should be used
+#     HAVE_NCURSESW_FORM_H    - if <ncursesw/form.h> should be used
+#
+#   The following output variables may be defined by these macros; these are
+#   precious and may be overridden on the ./configure command line:
+#
+#     PANEL_LIB   - library to add to xxx_LDADD before CURSES_LIB
+#     MENU_LIB    - library to add to xxx_LDADD before CURSES_LIB
+#     FORM_LIB    - library to add to xxx_LDADD before CURSES_LIB
+#
+#   These libraries are NOT added to LIBS by default.  You need to add them
+#   to the appropriate xxx_LDADD line in your Makefile.am in front of the
+#   equivalent CURSES_LIB incantation.  For example:
+#
+#     prog_LDADD = @PANEL_LIB@ @CURSES_LIB@
+#
+#   If one of the xxx_LIB variables is set on the configure command line
+#   (such as by running "./configure PANEL_LIB=-lmypanel"), then the header
+#   file searched must NOT contain a subpath.  In this case, in other words,
+#   only <panel.h> would be searched for.  The user may use the CPPFLAGS
+#   precious variable to override the standard #include search path.
+#
+#   The following shell variables may be defined by these macros:
+#
+#     ax_cv_panel   - set to "yes" if Panels library is present
+#     ax_cv_menu    - set to "yes" if Menu library is present
+#     ax_cv_form    - set to "yes" if Form library is present
+#
+#   These variables can be used in your configure.ac to determine whether a
+#   library you require is actually present.  For example:
+#
+#     AX_WITH_CURSES
+#     if test "x$ax_cv_curses" != xyes; then
+#         AC_MSG_ERROR([requires a SysV or X/Open-compatible Curses library])
+#     fi
+#     AX_WITH_CURSES_PANEL
+#     if test "x$ax_cv_panel" != xyes; then
+#         AC_MSG_ERROR([requires the Curses Panel library])
+#     fi
+#
+#   To use the HAVE_xxx_H preprocessor symbols, insert the following into
+#   your system.h (or equivalent) header file:
+#
+#     For AX_WITH_CURSES_PANEL:
+#
+#     #if defined HAVE_NCURSESW_PANEL_H
+#     #  include <ncursesw/panel.h>
+#     #elif defined HAVE_NCURSES_PANEL_H
+#     #  include <ncurses/panel.h>
+#     #elif defined HAVE_PANEL_H
+#     #  include <panel.h>
+#     #else
+#     #  error "SysV-compatible Curses Panel header file required"
+#     #endif
+#
+#     For AX_WITH_CURSES_MENU:
+#
+#     #if defined HAVE_NCURSESW_MENU_H
+#     #  include <ncursesw/menu.h>
+#     #elif defined HAVE_NCURSES_MENU_H
+#     #  include <ncurses/menu.h>
+#     #elif defined HAVE_MENU_H
+#     #  include <menu.h>
+#     #else
+#     #  error "SysV-compatible Curses Menu header file required"
+#     #endif
+#
+#     For AX_WITH_CURSES_FORM:
+#
+#     #if defined HAVE_NCURSESW_FORM_H
+#     #  include <ncursesw/form.h>
+#     #elif defined HAVE_NCURSES_FORM_H
+#     #  include <ncurses/form.h>
+#     #elif defined HAVE_FORM_H
+#     #  include <form.h>
+#     #else
+#     #  error "SysV-compatible Curses Form header file required"
+#     #endif
+#
+# LICENSE
+#
+#   Copyright (c) 2011 John Zaitseff <J.Zaitseff@zap.org.au>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 2
+
+AC_DEFUN([_AX_WITH_CURSES_CHECKEXTRA], [
+    dnl Parameter 1 is the variable name component, using uppercase letters only
+    dnl Parameter 2 is the printable library name
+    dnl Parameter 3 is the C code to try compiling and linking
+    dnl Parameter 4 is the header filename
+    dnl Parameter 5 is the library command line
+
+    AS_VAR_PUSHDEF([_AX_WITH_CURSES_CHECKEXTRA_have_var],        [HAVE_$1])dnl
+    AS_VAR_PUSHDEF([_AX_WITH_CURSES_CHECKEXTRA_cv_var],          [ax_cv_[]m4_tolower($1)])dnl
+    AS_VAR_PUSHDEF([_AX_WITH_CURSES_CHECKEXTRA_header_var],      [ax_cv_header_$4])dnl
+    AS_VAR_PUSHDEF([_AX_WITH_CURSES_CHECKEXTRA_have_header_var], [HAVE_[]m4_toupper($4)])dnl
+
+    ax_saved_LIBS=$LIBS
+    AC_CACHE_CHECK([for Curses $2 library with $4], [_AX_WITH_CURSES_CHECKEXTRA_header_var], [
+        LIBS="$ax_saved_LIBS $5 $CURSES_LIB"
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+                @%:@include <$4>
+            ]], [$3])],
+            [_AX_WITH_CURSES_CHECKEXTRA_header_var=yes],
+            [_AX_WITH_CURSES_CHECKEXTRA_header_var=no])
+    ])
+    AS_IF([test "x$[]_AX_WITH_CURSES_CHECKEXTRA_header_var" = xyes], [
+        _AX_WITH_CURSES_CHECKEXTRA_cv_var=yes
+        AS_LITERAL_IF([$5], [$1_LIB="$5"])
+        AC_DEFINE([_AX_WITH_CURSES_CHECKEXTRA_have_var],        [1], [Define to 1 if the Curses $2 library is present])
+        AC_DEFINE([_AX_WITH_CURSES_CHECKEXTRA_have_header_var], [1], [Define to 1 if <$4> is present])
+    ], [
+        _AX_WITH_CURSES_CHECKEXTRA_cv_var=no
+    ])
+    LIBS=$ax_saved_LIBS
+
+    AS_VAR_POPDEF([_AX_WITH_CURSES_CHECKEXTRA_have_header_var])dnl
+    AS_VAR_POPDEF([_AX_WITH_CURSES_CHECKEXTRA_header_var])dnl
+    AS_VAR_POPDEF([_AX_WITH_CURSES_CHECKEXTRA_cv_var])dnl
+    AS_VAR_POPDEF([_AX_WITH_CURSES_CHECKEXTRA_have_var])dnl
+])dnl
+
+AC_DEFUN([_AX_WITH_CURSES_EXTRA], [
+    dnl Parameter 1 is the variable name component, using uppercase letters only
+    dnl Parameter 2 is the printable library name
+    dnl Parameter 3 is the C code to try compiling and linking
+    dnl Parameter 4 is the header filename component
+    dnl Parameter 5 is the NCursesW library command line
+    dnl Parameter 6 is the NCurses library command line
+    dnl Parameter 7 is the plain Curses library command line
+
+    AC_REQUIRE([AX_WITH_CURSES])
+    AC_ARG_VAR([$1_LIB], [linker library for Curses $2, e.g. $7])
+
+    AS_IF([test "x$[]$1_LIB" != x], [
+        _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$[]$1_LIB])
+    ], [
+        AS_IF([test "x$ax_cv_curses_which" = xncursesw], [
+            _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [ncursesw/$4], [$5])
+        ], [test "x$ax_cv_curses_which" = xncurses], [
+            _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [ncurses/$4], [$6])
+            _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$6])
+        ], [test "x$ax_cv_curses_which" = xplaincurses], [
+            _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$7])
+        ])
+    ])
+])dnl
+
+AC_DEFUN([AX_WITH_CURSES_PANEL], [
+    _AX_WITH_CURSES_EXTRA([PANEL], [Panel], [[
+            WINDOW *win = newwin(0, 0, 0, 0);
+            PANEL *pan = new_panel(win);
+        ]], [panel.h], [-lpanelw], [-lpanel], [-lpanel])
+])dnl
+
+AC_DEFUN([AX_WITH_CURSES_MENU], [
+    _AX_WITH_CURSES_EXTRA([MENU], [Menu], [[
+            ITEM **mi;
+            MENU *m = new_menu(mi);
+        ]], [menu.h], [-lmenuw], [-lmenu], [-lmenu])
+])dnl
+
+AC_DEFUN([AX_WITH_CURSES_FORM], [
+    _AX_WITH_CURSES_EXTRA([FORM], [Form], [[
+            FIELD **ff;
+            FORM *f = new_form(ff);
+        ]], [form.h], [-lformw], [-lform], [-lform])
+])dnl

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -63,6 +63,6 @@ noinst_HEADERS = \
 	setparameters.h show_help.h showinfo.h showpxmap.h showscore.h \
 	showzones.h sockserv.h speedupndown.h  \
 	splitscreen.h startmsg.h stoptx.h store_qso.h sunup.h \
-	rtty.h time_update.h tlf.h ui_utils.h \
+	rtty.h time_update.h tlf.h tlf_panel.h ui_utils.h \
 	write_keyer.h writecabrillo.h writeparas.h \
 	zone_nr.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,7 +33,7 @@ tlf_SOURCES = \
 	write_keyer.c writecabrillo.c writeparas.c \
 	zone_nr.c
 
-tlf_LDADD = @GLIB_LIBS@
+tlf_LDADD = @GLIB_LIBS@ @PANEL_LIB@ @CURSES_LIB@
 
 noinst_HEADERS = \
 	addarea.h addcall.h addmult.h addpfx.h addspot.h audio.h autocq.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -63,6 +63,6 @@ noinst_HEADERS = \
 	setparameters.h show_help.h showinfo.h showpxmap.h showscore.h \
 	showzones.h sockserv.h speedupndown.h  \
 	splitscreen.h startmsg.h stoptx.h store_qso.h sunup.h \
-	rtty.h time_update.h tlf.h tlf_panel.h ui_utils.h \
+	rtty.h time_update.h tlf.h tlf_curses.h tlf_panel.h ui_utils.h \
 	write_keyer.h writecabrillo.h writeparas.h \
 	zone_nr.h

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -29,10 +29,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "addmult.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "tlf_curses.h"
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>

--- a/src/addspot.c
+++ b/src/addspot.c
@@ -31,12 +31,11 @@
 #include <string.h>
 #include <time.h>
 
-#include <curses.h>
-
 #include "get_time.h"
 #include "lancode.h"
 #include "splitscreen.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 
 int addspot(void)

--- a/src/audio.c
+++ b/src/audio.c
@@ -32,10 +32,9 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 
-#include <curses.h>
-
 #include "audio.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 #ifdef HAVE_CONFIG_H

--- a/src/autocq.c
+++ b/src/autocq.c
@@ -26,14 +26,13 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "clear_display.h"
 #include "cw_utils.h"
 #include "printcall.h"
 #include "sendbuf.h"
 #include "stoptx.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 #include "time_update.h"
 

--- a/src/background_process.c
+++ b/src/background_process.c
@@ -23,8 +23,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "fldigixmlrpc.h"
 #include "getctydata.h"
 #include "get_time.h"
@@ -40,6 +38,7 @@
 #include "set_tone.h"
 #include "splitscreen.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "write_keyer.h"
 
 

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -25,12 +25,11 @@
 #include <stdio.h>
 #include <sys/time.h>
 
-#include <curses.h>
-
 #include "bandmap.h"
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h
 #include "searchcallarray.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 #define TOLERANCE 100 		/* spots with a QRG +/-TOLERANCE

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -26,12 +26,11 @@
 
 #include <string.h>
 
-#include <curses.h>
-
 #include "getctydata.h"
 #include "searchlog.h"		// Includes glib.h
 #include "showinfo.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/changefreq.c
+++ b/src/changefreq.c
@@ -20,10 +20,9 @@
 
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "freq_display.h"
 #include "time_update.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 #ifdef HAVE_CONFIG_H

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -31,8 +31,6 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "audio.h"
 #include "changepars.h"
 #include "clear_display.h"
@@ -55,6 +53,7 @@
 #include "show_help.h"
 #include "showpxmap.h"
 #include "splitscreen.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 #include "writecabrillo.h"
 #include "writeparas.h"

--- a/src/checklogfile.c
+++ b/src/checklogfile.c
@@ -34,11 +34,11 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <curses.h>
 #include <glib.h>
 
 #include "startmsg.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -23,9 +23,8 @@
 	 *--------------------------------------------------------------*/
 
 
-#include <curses.h>
-
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -27,8 +27,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <curses.h>
-
 #include "cw_utils.h"
 #include "get_time.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
@@ -36,6 +34,7 @@
 #include "qsonr_to_str.h"
 #include "searchlog.h"		// Includes glib.h
 #include "showscore.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -29,14 +29,13 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-#include <curses.h>
-
 #include "clear_display.h"
 #include "deleteqso.h"
 #include "printcall.h"
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h
 #include "qsonr_to_str.h"
+#include "tlf_curses.h"
 #include "scroll_log.h"
 #include "ui_utils.h"
 

--- a/src/displayit.c
+++ b/src/displayit.c
@@ -26,10 +26,10 @@
 
 #include <string.h>
 
-#include <curses.h>
 #include <glib.h>
 
 #include "clear_display.h"
+#include "tlf_curses.h"
 
 
 void displayit(void)

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -28,11 +28,10 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "logview.h"
 #include "scroll_log.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 #define NR_LINES 5

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -29,11 +29,10 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-#include <curses.h>
-
 #include "clear_display.h"
 #include "scroll_log.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 
 int logedit(void)

--- a/src/focm.c
+++ b/src/focm.c
@@ -18,7 +18,6 @@
  */
 
 
-#include <curses.h>
 #include <glib.h>
 
 #include "displayit.h"
@@ -26,6 +25,7 @@
 #include "getctydata.h"
 #include "initial_exchange.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -29,8 +29,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "addspot.h"
 #include "cw_utils.h"
 #include "keyer.h"
@@ -47,6 +45,7 @@
 #include "speedupndown.h"
 #include "stoptx.h"
 #include "time_update.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 #define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))

--- a/src/getmessages.c
+++ b/src/getmessages.c
@@ -29,13 +29,12 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "checklogfile.h"
 #include "dxcc.h"
 #include "getctydata.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "qsonr_to_str.h"
+#include "tlf_curses.h"
 
 
 int getmessages(void)

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -25,11 +25,10 @@
 
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "fldigixmlrpc.h"
 #include "gettxinfo.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>

--- a/src/getwwv.c
+++ b/src/getwwv.c
@@ -22,11 +22,10 @@
 #include <string.h>
 #include <time.h>
 
-#include <curses.h>
-
-#include "tlf.h"
 #include "dxcc.h"
 #include "printcall.h"
+#include "tlf.h"
+#include "tlf_curses.h"
 
 
 int getwwv(void)

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -20,14 +20,13 @@
 
 #include <string.h>
 
-#include <curses.h>
-
 #include "bandmap.h"
 #include "fldigixmlrpc.h"
 #include "getctydata.h"
 #include "searchlog.h"		// Includes glib.h
 #include "showinfo.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -28,8 +28,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <panel.h>
-
 #include "clear_display.h"
 #include "netkeyer.h"
 #include "nicebox.h"		// Includes curses.h
@@ -37,6 +35,7 @@
 #include "speedupndown.h"
 #include "stoptx.h"
 #include "tlf.h"
+#include "tlf_panel.h"
 #include "ui_utils.h"
 
 /* size and position of keyer window */

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -31,10 +31,9 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
-#include <curses.h>
-
 #include "lancode.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 
 int lan_socket_descriptor;

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -29,8 +29,6 @@
 #include <pthread.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "addcall.h"
 #include "addspot.h"
 #include "gettxinfo.h"
@@ -40,6 +38,7 @@
 #include "scroll_log.h"
 #include "score.h"
 #include "store_qso.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 #ifdef HAVE_CONFIG_H

--- a/src/logit.c
+++ b/src/logit.c
@@ -26,9 +26,6 @@
 
 #include <string.h>
 
-#include <curses.h>
-
-#include "tlf.h"
 #include "callinput.h"
 #include "clear_display.h"
 #include "getexchange.h"
@@ -41,6 +38,8 @@
 #include "sendqrg.h"		// Sets HAVE_LIBHAMLIB if enabled
 #include "sendspcall.h"
 #include "set_tone.h"
+#include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -27,8 +27,6 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <panel.h>
-
 #include "addmult.h"
 #include "background_process.h"
 #include "bandmap.h"
@@ -58,6 +56,7 @@
 #include "set_tone.h"
 #include "splitscreen.h"
 #include "startmsg.h"
+#include "tlf_panel.h"
 #include "ui_utils.h"
 
 #ifdef HAVE_CONFIG_H

--- a/src/muf.c
+++ b/src/muf.c
@@ -23,12 +23,11 @@
 #include <string.h>
 #include <time.h>
 
-#include <panel.h>
-
 #include "dxcc.h"
 #include "get_time.h"
 #include "sunup.h"
 #include "tlf.h"
+#include "tlf_panel.h"
 #include "ui_utils.h"
 
 #define RADIAN		(180.0 / M_PI)

--- a/src/netkeyer.c
+++ b/src/netkeyer.c
@@ -22,10 +22,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
-#include "tlf.h"
 #include "netkeyer.h"
+#include "tlf.h"
+#include "tlf_curses.h"
 
 
 int netkeyer_port = 6789;

--- a/src/nicebox.h
+++ b/src/nicebox.h
@@ -21,7 +21,7 @@
 #ifndef NICEBOX_H
 #define NICEBOX_H
 
-#include <curses.h>
+#include "tlf_curses.h"
 
 void wnicebox(WINDOW *win, int y, int x, int height, int width, char *boxname);
 void nicebox(int y, int x, int height, int width, char *boxname);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -26,8 +26,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "bandmap.h"
 #include "cw_utils.h"
 #include "getctydata.h"
@@ -38,6 +36,7 @@
 #include "qtcvars.h"		// Includes globalvars.h
 #include "setcontest.h"
 #include "startmsg.h"
+#include "tlf_curses.h"
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>

--- a/src/printcall.c
+++ b/src/printcall.c
@@ -23,9 +23,8 @@
 	 *--------------------------------------------------------------*/
 
 
-#include <curses.h>
-
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/qtc_log.c
+++ b/src/qtc_log.c
@@ -26,12 +26,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <curses.h>
-
 #include "lancode.h"
 #include "qtc_log.h"
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h
+#include "tlf_curses.h"
 
 
 extern int trx_control;

--- a/src/qtcutil.c
+++ b/src/qtcutil.c
@@ -25,10 +25,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h
+#include "tlf_curses.h"
 
 
 GHashTable* qtc_store = NULL; 	/* stores number of QTC's per callsign */

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -27,8 +27,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <panel.h>
-
 #include "callinput.h"
 #include "cw_utils.h"
 #include "genqtclist.h"
@@ -43,6 +41,7 @@
 #include "sendbuf.h"
 #include "speedupndown.h"
 #include "time_update.h"
+#include "tlf_panel.h"
 #include "ui_utils.h"
 #include "write_keyer.h"
 

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -28,8 +28,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "addmult.h"
 #include "addpfx.h"
 #include "get_time.h"
@@ -38,6 +36,7 @@
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "paccdx.h"
 #include "startmsg.h"
+#include "tlf_curses.h"
 #include "zone_nr.h"
 
 

--- a/src/readctydata.c
+++ b/src/readctydata.c
@@ -28,11 +28,11 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
 #include <glib.h>
 
 #include "dxcc.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>

--- a/src/readqtccalls.c
+++ b/src/readqtccalls.c
@@ -27,10 +27,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h
+#include "tlf_curses.h"
 
 
 int qtcdirection = 0;

--- a/src/recall_exchange.c
+++ b/src/recall_exchange.c
@@ -21,10 +21,9 @@
 
 #include <string.h>
 
-#include <curses.h>
-
 #include "initial_exchange.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 
 /** \brief Recall former exchange or lookup initial exchange file

--- a/src/rtty.c
+++ b/src/rtty.c
@@ -31,11 +31,10 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "printcall.h"
 #include "qtcvars.h"		// Includes globalvars.h
 #include "startmsg.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -27,10 +27,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "qsonr_to_str.h"
+#include "tlf_curses.h"
 
 
 void scroll_log(void)

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -27,8 +27,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <panel.h>
-
 #include "dxcc.h"
 #include "getctydata.h"
 #include "getpx.h"
@@ -37,6 +35,7 @@
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h
 #include "searchlog.h"		// Includes glib.h
+#include "tlf_panel.h"
 #include "ui_utils.h"
 #include "zone_nr.h"
 

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -28,13 +28,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <curses.h>
 #include <glib.h>
 
 #include "displayit.h"
 #include "lancode.h"
 #include "netkeyer.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 
 char buffer[81];

--- a/src/setparameters.c
+++ b/src/setparameters.c
@@ -26,8 +26,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "clear_display.h"
 #include "checklogfile.h"
 #include "getmessages.h"
@@ -36,6 +34,7 @@
 #include "scroll_log.h"
 #include "setcontest.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 #include "writeparas.h"
 

--- a/src/show_help.c
+++ b/src/show_help.c
@@ -27,10 +27,10 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <curses.h>
 #include <glib/gstdio.h>
 
 #include "clear_display.h"
+#include "tlf_curses.h"
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -35,11 +35,10 @@
 #include <string.h>
 #include <time.h>
 
-#include <curses.h>
-
 #include "dxcc.h"
 #include "qrb.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/showpxmap.c
+++ b/src/showpxmap.c
@@ -24,12 +24,11 @@
 
 #include <string.h>
 
-#include <curses.h>
-
 #include "dxcc.h"
 #include "focm.h"
 #include "changepars.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/sockserv.c
+++ b/src/sockserv.c
@@ -30,9 +30,8 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "sockserv.h"
+#include "tlf_curses.h"
 
 
 /* This structure holds the buffers for each open socket.  It was an */

--- a/src/speedupndown.c
+++ b/src/speedupndown.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#include <curses.h>
 #include <glib.h>
 
 #include "clear_display.h"
@@ -31,6 +30,7 @@
 #include "netkeyer.h"
 #include "sendbuf.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 
 void setspeed(void) {

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -33,8 +33,6 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-#include <curses.h>
-
 #include "bandmap.h"
 #include "clear_display.h"
 #include "get_time.h"
@@ -42,6 +40,7 @@
 #include "lancode.h"
 #include "splitscreen.h"
 #include "sockserv.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/startmsg.c
+++ b/src/startmsg.c
@@ -20,9 +20,8 @@
 
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "tlf.h"
+#include "tlf_curses.h"
 
 
 static int linectr; // global

--- a/src/stoptx.c
+++ b/src/stoptx.c
@@ -22,11 +22,10 @@
  	*--------------------------------------------------------------*/
 
 
-#include <curses.h>
-
 #include "clear_display.h"
 #include "netkeyer.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 
 int stoptx(void)

--- a/src/store_qso.c
+++ b/src/store_qso.c
@@ -26,9 +26,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <curses.h>
-
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "tlf_curses.h"
 
 
 int store_qso(char *loglineptr)

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -27,8 +27,6 @@
 
 #include <string.h>
 
-#include <curses.h>
-
 #include "bandmap.h"
 #include "clusterinfo.h"
 #include "freq_display.h"
@@ -39,6 +37,7 @@
 #include "printcall.h"
 #include "showscore.h"
 #include "showzones.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 

--- a/src/tlf_curses.h
+++ b/src/tlf_curses.h
@@ -1,6 +1,6 @@
 /*
  * Tlf - contest logging program for amateur radio operators
- * Copyright (C) 2001-2002-2003 Rein Couperus <pa0rct@amsat.org>
+ * Copyright (C) 2015 Nate Bargmann <n0nb@n0nb.us>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,44 +16,28 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
- 	/* ------------------------------------------------------------
- 	*        View Log using "less" function
- 	*
- 	*--------------------------------------------------------------*/
 
 
-#include <stdlib.h>
-#include <string.h>
+/* Collate the macro test boilerplate into this file and then
+ * include this file into the Tlf source files that need [n]curses.h
+ * functions.
+ */
 
-#include "clear_display.h"
-#include "tlf.h"
-#include "tlf_curses.h"
+#ifndef TLF_CURSES_H
+#define TLF_CURSES_H
 
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
 
-int logview(void)
-{
-	extern char logfile[];
-	extern char backgrnd_str[];
+#if defined HAVE_NCURSES_CURSES_H
+# include <ncurses/curses.h>
+#elif defined HAVE_NCURSES_H
+# include <ncurses.h>
+#elif defined HAVE_CURSES_H
+# include <curses.h>
+#else
+# error "SysV or X/Open-compatible Curses header file required"
+#endif
 
-	char comstr[40]  = "";
-	int j, rc;
-
-	strcat(comstr,  "less  +G ");
-	strcat(comstr,  logfile);
-	rc=system(comstr);
-	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-	erase();
-	refreshp();
-	clear_display();
-	attron(COLOR_PAIR(C_LOG)  |  A_STANDOUT);
-
-	for (j = 13 ;  j  <= 23 ; j++){
-		mvprintw(j, 0, backgrnd_str);
-	}
-
-	refreshp();
-
-
-	return(0);
-}
-
+#endif

--- a/src/tlf_panel.h
+++ b/src/tlf_panel.h
@@ -1,0 +1,43 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2015 Nate Bargmann <n0nb@n0nb.us>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+
+/* Collate the macro test boilerplate into this file and then
+ * include this file into the Tlf source files that need panel.h
+ * functions.
+ *
+ * For ncurses including panel.h also includes curses.h.
+ */
+
+#ifndef TLF_PANEL_H
+#define TLF_PANEL_H
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#if defined HAVE_NCURSES_PANEL_H
+# include <ncurses/panel.h>
+#elif defined HAVE_PANEL_H
+# include <panel.h>
+#else
+# error "SysV-compatible Curses Panel header file required"
+#endif
+
+#endif

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -20,11 +20,10 @@
 /* User Interface helpers for ncurses based user interface */
 
 
-#include <curses.h>
-#include <panel.h>
-
 #include <pthread.h>
+
 #include "stoptx.h"
+#include "tlf_panel.h"
 
 
 extern int use_rxvt;

--- a/src/write_keyer.c
+++ b/src/write_keyer.c
@@ -23,11 +23,10 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "clear_display.h"
 #include "netkeyer.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 
 int write_keyer(void)

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -31,10 +31,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "getsummary.h"
 #include "qtcvars.h"		// Includes globalvars.h
+#include "tlf_curses.h"
 #include "ui_utils.h"
 
 #ifdef HAVE_CONFIG_H

--- a/src/writeparas.c
+++ b/src/writeparas.c
@@ -27,10 +27,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curses.h>
-
 #include "cw_utils.h"
 #include "tlf.h"
+#include "tlf_curses.h"
 
 
 int writeparas(void)


### PR DESCRIPTION
Reposition several tests to be run before the tests for third party
packages.

Temporarily comment out the AC_PROG_GCC_TRADITIONAL and AC_FUNC_STRFTIME
macros as the Autoconf documentation states they are obsolescent.

Temporarily comment out the AC_HEADER_STDBOOL macro as no source file
loads stdbool.h at this time.

Remove some header files from AC_CHECK_HEADERS as they are already
checked by the AC_HEADER_STDC macro.