### PR TITLE
fixing segv related to failed cluster connection

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -866,8 +866,7 @@ void tlf_cleanup()
 	pthread_join(background_thread, NULL);
     }
 
-//    commented out for the moment as it will segfault if called twice
-//    cleanup_telnet();
+    cleanup_telnet();
 
     if (trxmode == CWMODE && cwkeyer == NET_KEYER)
 	netkeyer_close();

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -749,7 +749,6 @@ int init_packet(void)
 
     struct termios termattribs;
 
-    int addrarg;
     int iptr = 0;
     mode_t mode = 0666;
 
@@ -757,8 +756,6 @@ int init_packet(void)
     attr[NORMAL_ATTR] = A_NORMAL;
     attr[MINE_ATTR] = modify_attr(A_NORMAL);
     attr[ENTRY_ATTR] = modify_attr(A_NORMAL);
-
-    addrarg = 0;
 
     if (initialized == 0) {
 
@@ -954,6 +951,10 @@ int cleanup_telnet(void)
     extern int packetinterface;
     extern int fdSertnc;
 
+    if (!initialized) {
+        return 0;
+    }
+
     if (packetinterface == TELNET_INTERFACE) {
 	if (prsock > 0)
 	    close_s(prsock);
@@ -1003,8 +1004,12 @@ int packet()
     char line[BUFFERSIZE];
 
     int i = 0;
-    int c, count;
+    int c;
     static int sent_login = 0;
+
+    if (!initialized) {
+        return 0;
+    }
 
     in_packetclient = 1;
     sleep(1);
@@ -1015,8 +1020,6 @@ int packet()
 
     wclear(entwin);
     wrefresh(entwin);
-
-    count = 0;
 
     if ((tln_loglines == 0) && (packetinterface == TELNET_INTERFACE)) {
 	addtext("Welcome to TLF telnet\n\n");

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -35,6 +35,8 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
+#define SPLITSCREEN_H_PRIVATE
+
 #include "bandmap.h"
 #include "clear_display.h"
 #include "get_time.h"

--- a/src/splitscreen.h
+++ b/src/splitscreen.h
@@ -20,11 +20,19 @@
 #ifndef SPLITSCREEN_H
 #define SPLITSCREEN_H
 
-#define SERVICE "telnet"
+int init_packet(void) ;
+int cleanup_telnet (void);
+int packet(void);
+int send_cluster(void);
+void addtext(char *s);
+int receive_packet(void);
 
-#define ALLOWCOLOR has_colors()
+
+#ifdef SPLITSCREEN_H_PRIVATE
+
 #define ENTRYROWS 2
 #define BUFFERSIZE 256
+
 #define SCROLLSIZE (LINES/4*3+1)
 #define DEFAULTTLN_LOGLINES 300
 
@@ -36,34 +44,29 @@
 #define STATE_VIEWING 1
 
 
-
 void addlog (char *s);
- int logattr(void);
- char *firstlog(void);
- char *lastlog(void);
+int logattr(void);
+char *firstlog(void);
+char *lastlog(void);
 char *nextlog(void);
 char *prevlog(void);
- void start_editing(void);
+void start_editing(void);
 void delete_prev_char(void);
 void right_arrow(void);
 void left_arrow(void);
 void move_eol(void);
- void gather_input(char *s);
+void gather_input(char *s);
 int walkup(void);
 int walkdn(void);
 int pageup(int lines);
 int pagedn(int lines);
 void viewbottom(void);
- void viewtop(void);
- void resume_editing(void);
- void viewlog(void);
- int edit_line(int c);
+void viewtop(void);
+void resume_editing(void);
+void viewlog(void);
+int edit_line(int c);
 void sanitize(char *s);
- void addtext(char *s);
-int init_packet(void) ;
-int cleanup_telnet (void);
-int packet(void);
-int receive_packet(void);
-int send_cluster(void);
+
+#endif /* SPLITSCREEN_H_PRIVATE */
 
 #endif /* end of include guard: SPLITSCREEN_H */


### PR DESCRIPTION
Reconnection after an initially failed cluster connection using the change parameters mode leads to segfault.

Steps to reproduce:
1) configure a non-reachable cluster access
2) start Tlf and enter change parameters menu by pressing colon (:)
3) either try to reconnect (RECON) or leave the menu (Enter)
Both produce segv.

The code tries to use curses objects that were freed after the failed connection.
I've added guards against this in two functions. Other functions are non susceptible as they have implicit checks.

Also removed unused variables. In the second commit the header file is a bit cleaned up and public/private functions are separated.
