### PR TITLE
added option to use backspace in the keyer window

### DIFF
--- a/src/keyer.c
+++ b/src/keyer.c
@@ -59,6 +59,7 @@ int keyer(void)
     extern int cwkeyer;
     extern int digikeyer;
     extern int weight;
+    extern int keyer_backspace;
 
     WINDOW *win = NULL;
     PANEL *panel = NULL;
@@ -133,6 +134,23 @@ int keyer(void)
 
 	    break;
 	}
+
+
+        if (x == KEY_BACKSPACE
+            || x == KEY_DC /* delete-character key */
+            || x == KEY_LEFT) {
+
+            x = 0;  // default: no operation
+
+            if (keyer_backspace && keyerstringpos > 0) {
+                //
+                // remove last char
+                //
+                --keyerstringpos;
+                keyerstring[keyerstringpos] = '\0';
+                x = KEY_BACKSPACE;
+            }
+        }
 
 	// Promote lower case to upper case.
 	if (x > 96 && x < 123)
@@ -291,6 +309,11 @@ int keyer(void)
 		{
 
 		    sendmessage(message[11]);	/* F12 */
+		    break;
+		}
+	    case KEY_BACKSPACE:
+		{
+		    sendmessage("\b");          /* ASCII BS */
 		    break;
 		}
 

--- a/src/main.c
+++ b/src/main.c
@@ -316,6 +316,7 @@ int cwkeyer = NO_KEYER;
 int digikeyer = NO_KEYER;
 
 char keyer_device[10] = "";	// ttyS0, ttyS1, lp0-2 for net_keyer
+int keyer_backspace = 0;        // disabled
 
 char controllerport[80] = "/dev/ttyS0"; // for GMFSK or MFJ-1278
 char rttyoutput[120];		// where to GMFSK digimode output

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -49,6 +49,7 @@
 
 extern int cwkeyer;
 extern int digikeyer;
+extern int keyer_backspace;
 extern char tonestr[];
 extern int partials;
 extern int use_part;
@@ -69,7 +70,7 @@ void KeywordNotSupported(char *keyword);
 void ParameterNeeded(char *keyword);
 void WrongFormat(char *keyword);
 
-#define  MAX_COMMANDS 236	/* commands in list */
+#define  MAX_COMMANDS 237	/* commands in list */
 
 
 int read_logcfg(void)
@@ -540,7 +541,8 @@ int parse_logcfg(char *inputbuffer)
 	"FLDIGI",
 	"RIGPTT",
 	"MINITEST",
-	"UNIQUE_CALL_MULTI"		/* 235 */
+	"UNIQUE_CALL_MULTI",		/* 235 */
+        "KEYER_BACKSPACE"
     };
 
     char **fields;
@@ -1867,6 +1869,10 @@ int parse_logcfg(char *inputbuffer)
 		    sleep(5);
 		    exit(1);
 	    }
+	    break;
+    }
+    case 236: { // KEYER_BACKSPACE
+	    keyer_backspace = 1;
 	    break;
     }
     default: {


### PR DESCRIPTION
This is for the fast but not perfectly typers: it allows erasing the last character in the keyer window using backspace/delete/arrow-left key.
Upcoming libcw (and thus cwdaemon) will support removing queued character using ASCII BS (0x08).
By default this feature is disabled so normal use is not affected.
(note: as tlf has no information if a char has been already sent one can always backspace until the first char)
