### PR TITLE
malloc() is defined in stdlib.h.

### DIFF
--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -26,7 +26,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "dxcc.h"
 #include "getpx.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h


### PR DESCRIPTION
stdlib.h has been the correct header for malloc() since C89.