### PR TITLE
Fixed hamlib-related variable compile error

### DIFF
--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -60,7 +60,9 @@ int fldigi_xmlrpc_get_carrier() {
     xmlrpc_value * result;
     xmlrpc_int32 sum;
     xmlrpc_env_init(&env);
+#ifdef HAVE_LIBHAMLIB
     freq_t rigfreq;
+#endif
     int retval;
 
     static int errflg;


### PR DESCRIPTION
There is a missed hamlib-related variable, which needs to placed in #ifdef macro.