### PR TITLE
limit freq polling to 200 ms; reuse freq2band func

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -36,14 +36,7 @@
 #include "tlf.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
-
-#ifdef HAVE_LIBHAMLIB
-# include <hamlib/rig.h>
-#endif
+#include "gettxinfo.h"
 
 #ifdef __OpenBSD__
 # include <soundcard.h>
@@ -394,13 +387,6 @@ int drawSmeter(int xpos, int ypos, int yheight, float testvalue)
 
 int panscan(void)
 {
-
-#ifdef HAVE_LIBHAMLIB
-    extern freq_t outfreq;
-#else
-    extern int outfreq;
-#endif
-
     int rc, j, key = 0;
     float testvalue;
     float FromFrequency = 0.0;
@@ -459,16 +445,12 @@ int panscan(void)
 	    int i;
 
 	    for (i = 0; i < 100; i++) {
-		if (outfreq == 0)
+		if (get_outfreq() == 0)
 		    break;
-		usleep(10000);
+		usleep(10 * 1000);
 	    }
 
-#ifdef HAVE_LIBHAMLIB
-	    outfreq = (freq_t) (frequencies[j] * 1000);
-#else
-	    outfreq = (int) (frequencies[j] * 1000);
-#endif
+	    set_outfreq(frequencies[j] * 1000);
 
 	    usleep(50 * 1000);
 	    testvalue = get_audio_sample();
@@ -496,12 +478,6 @@ int panscan(void)
 
 int nbscan(void)
 {
-#ifdef HAVE_LIBHAMLIB
-    extern freq_t outfreq;
-#else
-    extern int outfreq;
-#endif
-
     int rc, j, key = 0;
     float testvalue;
     float FromFrequency = 0.0;
@@ -559,15 +535,13 @@ int nbscan(void)
 	    int i;
 
 	    for (i = 0; i < 100; i++) {
-		if (outfreq == 0)
+		if (get_outfreq() == 0)
 		    break;
-		usleep(10000);
+		usleep(10 * 1000);
 	    }
-#ifdef HAVE_LIBHAMLIB
-	    outfreq = (freq_t) (frequencies[j] * 1000);
-#else
-	    outfreq = (int) (frequencies[j] * 1000);
-#endif
+
+	    set_outfreq(frequencies[j] * 1000);
+
 	    usleep(50 * 1000);
 	    testvalue = get_audio_sample();
 	    values[j] = testvalue;

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -45,7 +45,7 @@
 				/* 3 space before and 1 after call */
 
 
-unsigned int bandcorner[NBANDS][2] =
+const unsigned int bandcorner[NBANDS][2] =
 {{ 1800000, 2000000 },	// band bottom, band top
  { 3500000, 4000000 },
  { 7000000, 7300000 },
@@ -57,7 +57,7 @@ unsigned int bandcorner[NBANDS][2] =
  { 28000000, 29700000 },
  {        0,        0 }};
 
-unsigned int cwcorner[NBANDS] =
+const unsigned int cwcorner[NBANDS] =
 { 1838000,
   3580000,
   7040000,
@@ -69,7 +69,7 @@ unsigned int cwcorner[NBANDS] =
   28070000,
          0};
 
-unsigned int ssbcorner[NBANDS] =
+const unsigned int ssbcorner[NBANDS] =
 { 1840000,
   3600000,
   7040000,
@@ -237,20 +237,20 @@ void bm_init() {
 }
 
 
-/** \brief convert frequency to bandnumber
+/** \brief convert frequency in Hz to bandindex
  *
- * \return	bandnumber or -1 if not in any band
+ * \return	bandindex or BANDINDEX_OOB if not in any band
  */
 int freq2band(unsigned int freq) {
     int i;
 
     for (i = 0; i < NBANDS; i++) {
-	if (freq >= (unsigned int)bandcorner[i][0] &&
-		    freq <= (unsigned int)bandcorner[i][1])
+	if (freq >= bandcorner[i][0] &&
+		    freq <= bandcorner[i][1])
 	    return i;	/* in actual band */
     }
 
-    return -1;		/* not in any band */
+    return BANDINDEX_OOB;   /* not in any band (out of band) */
 }
 
 
@@ -336,7 +336,7 @@ void bandmap_addspot( char *call, unsigned int freq, char node) {
 	return;
 
     band = freq2band(freq);
-    if (band < 0)	/* no ham band */
+    if (band == BANDINDEX_OOB)  /* no ham band */
 	return;
 
     mode = freq2mode(freq, band);
@@ -661,7 +661,7 @@ void next_spot_position (int *y, int *x) {
  * Otherwise calculate center frequency from band and mode
  * as middle value of the band/mode corners.
  */
-float bm_get_center(band, mode)
+float bm_get_center(int band, int mode)
 {
     float centerfrequency;
 

--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -21,6 +21,8 @@
 #ifndef _BANDMAP_H
 #define _BANDMAP_H
 
+#include "tlf.h"
+
 typedef struct {
     char 	*call;
     int 	freq;	/* freq in Hz */

--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -146,4 +146,10 @@ spot *bandmap_lookup(char *partialcall);
 spot *bandmap_next(unsigned int upwards, unsigned int freq);
 
 void get_spot_on_qrg(char *dest, float freq);
+
+/** \brief convert frequency in Hz to bandindex
+ *
+ * \return	bandindex or BANDINDEX_OOB if not in any band
+ */
+int freq2band(unsigned int freq);
 #endif

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -44,6 +44,7 @@
 #include "edit_last.h"
 #include "deleteqso.h"
 #include "getctydata.h"
+#include "gettxinfo.h"
 #include "grabspot.h"
 #include "lancode.h"
 #include "muf.h"
@@ -990,12 +991,14 @@ char callinput(void)
 	// Ctrl-G (^G), grab next DX spot from bandmap.
 	case 7:
 	    {
-		grab_next();
-		grab.state = IN_PROGRESS;
-		grab.spotfreq = outfreq/1000.;
-		attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-		mvprintw(0, 2, "%s", mode);
-		freqstore = 0;
+		double f = grab_next();
+                if (f > 0.0) {
+                    grab.state = IN_PROGRESS;
+                    grab.spotfreq = f/1000.;
+                    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+                    mvprintw(0, 2, "%s", mode);
+                    freqstore = 0;
+                }
 
 		break;
 	    }
@@ -1003,12 +1006,14 @@ char callinput(void)
 	// Alt-g (M-g), grab first spot matching call field chars.
 	case 231:
 	    {
-		grabspot();
-		grab.state = IN_PROGRESS;
-		grab.spotfreq = outfreq/1000.;
-		attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-		mvprintw(0, 2, "%s", mode);
-		freqstore = 0;
+		double f = grabspot();
+                if (f > 0.0) {
+                    grab.state = IN_PROGRESS;
+                    grab.spotfreq = f/1000.;
+                    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+                    mvprintw(0, 2, "%s", mode);
+                    freqstore = 0;
+                }
 
 		break;
 	    }
@@ -1422,9 +1427,9 @@ void handle_bandswitch(int direction) {
     attron(COLOR_PAIR(C_WINDOW) | A_STANDOUT);
     mvprintw(12, 0, band[bandinx]);
 
-    if (trx_control == 1) {
-        freq = bandfrequency[bandinx];
-        outfreq = (int) (bandfrequency[bandinx] * 1000);
+    if (trx_control) {
+        freq = bandfrequency[bandinx]; // TODO: is this needed?
+        set_outfreq(bandfrequency[bandinx] * 1000);
     }
 
     send_bandswitch(bandinx);

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -1394,10 +1394,10 @@ static void next_band(int direction) {
     bandinx += direction;
 
     if (bandinx < 0) {
-        bandinx = NBANDS - 1;
+        bandinx = BANDINDEX_OOB - 1;
     }
 
-    if (bandinx >= NBANDS) {
+    if (bandinx >= BANDINDEX_OOB) {
         bandinx = 0;
     }
 }

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -97,11 +97,6 @@ extern int bandinx;
 extern char band[NBANDS][4];
 extern int contest;
 extern int dxped;
-#ifdef HAVE_LIBHAMLIB
-extern freq_t outfreq;
-#else
-extern int outfreq;
-#endif
 extern float freq;
 extern int trx_control;
 extern float bandfrequency[];
@@ -578,7 +573,7 @@ char callinput(void)
 		} else {
 		    freq = mem;
 
-		    outfreq = (int) (mem * 1000);
+		    set_outfreq(mem * 1000);
 
 		    mem = 0.0;
 		    mvprintw(14, 68, "            ");

--- a/src/callinput.h
+++ b/src/callinput.h
@@ -23,5 +23,6 @@
 
 char callinput(void);
 int play_file(char *audiofile);
+void send_bandswitch(int freq);
 
 #endif /* CALLINPUT_H */

--- a/src/changefreq.c
+++ b/src/changefreq.c
@@ -24,25 +24,14 @@
 #include "time_update.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
-
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
-
-#ifdef HAVE_LIBHAMLIB
-# include <hamlib/rig.h>
-#endif
+#include "gettxinfo.h"
 
 
 void change_freq (void) {
 
     extern float freq;
     extern int trx_control;
-#ifdef HAVE_LIBHAMLIB
-    extern freq_t outfreq;
-#else
-    extern int outfreq;
-#endif
+
     int brkflg = 0;
     int x;
 
@@ -55,86 +44,52 @@ void change_freq (void) {
 
 	freq_display();
 
-	if (outfreq == 0) {
+	if (get_outfreq() == 0) {
 	    x = key_get();
+
+            int deltaf = 0;
 
 	    switch (x) {
 
 	    // Up arrow, raise frequency by 100 Hz.
 	    case KEY_UP:
 		{
-#ifdef HAVE_LIBHAMLIB
-		    outfreq = (freq_t) (freq * 1000);
-#else
-		    outfreq = (int) (freq * 1000);
-#endif
-		    outfreq += 100;
-
+		    deltaf = 100;
 		    break;
 		}
 
 	    // Down arrow, lower frequency by 100 Hz.
 	    case KEY_DOWN:
 		{
-#ifdef HAVE_LIBHAMLIB
-		    outfreq = (freq_t) (freq * 1000);
-#else
-		    outfreq = (int) (freq * 1000);
-#endif
-		    outfreq -= 100;
-
+		    deltaf = -100;
 		    break;
 		}
 
 	    // Right arrow, raise frequency by 20 Hz.
 	    case KEY_RIGHT:
 		{
-#ifdef HAVE_LIBHAMLIB
-		    outfreq = (freq_t) (freq * 1000);
-#else
-		    outfreq = (int) (freq * 1000);
-#endif
-		    outfreq += 20;
-
+		    deltaf = 20;
 		    break;
 		}
 
 	    // Left arrow, lower frequency by 20 Hz.
 	    case KEY_LEFT:
 		{
-#ifdef HAVE_LIBHAMLIB
-		    outfreq = (freq_t) (freq * 1000);
-#else
-		    outfreq = (int) (freq * 1000);
-#endif
-		    outfreq -= 20;
-
+		    deltaf = -20;
 		    break;
 		}
 
 	    // <Page-Up>, raise frequency by 500 Hz.
 	    case KEY_PPAGE:
 		{
-#ifdef HAVE_LIBHAMLIB
-		    outfreq = (freq_t) (freq * 1000);
-#else
-		    outfreq = (int) (freq * 1000);
-#endif
-		    outfreq += 500;
-
+		    deltaf = 500;
 		    break;
 		}
 
 	    // <Page-Down>, lower frequency by 500 Hz.
 	    case KEY_NPAGE:
 		{
-#ifdef HAVE_LIBHAMLIB
-		    outfreq = (freq_t) (freq * 1000);
-#else
-		    outfreq = (int) (freq * 1000);
-#endif
-		    outfreq -= 500;
-
+		    deltaf = -500;
 		    break;
 		}
 
@@ -144,6 +99,10 @@ void change_freq (void) {
 		}
 
 	    }
+
+            if (deltaf) {
+                set_outfreq(freq * 1000 + deltaf);
+            }
 	}
 
 	if (brkflg == 1) {
@@ -155,7 +114,7 @@ void change_freq (void) {
 
 	time_update();
 
-	usleep(100000);
+	usleep(100 * 1000);
 
     }
     curs_set(1);

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -93,13 +93,6 @@ int changepars(void)
     extern char *config_file;
     extern int miniterm;
     extern int total;
-
-#ifdef HAVE_LIBHAMLIB
-    extern freq_t outfreq;
-#else
-    extern int outfreq;
-#endif
-
     extern int simulator;
     extern int cwkeyer;
     extern char synclogfile[];
@@ -464,15 +457,13 @@ int changepars(void)
 		sendmessage("MODE CW\015K\015");
 	    }
 	    trxmode = CWMODE;
-
-	    if (trx_control == 1)
-		outfreq = SETCWMODE;
+            set_outfreq(SETCWMODE);
 	    break;
 	}
     case 31:			/* SSBMODE  */
 	{
 	    trxmode = SSBMODE;
-	    outfreq = SETSSBMODE;
+            set_outfreq(SETSSBMODE);
 	    break;
 	}
     case 32:			/* DIGIMODE  */

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -72,11 +72,10 @@ extern unsigned char rigptt;
  *  else - set rig frequency
  *
  */
-//static double outfreq;
 #ifdef HAVE_LIBHAMLIB
-freq_t outfreq;
+static freq_t outfreq = 0;
 #else
-int outfreq;
+static int outfreq = 0;
 #endif
 
 static pthread_mutex_t outfreq_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -86,9 +85,16 @@ static double get_current_seconds();
 static void handle_trx_bandswitch(int freq);
 
 void set_outfreq(double hertz) {
+    if (!trx_control) {
+	hertz = 0;      // no rig control, ignore request
+    }
     pthread_mutex_lock (&outfreq_mutex);
     outfreq = hertz;
     pthread_mutex_unlock (&outfreq_mutex);
+}
+
+double get_outfreq() {
+    return outfreq;
 }
 
 static double get_and_reset_outfreq() {

--- a/src/gettxinfo.h
+++ b/src/gettxinfo.h
@@ -21,9 +21,11 @@
 #ifndef GETTXINFO_H
 #define GETTXINFO_H
 
-#define SETCWMODE 1
-#define SETSSBMODE 2
-#define RESETRIT 99
+#define SETCWMODE   (-1)
+#define SETSSBMODE  (-2)
+#define RESETRIT    (-3)
+
+void set_outfreq(double hertz); 
 
 void gettxinfo(void);
 

--- a/src/gettxinfo.h
+++ b/src/gettxinfo.h
@@ -26,6 +26,7 @@
 #define RESETRIT    (-3)
 
 void set_outfreq(double hertz); 
+double get_outfreq();
 
 void gettxinfo(void);
 

--- a/src/gettxinfo.h
+++ b/src/gettxinfo.h
@@ -25,6 +25,6 @@
 #define SETSSBMODE 2
 #define RESETRIT 99
 
-int gettxinfo(void);
+void gettxinfo(void);
 
 #endif /* GETTXINFO_H */

--- a/src/grabspot.h
+++ b/src/grabspot.h
@@ -21,7 +21,7 @@
 #ifndef GRABSPOT_H
 #define GRABSPOT_H
 
-void grabspot (void);
-void grab_next (void);
+double grabspot (void);
+double grab_next (void);
 
 #endif /* GRABSPOT_H */

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -42,14 +42,6 @@
 #include "ui_utils.h"
 #include "cleanup.h"
 
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
-
-#ifdef HAVE_LIBHAMLIB
-# include <hamlib/rig.h>
-#endif
-
 
 pthread_mutex_t disk_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -69,11 +61,6 @@ int log_to_disk(int from_lan)
     extern int rit;
     extern int trx_control;
     extern int cqmode;
-#ifdef HAVE_LIBHAMLIB
-    extern freq_t outfreq;
-#else
-    extern int outfreq;
-#endif
     extern int block_part;
     extern char lan_message[];
     extern char thisnode;
@@ -160,8 +147,9 @@ int log_to_disk(int from_lan)
 
     sync();
 
-    if ((rit == 1) && (trx_control == 1))
-	outfreq = RESETRIT;
+    if (rit) {
+	set_outfreq(RESETRIT);
+    }
 
     block_part = 0;		/* unblock use partials */
 

--- a/src/main.c
+++ b/src/main.c
@@ -352,13 +352,10 @@ int bmautograb = 0;
 #ifdef HAVE_LIBHAMLIB
 rig_model_t myrig_model = 351;
 RIG *my_rig;			/* handle to rig (instance) */
-freq_t outfreq;			/* output  to rig */
 rmode_t rmode;			/* radio mode of operation */
 pbwidth_t width;
 vfo_t vfo;			/* vfo selection */
 port_t myport;
-#else
-int outfreq;			/* output  to rig */
 #endif
 int ssb_bandwidth = 3000;
 int cw_bandwidth = 0;


### PR DESCRIPTION
In the current code the background process delays 10 ms between frequency read-outs (if no other action like lan check has to be done). This means a very frequent (10-50 times/sec) polling that has no real use as the display is updated once per second. Normally a poll each 200-500 ms should be sufficient to get a reasonably live frequency display.  Too frequent polling can have negative impact on other actions (e.g. sending cw via hamlib).

gettxinfo was changed to skip polling if the previous was done within 200 ms.  The code was restructured and some code duplicates removed. The function freq2band is reused as it provides the needed mapping. This serves also to reduce code duplication.

note: outfreq needs to be mutexed (r/w access from two threads), I'll fix that later.