### PR TITLE
rework of addmult() function

### DIFF
--- a/src/addmult.c
+++ b/src/addmult.c
@@ -142,51 +142,37 @@ int addmult(void)
 int addmult2(void)
 {
     int n, addarea = 0, found = 0;
-    int i, j, ismult, multlen = 0;
+    int i;
+    int matching_len = 0, idx = -1;
     char ssexchange[21];
 
     shownewmult = -1;
 
+    // --------------------------- arrlss ------------------------------------
     if (arrlss == 1) {		// mult for all bands
-	ismult = 0;
 	strncpy(ssexchange, lan_logline + 54, 20);
 
-	if (mults_possible->len > 0) {
-	    for (i = 0; i < mults_possible->len; i++) {
-		if ((strstr(ssexchange, MULTS_POSSIBLE(i)) != NULL) &&
-		    (strlen(MULTS_POSSIBLE(i)) > 1)) {
+	/* check all possible mults for match and remember the longest one */
+	for (i = 0; i < mults_possible->len; i++) {
+	    if ((strstr(ssexchange, MULTS_POSSIBLE(i)) != NULL)
+		&& (strlen(MULTS_POSSIBLE(i)) > 1)) {
 
-		    ismult = 1;
-		    multlen = strlen(MULTS_POSSIBLE(i));
-		    break;
+		if (strlen(MULTS_POSSIBLE(i)) > matching_len) {
+		    matching_len = strlen(MULTS_POSSIBLE(i));
+		    idx = i;
 		}
 	    }
 	}
 
-	if (ismult != 0) {
-	    for (j = 0; j < multarray_nr; j++) {
-		if (strncmp
-		    (mults[j], strstr(ssexchange, MULTS_POSSIBLE(i)),
-		     multlen) == 0) {
-		    found = 1;
-		    break;
-		}
-	    }
-
-	    if (found == 0) {
-		/* not found, add it */
-		strncpy(mults[multarray_nr],
-			strstr(ssexchange, MULTS_POSSIBLE(i)), multlen);
-		multarray_nr++;
-
-		if (strlen(mults[multarray_nr]) == 2)
-		    strcat(mults[multarray_nr], " ");
-	    }
+	if (idx >= 0) {
+	    remember_multi(MULTS_POSSIBLE(idx), bandinx, ALL_BAND);
 	}
     }
 
+    // --------------------wysiwyg----------------
     if (wysiwyg_once == 1) {
 	for (n = 0; n < multarray_nr; n++) {
+	    /** \todo that is the wrong 'comment' field here */
 	    if (strcmp(mults[n], comment) == 0) {
 		found = 1;
 		break;

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -141,15 +141,16 @@ int addmult(void)
 
 int addmult2(void)
 {
-    int n, addarea = 0, found = 0;
+    int found = 0;
     int i;
     int matching_len = 0, idx = -1;
     char ssexchange[21];
+    char stripped_comment[21];
 
     shownewmult = -1;
 
     // --------------------------- arrlss ------------------------------------
-    if (arrlss == 1) {		// mult for all bands
+    if (arrlss == 1) {
 	strncpy(ssexchange, lan_logline + 54, 20);
 
 	/* check all possible mults for match and remember the longest one */
@@ -171,46 +172,17 @@ int addmult2(void)
 
     // --------------------wysiwyg----------------
     if (wysiwyg_once == 1) {
-	for (n = 0; n < multarray_nr; n++) {
-	    /** \todo that is the wrong 'comment' field here */
-	    if (strcmp(mults[n], comment) == 0) {
-		found = 1;
-		break;
-	    }
-	}
+	strncpy(stripped_comment, lan_logline + 54, 14);
+	g_strchomp(stripped_comment);
 
-	if (found == 0) {
-	    strcpy(mults[multarray_nr], comment);
-	    multarray_nr++;
-	    addarea = 1;
-	    shownewmult = n;
-	}
+	shownewmult = remember_multi(stripped_comment, bandinx, ALL_BAND);
     }
 
-    if ((wysiwyg_multi == 1) && (strlen(comment) > 0)) {
-	for (n = 0; n < multarray_nr; n++) {
-	    if (strcmp(mults[n], comment) == 0) {
-		found = 1;
-		break;
-	    }
-	}
+    if (wysiwyg_multi == 1) {
+	strncpy(stripped_comment, lan_logline + 54, 14);
+	g_strchomp(stripped_comment);
 
-	if (found == 0) {
-	    strcpy(mults[multarray_nr], comment);
-	    mult_bands[multarray_nr] =
-		mult_bands[multarray_nr] | inxes[bandinx];
-	    multarray_nr++;
-	    addarea = 1;
-	    shownewmult = multarray_nr - 1;
-	} else if ((found == 1) && ((mult_bands[n] & inxes[bandinx]) == 0)) {
-	    mult_bands[n] = mult_bands[n] | inxes[bandinx];
-	    addarea = 1;
-	    shownewmult = n;
-	}
-    }
-
-    if (addarea == 1) {
-	multscore[bandinx]++;
+	shownewmult = remember_multi(stripped_comment, bandinx, PER_BAND);
     }
 
     return (found);

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -231,6 +231,12 @@ int addmult2(void)
 }
 
 
+/* compare functions to sort multi by aphabetic order  */
+gint	cmp_size (char **a, char **b) {
+
+    return g_strcmp0(*a, *b);
+}
+
 /** loads possible multipliers from external file
  *
  * Read in the file named by 'multiplierlist' and interpret it as list
@@ -303,6 +309,9 @@ int init_and_load_multipliers(void)
 	}
 
 	fclose(cfp);
+
+	/* do not rely on the order in the mult file but sort it here */
+	g_ptr_array_sort(mults_possible, (GCompareFunc)cmp_size);
     }
 
     return (count);

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -262,7 +262,7 @@ int addmult2(void)
  *
  * \return number of loaded multipliers (nr of entries in mults_possible)
  * */
-int load_multipliers(void)
+int init_and_load_multipliers(void)
 {
     extern GPtrArray *mults_possible;
     extern char multsfile[];	// Set by parse_logcfg()
@@ -272,12 +272,15 @@ int load_multipliers(void)
     char mults_location[_POSIX_PATH_MAX * 2];	// 512 chars.  Larger?
     int count = 0;
 
+    if (mults_possible) {
+	/* free old array if exists */
+	g_ptr_array_free(mults_possible, TRUE);
+    }
+    mults_possible = g_ptr_array_new_with_free_func( g_free );
+
 
     if (strlen(multsfile) == 0) {
-	mvprintw(9, 0, "No multiplier file specified, exiting.. !!\n");
-	refreshp();
-	sleep(5);
-	exit(1);
+	return 0;
     }
 
     // Check for mults file in working directory first

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -48,7 +48,7 @@ int inxes[NBANDS] = \
 int addmult(void)
 {
     int found = 0;
-    int i, j, ismult, multlen = 0;
+    int i, j, ismult = 0, multlen = 0;
     char *stripped_comment;
 
     shownewmult = -1;
@@ -58,17 +58,14 @@ int addmult(void)
 
     // mult for all bands   -------- arrlss --------------
     if (arrlss == 1) {
-	ismult = 0;
 
 	/* is it a possible mult? */
-	if (mults_possible->len > 0) {
-	    for (i = 0; i < mults_possible->len; i++) {
-		if ((strstr(ssexchange, MULTS_POSSIBLE(i)) != NULL)
-		    && (strlen(MULTS_POSSIBLE(i)) > 1)) {
+	for (i = 0; i < mults_possible->len; i++) {
+	    if ((strstr(ssexchange, MULTS_POSSIBLE(i)) != NULL)
+		&& (strlen(MULTS_POSSIBLE(i)) > 1)) {
 
-		    ismult = 1;
-		    break;
-		}
+		ismult = 1;
+		break;
 	    }
 	}
 
@@ -97,16 +94,13 @@ int addmult(void)
     // ---------------------------serial + section ---------------------------
 
     if ((serial_section_mult == 1) || (sectn_mult == 1)) {
-	ismult = 0;
 
 	/* is it a possible mult? */
-	if (mults_possible->len > 0) {
-	    for (i = 0; i < mults_possible->len; i++) {
-		// check if valid mult....
-		if (strcmp(ssexchange, MULTS_POSSIBLE(i)) == 0) {
-		    ismult = 1;
-		    break;
-		}
+	for (i = 0; i < mults_possible->len; i++) {
+	    // check if valid mult....
+	    if (strcmp(ssexchange, MULTS_POSSIBLE(i)) == 0) {
+		ismult = 1;
+		break;
 	    }
 	}
 
@@ -119,24 +113,20 @@ int addmult(void)
 
     if ((dx_arrlsections == 1) &&
 	((countrynr == w_cty) || (countrynr == ve_cty))) {
+
 	char *ptr;		// local pointer
 
-	ismult = 0;
-
 	/* is it a possible mult? */
-	if (mults_possible->len > 0) {
-	    // check if valid mult.
-	    for (i = 0; i < mults_possible->len; i++) {
-		ptr = strstr(ssexchange, MULTS_POSSIBLE(i));
+	// check if valid mult.
+	for (i = 0; i < mults_possible->len; i++) {
+	    ptr = strstr(ssexchange, MULTS_POSSIBLE(i));
 
-		if (ptr != NULL) {
-		    ismult = 1;
-		    multlen = strlen(MULTS_POSSIBLE(i));
+	    if (ptr != NULL) {
+		ismult = 1;
 
-		    if (strlen(MULTS_POSSIBLE(i)) == strlen(ptr))
-			break;
+		if (strlen(MULTS_POSSIBLE(i)) == strlen(ptr))
+		    break;
 
-		}
 	    }
 	}
 
@@ -150,11 +140,11 @@ int addmult(void)
 	shownewmult = remember_multi(stripped_comment, bandinx, 0);
     }
 
-    if (wysiwyg_multi == 1 && strlen(stripped_comment) > 0) {
+    if (wysiwyg_multi == 1) {
 	shownewmult = remember_multi(stripped_comment, bandinx, 1);
     }
 
-    if (serial_grid4_mult == 1 && strlen(section) > 0) {
+    if (serial_grid4_mult == 1) {
 	section[4] = '\0';
 	shownewmult = remember_multi(section, bandinx, 1);
     }

--- a/src/addmult.h
+++ b/src/addmult.h
@@ -23,7 +23,7 @@
 
 int addmult( void);
 int addmult2( void);
-int load_multipliers(void);
+int init_and_load_multipliers(void);
 int remember_multi(char *multiplier, int band, int show_new_band);
 void init_mults();
 

--- a/src/main.c
+++ b/src/main.c
@@ -639,12 +639,17 @@ int databases_load()
 	return EXIT_FAILURE;
     }
 
-    mults_possible = g_ptr_array_new();
 
     if (multlist == 1) {
 	showmsg("reading multiplier data      ");
-	load_multipliers();
+	if (strlen(multsfile) == 0) {
+	    mvprintw(9, 0, "No multiplier file specified, exiting.. !!\n");
+	    refreshp();
+	    sleep(5);
+	    exit(1);
+	}
     }
+    init_and_load_multipliers();
 
     showmsg("reading callmaster data");
     load_callmaster();


### PR DESCRIPTION
The proposed patch provides some cleanup and error correction for loading an external multfile and registering multis. It contains the following changes:

- Drop not needed code and double checks for border conditions
- Use the existing 'remember_multi()' function also for arrl Sweep stake registration
- init_init_and_load_multipliers() (former load_multipliers() )  is now responsible for (freeing and new) allocation of the mults_possible array.
It now handles empty multplier filenames gracefully by giving back an empty mults_possible array. The former check for naming the file is now  the responsibility of the calling function (if needed) 
- The tests for possible multis for ARRL_SS and DX_&_SECTIONS are improved.  The new logic scans all possible multis and keeps the longest one which matches. That should fix #50.
- Keeps the array of possible multis sorted.

There are still problems in addmult2() function which is used for handling data coming from a networked tlf station. That has still to be fixed.

Please review and comment.

Tom