### PR TITLE
Extended Fldigi interface

### DIFF
--- a/doc/README.RTTY
+++ b/doc/README.RTTY
@@ -1,6 +1,6 @@
 Tlf RTTY howto
 
-2016, Ervin Hegedus, HA2OS
+2016-2018, Ervin Hegedus, HA2OS
 
 This is a guide for Tlf, how to use it with Fldigi in RTTY mode,
 especially in FSK, LSB or USB modulations. Tlf got a new Fldigi
@@ -18,43 +18,17 @@ Let's see, how works the TX direction with Fldigi.
 
 Important: if you set up your Fldigi instance, don't set up your
 RIG! Tlf needs to handle the RIG, because it needs to tune the VFO,
-to use the bandmap.
+to use the bandmap. After the version 1.3, Tlf can controlls Fldigi,
+then it can be show the QRG (frequency of RIG - see later), and
+mode of RIG (eg: LSB, USB, FSK).
 
 Starting with TLF-1.3 there are two ways to comunicate with Fldigi -
-the old GMFSK interface and the actual XMLRPC one.
+the old GMFSK interface and the actual XMLRPC one. Note, that after
+version 1.3 the GMFSK works as standalone interface, but can't work
+with Fldigi.
 
-Note: Using the new interface ist recommended. The old GMFSK interface 
+Note: Using the new interface is recommended. The old GMFSK interface 
 will be no longer maintained and will go away soon.
-
-GMFSK interface
-===============
-
-First you need to create some filesin your $HOME directory:
-
-~$ touch TLFfldigi
-~$ touch gmfsk_autofile
-
-The TLFfldigi file indicates to Fldigi, that it needs to listen
-the gmfsk_autofile file. Tlf writes its RTTY messages to
-that file, and Fldigi reads the messages from it. 
-
-In your logcfg.dat, you had to set up the following lines:
-
-RTTYMODE
-GMFSK=/home/YOURUSER/gMFSK.log
-DIGIMODEM=/home/YOURUSER/gmfsk_autofile
-
-Note, that GMFSK directive tells Tlf, that it can read the
-output of modem, and it can be shown in its own modem window.
-(The miniterm window opens when you type the ":miniterm" command
-in callsign field.)
-
-If you want to use a serial port driven FSK modem, just replace
-the DIGIMODEM value for your modem path. Eg. I've build an FSK
-modem with the Arduino board, which reads the serial port of my
-PC. So, I've set it up like this:
-
-DIGIMODEM=/dev/ttyS0
 
 XMLRPC interface
 ================
@@ -77,10 +51,12 @@ communicate through XMLRPC.
 You can still read of Fldigi RX window (top) in Tlf own terminal,
 just use ":miniterm" command in callsign field.
 
-IMPORTANT: The FLDIGI command sets the XMLRPC interface as keyer for
-both CW and DIGIMODE. That means you can not have FLDIGI and NETKEYER 
-(first for Ddigimode, second for CW) at the same time. That limitation
-will go away in next versions of tlf.
+There is a new command: ":fldigi", which helps to you to turn on and
+off Fldigi communication. Then you don't need to modifiy the logcfg.dat
+to change your mode.
+
+Note: in old versions of Tlf, you could't use NETKEYER and FLDIGI in
+same time. Now this restriction is gone, you can use them in same time.
 
 The RX mode is a slightly difficult. I don't want to expose that
 here, I suppose that anybody knows that, if works in RTTY. I had
@@ -120,6 +96,14 @@ the Fldigi carrier's as it exists, and grab the next spot. Tlf will
 calculates the requested QRG from the different of the spot and
 Fldigi carrier's frequency, and tune the RIG. That's it.
 
