### PR TITLE
Use condition variables to start/stop the background process.

### DIFF
--- a/src/background_process.c
+++ b/src/background_process.c
@@ -19,6 +19,7 @@
  */
 
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -43,7 +44,6 @@
 #include "qtcvars.h"
 
 
-extern int stop_backgrnd_process;
 extern int this_second;
 extern int cluster;
 extern int packetinterface;
@@ -68,8 +68,38 @@ extern int trxmode;
 extern int digikeyer;
 extern int trx_control;
 extern int use_fldigi;
+static int stop_backgrnd_process = 1;	/* dont start until we know what we are doing */
+static pthread_mutex_t stop_backgrnd_process_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t start_backgrnd_process_cond = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t backgrnd_process_stopped_cond = PTHREAD_COND_INITIALIZER;
 
 int cw_simulator(void);
+
+void stop_background_process(void) {
+	pthread_mutex_lock(&stop_backgrnd_process_mutex);
+	assert(stop_backgrnd_process == 0);
+	stop_backgrnd_process = 1;
+	pthread_cond_wait(&backgrnd_process_stopped_cond, &stop_backgrnd_process_mutex);
+	pthread_mutex_unlock(&stop_backgrnd_process_mutex);
+}
+
+void start_background_process(void) {
+	pthread_mutex_lock(&stop_backgrnd_process_mutex);
+	assert(stop_backgrnd_process == 1);
+	stop_backgrnd_process = 0;
+	pthread_cond_broadcast(&start_backgrnd_process_cond);
+	pthread_mutex_unlock(&stop_backgrnd_process_mutex);
+}
+
+static void background_process_wait(void)
+{
+	pthread_mutex_lock(&stop_backgrnd_process_mutex);
+	if (stop_backgrnd_process) {
+		pthread_cond_broadcast(&backgrnd_process_stopped_cond);
+		pthread_cond_wait(&start_backgrnd_process_cond, &stop_backgrnd_process_mutex);
+	}
+	pthread_mutex_unlock(&stop_backgrnd_process_mutex);
+}
 
 void *background_process(void *ptr) {
 
@@ -90,9 +120,7 @@ void *background_process(void *ptr) {
 
     while (i) {
 
-	while (stop_backgrnd_process == 1) {
-	    sleep(1);
-	}
+	background_process_wait();
 
 
 	usleep(10000);

--- a/src/background_process.h
+++ b/src/background_process.h
@@ -23,5 +23,7 @@
 #define BACKGROUND_PROCESS_H
 
 void *background_process(void *);
+void stop_background_process(void);
+void start_background_process(void);
 
 #endif /* end of include guard: BACKGROUND_PROCESS_H */

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "background_process.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "logview.h"
 #include "scroll_log.h"
@@ -101,7 +102,7 @@ void edit_last(void) {
     if (nr_qsos == 0)
 	return;			/* nothing to edit */
 
-    stop_backgrnd_process = 1;	//(no qso add during edit process)
+    stop_background_process();
 
     b = 29;
 
@@ -233,5 +234,5 @@ void edit_last(void) {
 
     scroll_log();
 
-    stop_backgrnd_process = 0;
+    start_background_process();
 }

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
+#include "background_process.h"
 #include "clear_display.h"
 #include "scroll_log.h"
 #include "tlf.h"
@@ -40,7 +41,6 @@ int logedit(void) {
     extern char logfile[];
     extern char backgrnd_str[];
     extern int editor;
-    extern int stop_backgrnd_process;
 
     char comstr[40] = "";
     int j;
@@ -93,7 +93,7 @@ int logedit(void) {
 
 	    close(lfile);
 
-	    stop_backgrnd_process = 1;
+	    stop_background_process();
 
 	    if ((infile = fopen(logfile, "r")) == NULL) {
 		mvprintw(24, 0, "Unable to open logfile...");
@@ -150,7 +150,7 @@ int logedit(void) {
 	} else
 	    close(lfile);
 
-	stop_backgrnd_process = 0;
+	start_background_process();
     }
 
     close(lfile);

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -70,7 +70,6 @@ extern char logline_edit[5][LOGLINELEN + 1];
 #define logline3 logline_edit[3]
 #define logline4 logline_edit[4]
 
-extern int stop_backgrnd_process;
 extern char band[NBANDS][4];
 extern struct tm *time_ptr;
 extern struct tm time_ptr_cabrillo;

--- a/src/logit.c
+++ b/src/logit.c
@@ -62,7 +62,6 @@ void logit(void) {
     extern char cq_return[];
     extern char sp_return[];
     extern int defer_store;
-    extern int stop_backgrnd_process;
     extern int recall_mult;
     extern int simulator;
     extern int simulator_mode;
@@ -83,7 +82,7 @@ void logit(void) {
     clear_display();
     defer_store = 0;
 
-    stop_backgrnd_process = 0;	/* start it up */
+    start_background_process();	/* start it up */
 
     while (1) {
 	printcall();

--- a/src/main.c
+++ b/src/main.c
@@ -458,7 +458,6 @@ int m = 1;
 char hiscountry[40];
 
 int this_second;
-int stop_backgrnd_process = 1;	/* dont start until we know what we are doing */
 
 int wazmult = 0;		/* to add the ability of WAZ zones to be multiplier */
 int itumult = 0;		/* to add the ability of ITU zones to be multiplier */

--- a/src/setparameters.c
+++ b/src/setparameters.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "background_process.h"
 #include "clear_display.h"
 #include "checklogfile.h"
 #include "getmessages.h"
@@ -50,13 +51,12 @@ int setparameters(void) {
     extern char call[];
     extern char logfile[];
     extern char whichcontest[];
-    extern int stop_backgrnd_process;
 
     int i = '9';
     char callcpy[12] = "";
     char logbuffer[20];
 
-    stop_backgrnd_process = 1;	/* to prevent race condition */
+    stop_background_process();	/* to prevent race condition */
 
     while ((i == '7') || (i == '8') || (i == '9')) {
 
@@ -188,7 +188,7 @@ int setparameters(void) {
 	beep();
     }
 
-    stop_backgrnd_process = 0;	/* release backgrnd process */
+    start_background_process();	/* release backgrnd process */
 
     return (0);
 }

--- a/src/writeparas.c
+++ b/src/writeparas.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "background_process.h"
 #include "cw_utils.h"
 #include "tlf.h"
 #include "tlf_curses.h"
@@ -49,13 +50,11 @@ int writeparas(void) {
     extern int showscore_flag;
     extern int cqdelay;
     extern int trxmode;
-    extern int stop_backgrnd_process;
 
     FILE *fp;
     int i;
 
-    stop_backgrnd_process = 1;
-    sleep(1);
+    stop_background_process();
 
     if (strlen(call) <= 3) {
 	mvprintw(24, 0, "Cannot write parameters file: data corrupt... ");
@@ -155,7 +154,7 @@ int writeparas(void) {
 
     fclose(fp);
 
-    stop_backgrnd_process = 0;
+    start_background_process();
 
     return (0);
 


### PR DESCRIPTION
Testing a global in a loop without volatile can cause various issues
with optimizers.  Further, the sleep(1) granularity made the
background task unresponsive.

Instead, use condition variables and mutexes to allow waiting for
the background thread to be restarted, then running immediately
when the condition occurs.