### PR TITLE
fix long CQ bug

### DIFF
--- a/src/callinput.c
+++ b/src/callinput.c
@@ -105,7 +105,7 @@ extern float bandfrequency[];
 /** callsign input loop
  *
  * \return code of last typed character */
-char callinput(void)
+int callinput(void)
 {
     extern int itumult;
     extern int wazmult;
@@ -169,7 +169,7 @@ char callinput(void)
 
 
     int cury, curx;
-    int i, j, ii, rc, t, x = 0;
+    int j, ii, rc, t, x = 0;
     char instring[2] = { '\0', '\0' };
     static int lastwindow;
 
@@ -179,7 +179,7 @@ char callinput(void)
     printcall();	/* print call input field */
     searchlog(hiscall);
 
-    for (i = strlen(hiscall); i <= 13; i++) {
+    while (strlen(hiscall) <= 13) {
 
 	show_zones(bandinx);
 	printcall();
@@ -253,9 +253,8 @@ char callinput(void)
 
 	}
 
-
 	/* special handling of some keycodes if call field is empty */
-	if (i == 0 || *hiscall == '\0') {
+	if (*hiscall == '\0') {
 	    if ((x == '+') && (*hiscall == '\0') && (ctcomp == 0)) {
 		/* switch to other mode */
 		if (cqmode == CQ) {
@@ -686,7 +685,6 @@ char callinput(void)
 			refreshp();
 		    }
 
-		    i--;
 		    x = -1;
 		    break;
 		}

--- a/src/callinput.h
+++ b/src/callinput.h
@@ -21,7 +21,7 @@
 #ifndef CALLINPUT_H
 #define CALLINPUT_H
 
-char callinput(void);
+int callinput(void);
 int play_file(char *audiofile);
 void send_bandswitch(int freq);
 

--- a/src/logit.c
+++ b/src/logit.c
@@ -47,7 +47,7 @@
 void refresh_comment(void);
 void change_mode(void);
 
-void *logit(void *ptr)
+void logit(void)
 {
     extern char mode[];
     extern int trxmode;
@@ -76,7 +76,7 @@ void *logit(void *ptr)
     extern int dxped;
     extern int sprint_mode;
 
-    char callreturn = 0;
+    int callreturn = 0;
     int cury, curx;
     int qrg_out = 0;
 

--- a/src/logit.h
+++ b/src/logit.h
@@ -21,7 +21,7 @@
 #ifndef LOGIT_H
 #define LOGIT_H
 
-void *logit(void *);
+void logit(void);
 void refresh_comment(void);
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -1001,7 +1001,7 @@ int main(int argc, char *argv[])
     }
 
     /* now start logging  !! Does never return */
-    logit(NULL);
+    logit();
 
     return 0;
 }


### PR DESCRIPTION
This PR fixes the "long CQ bug": when sending a longer series of unanswered CQ's the cursor  sometimes jumps to the exchange field. This causes F1 to send your call instead of CQ, so the op has to press either Esc or Tab to get back to CQ'ing. Quite annoying, but keeps op awake. :-)

An Easter egg version of this "feature" is:
* start tlf
* press F3 14 times
* CW keyer window pops up.

The bug is a result of two issues.
* In `callinput()` key codes returned as `char` although they fit in an `int` only. E.g. F1 is 0x109 and F3 is 0x10B.  On return only the lower 8 bits are kept and thus F1 is transformed into a Tab/Ctrl-I (0x09) and F3 into Ctrl-K (0x0B).
* `callinput()` is supposed to return to `logit()` only when some non-local keypress is to be handled (e.g. Enter).  Instead it returns when its internal counter `i` reaches 14: 
```
for (i = strlen(hiscall); i <= 13; i++) {
```

The idea may have been an optimization to avoid excessive calls to `strlen` and track call length in `i`.
But this doesn't bring anything as this check is done only once per keypress and in the inner loop [`while (x < 1)`] `strlen` and other stuff is happening 100 times a second anyway.

As a side effect I have changed the signature of `logit` from the mystical
`void *logit(void *ptr)`
to a plain
`void logit(void)`
It neither expects nor returns anything.