### PR TITLE
There are more than two valid TERM values...

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -550,8 +550,7 @@ void ui_init() {
     } else if (strcasecmp(term, "xterm") == 0) {
 	use_xterm = 1;
 	use_rxvt = 1;
-    } else
-	putenv("TERM=rxvt");	/*or going to native console linux driver */
+    }
 
     /* Check the environment variable ESCDELAY.
      *


### PR DESCRIPTION
Remove the hack which replaced any TERM value that wasn't "xterm"
with "rxvt".  Forcing rxvt means that if the terminal is not rxvt
compatible, all kinds of ncurses things would break.  The most
common difference is F1 - F4.  rxvt uses \E[11~, \E[12~, \E[13~
and \E[14~ while most modern xterm compatibles use \E[OP, \E[OQ,
\EOR, and \EOS respectively.

xterm-color and xterm-256color for example would suffer from this
issue, and F1 to F4 would not work correctly.