### PR TITLE
Switch back to normal keypad mode in logview

### DIFF
--- a/src/logview.c
+++ b/src/logview.c
@@ -53,6 +53,7 @@ int logview(void)
 
 	refreshp();
 
+        keypad(stdscr, TRUE);
 
 	return(0);
 }


### PR DESCRIPTION
This fixes loss of cursor key functionality once the log view feature has been triggered.
Keypad mode was not restored after executing external pager program.

Steps to reproduce:
- add at least one log line
- press cursor up until log view is started (try to move above the topmost log line)
- exit `less` by pressing `q`
- upon return to the main screen cursor keys stop working (showing only A-B-C-D chars)
