### PR TITLE
Add missing socket headers.

### DIFF
--- a/src/netkeyer.c
+++ b/src/netkeyer.c
@@ -18,6 +18,9 @@
  */
 
 
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <netdb.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/sockserv.c
+++ b/src/sockserv.c
@@ -23,6 +23,8 @@
 /* Written by N2RJT - Dave Brown */
 
 
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <errno.h>
 #include <netdb.h>
 #include <stdio.h>


### PR DESCRIPTION
These are necessary to build on at least FreeBSD, and likely many
more systems.  I'm actually surprised Linux builds without them.