### PR TITLE
Add DIGI_RIG_MODE config option

### DIFF
--- a/src/changepars.c
+++ b/src/changepars.c
@@ -441,6 +441,7 @@ int changepars(void) {
 	}
 	case 32: {		/* DIGIMODE  */
 	    trxmode = DIGIMODE;
+	    set_outfreq(SETDIGIMODE);
 	    break;
 	}
 	case 33: {		/* PACKET  */

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -53,6 +53,7 @@ extern int cw_bandwidth;
 extern int trxmode;
 extern int rigmode;
 extern int digikeyer;
+extern rmode_t digi_mode;
 #endif
 
 extern float freq;
@@ -69,6 +70,7 @@ extern unsigned char rigptt;
  *  SETCWMODE
  *  SETSSBMODE
  *  RESETRIT
+ *  SETDIGIMODE
  *  else - set rig frequency
  *
  */
@@ -242,6 +244,26 @@ void gettxinfo(void) {
 	    retval =
 		rig_set_mode(my_rig, RIG_VFO_CURR, RIG_MODE_LSB,
 			     TLF_DEFAULT_PASSBAND);
+
+	if (retval != RIG_OK) {
+	    mvprintw(24, 0, "Problem with rig link!\n");
+	    refreshp();
+	    sleep(1);
+	}
+#endif
+
+    } else if (reqf == SETDIGIMODE) {
+#ifdef HAVE_LIBHAMLIB		// Code for Hamlib interface
+	rmode_t new_mode = digi_mode;
+	if (new_mode == RIG_MODE_NONE) {
+	    if (digikeyer == FLDIGI)
+		new_mode = RIG_MODE_USB;
+	    else
+		new_mode = RIG_MODE_LSB;
+	}
+	retval =
+	    rig_set_mode(my_rig, RIG_VFO_CURR, new_mode,
+		TLF_DEFAULT_PASSBAND);
 
 	if (retval != RIG_OK) {
 	    mvprintw(24, 0, "Problem with rig link!\n");

--- a/src/gettxinfo.h
+++ b/src/gettxinfo.h
@@ -24,6 +24,7 @@
 #define SETCWMODE   (-1)
 #define SETSSBMODE  (-2)
 #define RESETRIT    (-3)
+#define SETDIGIMODE (-4)
 
 void set_outfreq(double hertz);
 double get_outfreq();

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -4,6 +4,10 @@
 
 #include <glib.h>
 
+#ifdef HAVE_LIBHAMLIB
+# include <hamlib/rig.h>
+#endif
+
 extern char qsos[MAX_QSOS][LOGLINELEN + 1];
 					// array of log lines of QSOs so far;
 					// note that not every log line needs
@@ -116,3 +120,6 @@ extern int three_point;
 extern int dxped;
 extern int addzone;
 extern int do_cabrillo;
+#ifdef HAVE_LIBHAMLIB
+extern rmode_t digi_mode;
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -326,6 +326,9 @@ int keyer_backspace = 0;        // disabled
 
 char controllerport[80] = "/dev/ttyS0"; // for GMFSK or MFJ-1278
 char rttyoutput[120];		// where to GMFSK digimode output
+#ifdef HAVE_LIBHAMLIB
+rmode_t digi_mode = RIG_MODE_NONE;
+#endif
 
 int txdelay = 0;
 int weight = 0;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -59,6 +59,9 @@ extern int packetinterface;
 extern int tncport;
 extern int shortqsonr;
 extern char *cabrillo;
+#ifdef HAVE_LIBHAMLIB
+extern rmode_t digi_mode;
+#endif
 
 int exist_in_country_list();
 int continent_found();
@@ -70,7 +73,7 @@ void KeywordNotSupported(char *keyword);
 void ParameterNeeded(char *keyword);
 void WrongFormat(char *keyword);
 
-#define  MAX_COMMANDS 237	/* commands in list */
+#define  MAX_COMMANDS (sizeof(commands) / sizeof(*commands))	/* commands in list */
 
 
 int read_logcfg(void) {
@@ -305,7 +308,7 @@ int parse_logcfg(char *inputbuffer) {
     extern int minitest;
     extern int unique_call_multi;
 
-    char commands[MAX_COMMANDS][30] = {
+    char *commands[] = {
 	"enable",		/* 0 */		/* deprecated */
 	"disable",				/* deprecated */
 	"F1",
@@ -543,7 +546,8 @@ int parse_logcfg(char *inputbuffer) {
 	"RIGPTT",
 	"MINITEST",
 	"UNIQUE_CALL_MULTI",		/* 235 */
-	"KEYER_BACKSPACE"
+	"KEYER_BACKSPACE",
+	"DIGI_RIG_MODE"
     };
 
     char **fields;
@@ -1872,6 +1876,27 @@ int parse_logcfg(char *inputbuffer) {
 	}
 	case 236: { // KEYER_BACKSPACE
 	    keyer_backspace = 1;
+	    break;
+	}
+	case 237: {
+#ifdef HAVE_LIBHAMLIB
+	    PARAMETER_NEEDED(teststring);
+	    g_ascii_strup(g_strchomp(fields[1]), -1);
+	    if (strcmp(fields[1], "USB") == 0)
+		digi_mode = RIG_MODE_USB;
+	    else if (strcmp(fields[1], "LSB") == 0)
+		digi_mode = RIG_MODE_LSB;
+	    else if (strcmp(fields[1], "RTTY") == 0)
+		digi_mode = RIG_MODE_RTTY;
+	    else if (strcmp(fields[1], "RTTYR") == 0)
+		digi_mode = RIG_MODE_RTTYR;
+	    else {
+		showmsg
+		("WARNING: invalid DIGI_RIG_MODE value, must be \"USB\", \"LSB\", \"RTTY\", or \"RTTYR\"");
+		sleep(5);
+		exit(1);
+	    }
+#endif
 	    break;
 	}
 	default: {

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -26,6 +26,7 @@
 #include "startmsg.h"
 #include "gettxinfo.h"
 #include "bandmap.h"
+#include "globalvars.h"
 
 
 void send_bandswitch(int trxqrg);
@@ -214,6 +215,18 @@ int init_tlf_rig(void) {
 	sleep(10);
 
     }				// end debug
+
+    switch (trxmode) {
+	case SSBMODE:
+	    set_outfreq(SETSSBMODE);
+	    break;
+	case DIGIMODE:
+	    set_outfreq(SETDIGIMODE);
+	    break;
+	case CWMODE:
+	    set_outfreq(SETCWMODE);
+	    break;
+    }
 
     sleep(1);
     return (0);

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1385,6 +1385,13 @@ is present in logcfg.dat, and @PACKAGE_NAME@ if is in DIGIMODE, then the
 other station's callsign will be sent before \(lqDE\(rq, e.g. \(lqDL1A DE
 W1AW\(rq.
 .
+.TP
+\fBDIGI_RIG_MODE\fR=\fImode\fR
+If set with \fBRADIO_CONTROL\fR option, specifies the mode to change the
+rig to when :DIG mode is selected. \fImode\fR may be one of \(lqUSB\(rq, \(lqLSB\(rq,
+\(lqRTTY\(rq, or \(lqRTTYR\(rq.  If not set, \(lqUSB\(rq is used if FLDIGI is
+set and \(lqLSB\(rq is used otherwise.
+.
 .SH RULES
 .
 The contest rules can be put into separate files.  @PACKAGE_NAME@ will


### PR DESCRIPTION
This option can be one of RTTY, RTTYR, USB, or LSB.  If set, the
rig mode is changed to it any time digi mode is activated.

The mode is also set on startup.

This commit also cleans up the commads array so that MAX_COMMANDS
doesn't need to be updated every time a new command is added.