### PR TITLE
Support CT9 cty.dat files

### DIFF
--- a/src/calledit.c
+++ b/src/calledit.c
@@ -110,7 +110,7 @@ void calledit(void) {
 		hiscall[j] = hiscall[j + 1];	/* move to left incl. \0 */
 	    }
 
-	    showinfo(getctydata(hiscall));
+	    showinfo(getctydata_pfx(hiscall));
 
 	    if (cnt > 1)
 		searchlog(hiscall);
@@ -128,7 +128,7 @@ void calledit(void) {
 		    hiscall[j] = hiscall[j + 1];
 		}
 
-		showinfo(getctydata(hiscall));
+		showinfo(getctydata_pfx(hiscall));
 
 		if (cnt > 1)
 		    searchlog(hiscall);
@@ -178,7 +178,7 @@ void calledit(void) {
 		else
 		    break;
 
-		showinfo(getctydata(hiscall));
+		showinfo(getctydata_pfx(hiscall));
 
 		searchlog(hiscall);
 

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -219,7 +219,7 @@ int callinput(void) {
 		    grab.state = REACHED;
 		    grab.spotfreq = freq;
 
-		    showinfo(getctydata(hiscall));
+		    showinfo(getctydata_pfx(hiscall));
 		    printcall();
 		    searchlog(hiscall);
 		    freqstore = 0;
@@ -241,7 +241,7 @@ int callinput(void) {
 		hiscall[0] = '\0';
 		printcall();
 		HideSearchPanel();
-		showinfo(0);
+		showinfo(SHOWINFO_DUMMY);
 	    }
 
 
@@ -653,7 +653,7 @@ int callinput(void) {
 		    hiscall[strlen(hiscall) - 1] = '\0';
 
 		    if (atoi(hiscall) < 1800) {	/*  no frequency */
-			showinfo(getctydata(hiscall));
+			showinfo(getctydata_pfx(hiscall));
 			searchlog(hiscall);
 			refreshp();
 		    }
@@ -909,7 +909,7 @@ int callinput(void) {
 	    case 1: {
 		addspot();
 		HideSearchPanel();
-		showinfo(0);
+		showinfo(SHOWINFO_DUMMY);
 
 		grab.state = REACHED;
 		grab.spotfreq = freq;
@@ -1065,7 +1065,7 @@ int callinput(void) {
 
 	    if (atoi(hiscall) < 1800) {	/*  no frequency */
 
-		showinfo(getctydata(hiscall));
+		showinfo(getctydata_pfx(hiscall));
 		searchlog(hiscall);
 	    }
 

--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -41,7 +41,7 @@ prefix_data dummy_pfx = {
     INFINITY,
     NULL,
     INFINITY,
-    FALSE
+    false
 };
 
 
@@ -56,7 +56,7 @@ void prefix_free(gpointer data) {
 
 void prefix_init(void) {
     if (prefix) {
-	g_ptr_array_free(prefix, TRUE);
+	g_ptr_array_free(prefix, true);
     }
     prefix = g_ptr_array_new_with_free_func(prefix_free);
 }
@@ -82,11 +82,11 @@ void prefix_add(char *pfxstr) {
     prefix_data *new_prefix = g_new(prefix_data, 1);
 
     if (*pfxstr == '=') {
-	new_prefix -> exact = TRUE;
-	have_exact_matches = TRUE;
+	new_prefix -> exact = true;
+	have_exact_matches = true;
 	pfxstr++;
     } else
-	new_prefix -> exact = FALSE;
+	new_prefix -> exact = false;
 
     loc = strchr(pfxstr, '~');
     if (loc != NULL) {
@@ -152,7 +152,7 @@ void dxcc_free(gpointer data) {
 
 void dxcc_init(void) {
     if (dxcc) {
-	g_ptr_array_free(dxcc, TRUE);
+	g_ptr_array_free(dxcc, true);
     }
     dxcc = g_ptr_array_new_with_free_func(dxcc_free);
 }

--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -23,18 +23,25 @@
 #include <string.h>
 
 #include <glib.h>
+#include <math.h>
 
 #include "dxcc.h"
 
 
 GPtrArray *dxcc;
 GPtrArray *prefix;
+char have_exact_matches;
 
 prefix_data dummy_pfx = {
     "No Prefix",
     0,
     0,
-    0
+    0,
+    INFINITY,
+    INFINITY,
+    NULL,
+    INFINITY,
+    FALSE
 };
 
 
@@ -42,6 +49,7 @@ void prefix_free(gpointer data) {
     prefix_data *pfx_data = data;
 
     g_free(pfx_data -> pfx);
+    g_free(pfx_data -> continent);
     g_free(pfx_data);
 }
 
@@ -72,6 +80,44 @@ void prefix_add(char *pfxstr) {
     gint last_index = dxcc_count() - 1;
     dxcc_data *last_dx = dxcc_by_index(last_index);
     prefix_data *new_prefix = g_new(prefix_data, 1);
+
+    if (*pfxstr == '=') {
+	new_prefix -> exact = TRUE;
+	have_exact_matches = TRUE;
+	pfxstr++;
+    } else
+	new_prefix -> exact = FALSE;
+
+    loc = strchr(pfxstr, '~');
+    if (loc != NULL) {
+	new_prefix -> timezone = atof(loc + 1);
+	*loc = '\0';
+    }
+    else
+	new_prefix -> timezone = INFINITY;
+
+    loc = strchr(pfxstr, '{');
+    if (loc != NULL) {
+	new_prefix -> continent = g_strdup(loc + 1);
+	*loc = '\0';
+	loc = strchr(new_prefix -> continent, '}');
+	if (loc != NULL)
+	    *loc = '\0';
+    }
+    else
+	new_prefix -> continent = NULL;
+
+    loc = strchr(pfxstr, '<');
+    if (loc != NULL) {
+	new_prefix -> lat = atof(loc + 1);
+	*loc = '\0';
+	if ((loc = strchr(loc, '/')) != NULL)
+	    new_prefix -> lon = atof(loc + 1);
+	else
+	    new_prefix -> lon = INFINITY;
+    }
+    else
+	new_prefix -> lat = new_prefix -> lon = INFINITY;
 
     loc = strchr(pfxstr, '[');
     if (loc != NULL) {

--- a/src/dxcc.h
+++ b/src/dxcc.h
@@ -21,6 +21,8 @@
 #ifndef DXCC_H
 #define DXCC_H
 
+#include <stdbool.h>
+
 typedef struct {
     char *pfx;
     short cq;
@@ -30,7 +32,7 @@ typedef struct {
     float lon;
     char *continent;
     float timezone;
-    char exact;
+    bool exact;
 } prefix_data;
 
 typedef struct {

--- a/src/dxcc.h
+++ b/src/dxcc.h
@@ -26,6 +26,11 @@ typedef struct {
     short cq;
     short itu;
     short dxcc_index;
+    float lat;
+    float lon;
+    char *continent;
+    float timezone;
+    char exact;
 } prefix_data;
 
 typedef struct {
@@ -39,6 +44,8 @@ typedef struct {
     char *pfx;
     char starred;
 } dxcc_data;
+
+extern char have_exact_matches;
 
 void prefix_init(void);
 

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -258,9 +258,9 @@ static int getctydata_internal(char *checkcallptr, int get_country) {
 }
 
 int getctydata(char *checkcallptr) {
-    return getctydata_internal(checkcallptr, TRUE);
+    return getctydata_internal(checkcallptr, true);
 }
 
 int getctydata_pfx(char *checkcallptr) {
-    return getctydata_internal(checkcallptr, FALSE);
+    return getctydata_internal(checkcallptr, false);
 }

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -49,6 +49,8 @@ int find_full_match(const char *call) {
     w = -1;
     for (i = 0; i < pfxmax; i++) {
 	pfx = prefix_by_index(i);
+	if (have_exact_matches && !pfx->exact)
+	    continue;
 	if (strcmp(call, pfx->pfx) == 0) {
 	    w = i;
 	    break;
@@ -69,6 +71,13 @@ int find_best_match(const char *call) {
     for (i = 0; i < pfxmax; i++) {
 	int l;
 	pfx = prefix_by_index(i);
+	if (pfx->exact) {
+	    if (strcmp(call, pfx->pfx) == 0) {
+		w = i;
+		break;
+	    }
+	    continue;
+	}
 	if (*pfx->pfx != call[0])
 	    continue;
 
@@ -213,7 +222,7 @@ int getctynr(char *checkcall) {
  *
  * side effect: set up various global variables
  */
-int getctydata(char *checkcallptr) {
+static int getctydata_internal(char *checkcallptr, int get_country) {
     int w = 0, x = 0;
     char *normalized_call = NULL;
 
@@ -238,7 +247,20 @@ int getctydata(char *checkcallptr) {
 	strcpy(zone_export, ituzone);
 
     countrynr = x;
-    g_strlcpy(continent, dxcc_by_index(countrynr) -> continent, 3);
+    if (prefix_by_index(w) -> continent != NULL)
+	g_strlcpy(continent, prefix_by_index(w) -> continent, 3);
+    else
+	g_strlcpy(continent, dxcc_by_index(countrynr) -> continent, 3);
 
-    return (x);
+    if (get_country)
+	return (x);
+    return w;
+}
+
+int getctydata(char *checkcallptr) {
+    return getctydata_internal(checkcallptr, TRUE);
+}
+
+int getctydata_pfx(char *checkcallptr) {
+    return getctydata_internal(checkcallptr, FALSE);
 }

--- a/src/getctydata.h
+++ b/src/getctydata.h
@@ -23,6 +23,7 @@
 
 int getctynr(char *checkcall);
 int getctydata(char *checkcall);
+int getctydata_pfx(char *checkcallptr);
 
 
 #endif /* end of include guard: GETCTYDATA_H */

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -99,7 +99,7 @@ static double execute_grab(spot *data) {
 
     strcpy(hiscall, data->call);
 
-    showinfo(getctydata(hiscall));
+    showinfo(getctydata_pfx(hiscall));
     searchlog(hiscall);
 
     /* if in CQ mode switch to S&P and remember QRG */

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -31,12 +31,14 @@
  */
 
 
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
 
 #include "dxcc.h"
 #include "qrb.h"
+#include "showinfo.h"
 #include "tlf.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
@@ -64,11 +66,16 @@ int showinfo(int x) {
     char timebuff[80];
 
     dxcc_data *dx;
+    prefix_data *pfx;
     double d;
     time_t now;
     struct tm *ptr1;
 
-    dx = dxcc_by_index(x);
+    if (x == SHOWINFO_DUMMY)
+	pfx = prefix_by_index(prefix_count());
+    else
+	pfx = prefix_by_index(x);
+    dx = dxcc_by_index(pfx -> dxcc_index);
 
     strcpy(pxstr, dx->pfx);
     strcpy(countrystr, dx->countryname);	/* country */
@@ -88,16 +95,28 @@ int showinfo(int x) {
 	itustr[2] = '\0';
     }
 
-    d = dx->timezone;				/* GMT difference */
+    if (pfx->timezone != INFINITY)
+	d = pfx->timezone;
+    else
+	d = dx->timezone;				/* GMT difference */
 
     now = (time(0) + (long)((timeoffset - d) * 3600) + timecorr);
     ptr1 = gmtime(&now);
     strftime(timebuff, 80, "%H:%M", ptr1);
 
-    DEST_Lat = dx->lat;				/* where is he? */
-    DEST_Long = dx->lon;
+    if (pfx->lat != INFINITY)
+	DEST_Lat = pfx->lat;
+    else
+	DEST_Lat = dx->lat;				/* where is he? */
+    if (pfx->lon != INFINITY)
+	DEST_Lat = pfx->lon;
+    else
+	DEST_Long = dx->lon;
 
-    strncpy(contstr, dx->continent, 2);	/* continent */
+    if (pfx->continent != NULL)
+	strncpy(contstr, pfx->continent, 2);	/* continent */
+    else
+	strncpy(contstr, dx->continent, 2);	/* continent */
     contstr[2] = '\0';
 
     getyx(stdscr, cury, curx);

--- a/src/showinfo.h
+++ b/src/showinfo.h
@@ -21,6 +21,8 @@
 #ifndef SHOWINFO_H
 #define SHOWINFO_H
 
+#define SHOWINFO_DUMMY	-1
+
 int showinfo(int x);
 
 #endif /* end of include guard: SHOWINFO_H */


### PR DESCRIPTION
This adds three new overrides, lat/lon, continent, and time offset.
showinfo() now needs a prefix, so create add a getctydata_pfx()
function which returns the prefix rather than the country.

If a callsign in cty.dat starts with an '=', it will only use
exact matching, not prefix matching.  To allow backward compatability,
Tlf remembers if it saw any '=' prefixes and if so, find_full_match()
will only match those.  If there were no '=' prefixes, the behaviour
is as before, and it will match any prefix.