### PR TITLE
POSIX doesn't define the -w option

### DIFF
--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -675,7 +675,7 @@ int synclog(char *synclogfile) {
 
     showmsg("Merging logfiles...\n");
     sleep(1);
-    sprintf(wgetcmd, "cat log1 log2 | sort -g -k4,4 | uniq -w79 > %s",
+    sprintf(wgetcmd, "cat log1 log2 | sort -g -k4,4 | uniq  > %s",
 	    logfile);
     if (system(wgetcmd) == 0)
 	showmsg("Merging logs successfull\n");


### PR DESCRIPTION
It seems to be a GNU extension, and doesn't seem to be needed in
this use case.  The FreeBSD uniq utility doesn't support it.