### PR TITLE
Use memmove() for overlapping strings.

### DIFF
--- a/src/sockserv.c
+++ b/src/sockserv.c
@@ -412,7 +412,7 @@ int recvline(int *fd, char *buf, int buflen)
 			len = sockbuf[ifds].buflen;
 		    memcpy(buf, sockbuf[ifds].buf, len);
 		    if (sockbuf[ifds].buflen > len)
-			memcpy(sockbuf[ifds].buf, sockbuf[ifds].buf + len,
+			memmove(sockbuf[ifds].buf, sockbuf[ifds].buf + len,
 			       sockbuf[ifds].buflen - len);
 		    sockbuf[ifds].buflen -= len;
 		    *fd = ifds;


### PR DESCRIPTION
Checking Tlf with Valgrind showed that memcpy() was assigning a string
back onto itself.  The Glibc documentation says doing so will result in
undefined behavior and recommends using memmove() instead.