### PR TITLE
Revert local changes to macros/ax_with_curses.m4

### DIFF
--- a/macros/ax_with_curses.m4
+++ b/macros/ax_with_curses.m4
@@ -187,20 +187,12 @@
 AU_ALIAS([MP_WITH_CURSES], [AX_WITH_CURSES])
 AC_DEFUN([AX_WITH_CURSES], [
     AC_ARG_VAR([CURSES_LIB], [linker library for Curses, e.g. -lcurses])
-
-dnl As Ncurses is required for Tlf, comment out the AC_ARG_WITH macros
-dnl    AC_ARG_WITH([ncurses], [AS_HELP_STRING([--with-ncurses],
-dnl        [force the use of Ncurses or NcursesW])],
-dnl        [], [with_ncurses=check])
-dnl    AC_ARG_WITH([ncursesw], [AS_HELP_STRING([--without-ncursesw],
-dnl        [do not use NcursesW (wide character support)])],
-dnl        [], [with_ncursesw=check])
-
-dnl Now set the variables to force search for ncurses and ignoring
-dnl ncursesw at this time.
-
-    with_ncursesw=no
-    with_ncurses=yes
+    AC_ARG_WITH([ncurses], [AS_HELP_STRING([--with-ncurses],
+        [force the use of Ncurses or NcursesW])],
+        [], [with_ncurses=check])
+    AC_ARG_WITH([ncursesw], [AS_HELP_STRING([--without-ncursesw],
+        [do not use NcursesW (wide character support)])],
+        [], [with_ncursesw=check])
 
     ax_saved_LIBS=$LIBS
     AS_IF([test "x$with_ncurses" = xyes || test "x$with_ncursesw" = xyes],

--- a/src/tlf_curses.h
+++ b/src/tlf_curses.h
@@ -30,7 +30,11 @@
 # include <config.h>
 #endif
 
-#if defined HAVE_NCURSES_CURSES_H
+#if defined HAVE_NCURSESW_CURSES_H
+# include <ncursesw/curses.h>
+#elif defined HAVE_NCURSESW_H
+# include <ncursesw.h>
+#elif defined HAVE_NCURSES_CURSES_H
 # include <ncurses/curses.h>
 #elif defined HAVE_NCURSES_H
 # include <ncurses.h>

--- a/src/tlf_panel.h
+++ b/src/tlf_panel.h
@@ -32,7 +32,9 @@
 # include <config.h>
 #endif
 
-#if defined HAVE_NCURSES_PANEL_H
+#if defined HAVE_NCURSESW_PANEL_H
+# include <ncursesw/panel.h>
+#elif defined HAVE_NCURSES_PANEL_H
 # include <ncurses/panel.h>
 #elif defined HAVE_PANEL_H
 # include <panel.h>


### PR DESCRIPTION
Addresses the local changes made to macros/as_with_curses.m4 per issue #57.

This should be merged before the other pull request of this morning.