+Error handling: if you forgot to start the Fldigi, or you close that
+till Tlf runs and wants to communicate with it, Tlf tries to connect.
+After ten (10) continuous unsuccessful attemtp Tlf will show you the
+error message (at bottom left corner): "Fldigi: lost connection", and
+turns it off. If you want to turn on again, just type ":fldigi"
+command in CALLSIGN field. If Fldigi comes back after less, than ten
+attempt, the error counter cleared.
+
 More new feature in Fldigi interface:
 - when Tlf sends a message throug Fldigi, it switches Fldigi to TX mode.
 - similar to CW mode, if you press ESC while Fldigi sends the message,
@@ -129,6 +113,15 @@ More new feature in Fldigi interface:
   and handles as correctly. You will lost the Fldigi functions (no
   TX/RX, QRG align), but Tlf runs away. If you start Fldigi again,
   after a few seconds, Tlf will work with it again
+
+New features after 1.3:
+- Fldigi supports nanoIO software, which is a small Arduino project
+  Homepage: https://github.com/w1hkj/nanoIO
+  whit this, you can work in real FSK mode
+- Fldigi can catch the different strings as field values, eg:
+  CALLSIGN, EXCHANGE. If you click in RX window to a callsign, Fldigi
+  fills its CALL field, and Tlf will grab it. EXCHANGE field is similar.
+
 
 73, Ervin
 HA2OS

--- a/src/background_process.c
+++ b/src/background_process.c
@@ -67,6 +67,7 @@ extern char call[];
 extern int trxmode;
 extern int digikeyer;
 extern int trx_control;
+extern int fldigi_used;
 
 int cw_simulator(void);
 
