### PR TITLE
Fix fldigi keying.

### DIFF
--- a/src/background_process.c
+++ b/src/background_process.c
@@ -67,7 +67,6 @@ extern char call[];
 extern int trxmode;
 extern int digikeyer;
 extern int trx_control;
-extern int use_fldigi;
 
 int cw_simulator(void);
 
@@ -118,7 +117,7 @@ void *background_process(void *ptr) {
 	 *   fldigi_get_log_call() reads the callsign, if user clicks to a string in Fldigi's RX window
 	 *   fldigi_get_log_serial_number() reads the exchange
 	 */
-	if (digikeyer == FLDIGI && use_fldigi == 1
+	if (digikeyer == FLDIGI && fldigi_get()
 		&& trx_control == 1) {
 	    if (fldigi_rpc_cnt == 0) {
 		fldigi_xmlrpc_get_carrier();

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -100,7 +100,6 @@ int changepars(void) {
     extern char sc_volume[];
     extern int cwstart;
     extern int digikeyer;
-    extern int use_fldigi;
 
     char parameterstring[20];
     char parameters[52][19];
@@ -699,13 +698,11 @@ int changepars(void) {
 	}
         case 51: {              /* FLDIGI - turn on/off */
 	    if (digikeyer == FLDIGI) {
-		if (use_fldigi == 0) {
-		    use_fldigi = 1;
+		if (fldigi_toggle()) {
 		    fldigi_clear_connerr();
 		    mvprintw(13, 29, "FLDIGI ON");
 	        }
 	        else {
-		    use_fldigi = 0;
 		    mvprintw(13, 29, "FLDIGI OFF");
 		}
 		refreshp();

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -67,9 +67,11 @@ extern int use_fldigi;
 
 int fldigi_var_carrier = 0;
 int fldigi_var_shift_freq = 0;
+#ifdef HAVE_LIBXMLRPC
 static int initialized = 0;
-static int connerr = 0;
 static int fldigi_sending = 0;
+#endif
+static int connerr = 0;
 
 char thiscall[20] = "";
 char tcomment[20] = "";

--- a/src/fldigixmlrpc.h
+++ b/src/fldigixmlrpc.h
@@ -39,5 +39,7 @@ int fldigi_get_log_call();
 int fldigi_get_log_serial_number();
 void fldigi_clear_connerr();
 void fldigi_stop_text(void);
+int fldigi_toggle(void);
+int fldigi_get(void);
 
 #endif /* end of include guard: FLDIGIXMLRPC_H */

--- a/src/fldigixmlrpc.h
+++ b/src/fldigixmlrpc.h
@@ -38,5 +38,6 @@ void xmlrpc_showinfo();
 int fldigi_get_log_call();
 int fldigi_get_log_serial_number();
 void fldigi_clear_connerr();
+void fldigi_stop_text(void);
 
 #endif /* end of include guard: FLDIGIXMLRPC_H */

--- a/src/main.c
+++ b/src/main.c
@@ -373,7 +373,6 @@ int rig_comm_success = 0;
 
 /*----------------------------------fldigi---------------------------------*/
 char fldigi_url[50] = "http://localhost:7362/RPC2";
-int use_fldigi = 0;
 
 /*---------------------------------simulator-------------------------------*/
 int simulator = 0;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -28,6 +28,7 @@
 
 #include "bandmap.h"
 #include "cw_utils.h"
+#include "fldigixmlrpc.h"
 #include "getctydata.h"
 #include "getpx.h"
 #include "lancode.h"
@@ -300,7 +301,6 @@ int parse_logcfg(char *inputbuffer) {
     extern int bmautograb;
     extern int sprint_mode;
     extern char fldigi_url[50];
-    extern int use_fldigi;
     extern unsigned char rigptt;
     extern int minitest;
     extern int unique_call_multi;
@@ -1831,7 +1831,8 @@ int parse_logcfg(char *inputbuffer) {
 			  sizeof(fldigi_url));
 	    }
 	    digikeyer = FLDIGI;
-	    use_fldigi = 1;
+	    if (!fldigi_get())
+		fldigi_toggle();
 #endif
 	    break;
 	}

--- a/src/write_keyer.c
+++ b/src/write_keyer.c
@@ -116,6 +116,10 @@ int write_keyer(void) {
 
 	g_free(tosend);
 	tosend = NULL;
+    } else {
+	if (digikeyer == FLDIGI && trxmode == DIGIMODE)
+		fldigi_stop_text();
     }
+
     return (0);
 }


### PR DESCRIPTION
Use of the keyer with fldigi was causing PTT flapping and partial
sends.  Instead of stopping TX every sent string, track tx state,
and only send "^r" when there's nothing left to send.