@@ -105,17 +106,24 @@ void *background_process(void *ptr) {
 	    rx_rtty();
 
 	/*
-	 * calling Fldigi XMLRPC method, which reads the Fldigi's carrier
+	 * calling Fldigi XMLRPC method, which reads the Fldigi's carrier:
+	 * fldigi_xmlrpc_get_carrier()
 	 * this function helps to show the correct freq of the RIG: reads
 	 * the carrier value from Fldigi, and stores in a variable; then
 	 * it readable by fldigi_get_carrier()
 	 * only need at every 2nd cycle
 	 * see fldigixmlrpc.[ch]
+	 *
+	 * There are two addition routines
+	 *   fldigi_get_log_call() reads the callsign, if user clicks to a string in Fldigi's RX window
+	 *   fldigi_get_log_serial_number() reads the exchange
 	 */
-	if (trxmode == DIGIMODE && (digikeyer == GMFSK || digikeyer == FLDIGI)
+	if (digikeyer == FLDIGI && fldigi_used == 1
 		&& trx_control == 1) {
 	    if (fldigi_rpc_cnt == 0) {
 		fldigi_xmlrpc_get_carrier();
+		fldigi_get_log_call();
+		fldigi_get_log_serial_number();
 	    }
 	    fldigi_rpc_cnt = 1 - fldigi_rpc_cnt;
 	}

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -35,6 +35,7 @@
 #include "changepars.h"
 #include "clear_display.h"
 #include "editlog.h"
+#include "fldigixmlrpc.h"
 #include "gettxinfo.h"
 #include "lancode.h"
 #include "listmessages.h"
@@ -98,9 +99,11 @@ int changepars(void) {
     extern char synclogfile[];
     extern char sc_volume[];
     extern int cwstart;
+    extern int digikeyer;
+    extern int fldigi_used;
 
     char parameterstring[20];
-    char parameters[51][19];
+    char parameters[52][19];
     char cmdstring[80];
     int i, k, x, nopar = 0;
     int maxpar = 50;
@@ -160,6 +163,7 @@ int changepars(void) {
     strcpy(parameters[48], "SOUND");
     strcpy(parameters[49], "CWMODE");
     strcpy(parameters[50], "CHARS");
+    strcpy(parameters[51], "FLDIGI");
 
     nopar = 0;
 
@@ -692,6 +696,21 @@ int changepars(void) {
 	    refreshp();
 	    break;
 
+	}
+        case 51: {              /* FLDIGI - turn on/off */
+	    if (digikeyer == FLDIGI) {
+		if (fldigi_used == 0) {
+		    fldigi_used = 1;
+		    fldigi_clear_connerr();
+		    mvprintw(13, 29, "FLDIGI ON");
+	        }
+	        else {
+		    fldigi_used = 0;
+		    mvprintw(13, 29, "FLDIGI OFF");
+		}
+		refreshp();
+	    }
+	    break;
 	}
 	default: {
 	    nopar = 1;

--- a/src/fldigixmlrpc.h
+++ b/src/fldigixmlrpc.h
@@ -22,15 +22,21 @@
 #ifndef FLDIGIXMLRPC_H
 #define FLDIGIXMLRPC_H
 
+#define FLDIGI_TX   1
+#define FLDIGI_RX   2
+
 int fldigi_xmlrpc_init();
 int fldigi_xmlrpc_cleanup();
 
 int fldigi_xmlrpc_get_carrier(void);
 int fldigi_get_carrier();
 int fldigi_get_shift_freq();
-int fldigi_get_rx_text(char *line);
+int fldigi_get_rx_text(char *line, int len);
 int fldigi_send_text(char *line);
 void fldigi_to_rx();
 void xmlrpc_showinfo();
+int fldigi_get_log_call();
+int fldigi_get_log_serial_number();
+void fldigi_clear_connerr();
 
 #endif /* end of include guard: FLDIGIXMLRPC_H */

--- a/src/main.c
+++ b/src/main.c
@@ -353,6 +353,7 @@ int tnc_serial_rate = 2400;
 char clusterlogin[80] = "";
 int bmautoadd = 0;
 int bmautograb = 0;
+int hiscall_filled = 0;
 
 /*-------------------------------------rigctl-------------------------------*/
 #ifdef HAVE_LIBHAMLIB
@@ -373,6 +374,7 @@ int rig_comm_success = 0;
 
 /*----------------------------------fldigi---------------------------------*/
 char fldigi_url[50] = "http://localhost:7362/RPC2";
+int fldigi_used = 0;
 
 /*---------------------------------simulator-------------------------------*/
 int simulator = 0;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -300,6 +300,7 @@ int parse_logcfg(char *inputbuffer) {
     extern int bmautograb;
     extern int sprint_mode;
     extern char fldigi_url[50];
+    extern int fldigi_used;
     extern unsigned char rigptt;
     extern int minitest;
     extern int unique_call_multi;
@@ -1830,6 +1831,7 @@ int parse_logcfg(char *inputbuffer) {
 			  sizeof(fldigi_url));
 	    }
 	    digikeyer = FLDIGI;
+	    fldigi_used = 1;
 #endif
 	    break;
 	}

--- a/src/rtty.c
+++ b/src/rtty.c
@@ -281,7 +281,7 @@ int rx_rtty() {
 	    }
 	}
     } else if (digikeyer == FLDIGI) {
-	i = fldigi_get_rx_text(line);
+	i = fldigi_get_rx_text(line, sizeof(line));
 	for (j = 0; j < i; j++) {
 	    ry_addchar(line[j]);
 	}

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -303,6 +303,10 @@ Filter cluster info (announce, dx-spots, all).
 Show frequency or band/score information of your other stations.
 .
 .TP
+.BR :FLDIGI
+Turn off/on Fldigi communication.
+.
+.TP
 .BR :HEL p
 Show online help (displays
 .I help.txt


### PR DESCRIPTION
* remove GMFSK option handling from Fldigi connect, which was the previous interface;
  note, that the GMFSK as option still exists
* added CALLSIGN and EXCHANGE fields fill functions - see the doc/README.RTTY
* added new command (commands starts with ":" in CALL field): "FLDIGI"
  you can enable/disable the Fldigi without modification the logcfg.dat
* fixed QRG calculation in different modes (eg. LSB, USB, FSK)
* controll Fldigi fields: Frequency (of RIG) and Mode (of RIG) - see the doc/README.RTTY
* modified doc/README.RTTY
* added some comments in source code