### PR TITLE
Fix warnings.

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -378,7 +378,7 @@ int drawSmeter(int xpos, int ypos, int yheight, float testvalue) {
 
 int panscan(void) {
 
-    int rc, j, key = 0;
+    int j, key = 0;
     float testvalue;
     float FromFrequency = 0.0;
     float FrequencyStep = 0.0;
@@ -398,14 +398,14 @@ int panscan(void) {
 	mvprintw(5, 60, "Frequency: ");
 	refreshp();
 	echo();
-	rc = scanf("%f", &FromFrequency);
+	scanf("%f", &FromFrequency);
 	noecho();
 	mvprintw(5, 72, "%5.1f", FromFrequency);
 	mvprintw(22, 1, "%5.1f", FromFrequency);
 	refreshp();
 	mvprintw(7, 60, "Step (kHz): ");
 	refreshp();
-	rc = scanf("%f", &FrequencyStep);
+	scanf("%f", &FrequencyStep);
 	mvprintw(7, 72, "%5.1f", FrequencyStep);
 	refreshp();
 
@@ -469,7 +469,7 @@ int panscan(void) {
 
 int nbscan(void) {
 
-    int rc, j, key = 0;
+    int j, key = 0;
     float testvalue;
     float FromFrequency = 0.0;
     float FrequencyStep = 0.0;
@@ -489,13 +489,13 @@ int nbscan(void) {
 	mvprintw(1, 60, "- NOISE BRIDGE -");	// get the parameters
 	mvprintw(5, 60, "Frequency: ");
 	refreshp();
-	rc = scanf("%f", &FromFrequency);
+	scanf("%f", &FromFrequency);
 	mvprintw(5, 72, "%5.1f", FromFrequency);
 	mvprintw(22, 1, "%5.1f", FromFrequency);
 	refreshp();
 	mvprintw(7, 60, "Step (kHz): ");
 	refreshp();
-	rc = scanf("%f", &FrequencyStep);
+	scanf("%f", &FrequencyStep);
 	mvprintw(7, 72, "%5.1f", FrequencyStep);
 	refreshp();
 
@@ -652,7 +652,6 @@ void do_record(int message_nr) {
 
     extern char ph_message[14][80];
 
-    int rc;
     char commands[80] = "";
 
     mvprintw(15, 20, "recording %s", ph_message[message_nr]);
@@ -662,12 +661,12 @@ void do_record(int message_nr) {
     strcpy(commands, "rec -r 8000 ");	//G4KNO
     strcat(commands, ph_message[message_nr]);
     strcat(commands, " -q &");	//G4KNO
-    rc = system(commands);
+    system(commands);
     //G4KNO: Loop until <esc> keypress
     while (1) {
 	if (key_get() == 27) {
 	    //kill process (SIGINT=Ctrl-C).
-	    rc = system("pkill -SIGINT -n rec");
+	    system("pkill -SIGINT -n rec");
 	    break;
 	}
     }
@@ -678,7 +677,7 @@ void record(void) {
 
     extern char ph_message[14][80];
 
-    int rc, runnit = 1, key, i = 0, j = 4;
+    int runnit = 1, key, i = 0, j = 4;
     char commands[80] = "";
     char playbackfile[40];
     char printname[7];
@@ -758,9 +757,9 @@ void record(void) {
 
 	    // Start contest recording.
 	    case '1':
-		rc = system("echo " " > ~/.VRlock");
+		system("echo " " > ~/.VRlock");
 
-		rc = system
+		system
 		     ("cd ~/tlf/soundlogs; ./soundlog  > /dev/null 2> /dev/null &");
 
 		mvprintw(15, 20, "Contest recording enabled...");
@@ -774,8 +773,8 @@ void record(void) {
 		mvprintw(15, 20, "Contest recording disabled...");
 		refreshp();
 		sleep(1);
-		rc = system("rm ~/.VRlock");
-		rc = system("pkill -f soundlogs > /dev/null 2> /dev/null ");
+		system("rm ~/.VRlock");
+		system("pkill -f soundlogs > /dev/null 2> /dev/null ");
 		runnit = 0;
 		break;
 
@@ -837,7 +836,7 @@ void record(void) {
 		mvprintw(16, 20, "Use Ctrl-c to stop and return to tlf");
 		mvprintw(18, 20, "");
 		refreshp();
-		rc = system(commands);
+		system(commands);
 		runnit = 0;
 		break;
 	    case 27:

--- a/src/audio.c
+++ b/src/audio.c
@@ -398,14 +398,14 @@ int panscan(void) {
 	mvprintw(5, 60, "Frequency: ");
 	refreshp();
 	echo();
-	scanf("%f", &FromFrequency);
+	(void) scanf("%f", &FromFrequency);
 	noecho();
 	mvprintw(5, 72, "%5.1f", FromFrequency);
 	mvprintw(22, 1, "%5.1f", FromFrequency);
 	refreshp();
 	mvprintw(7, 60, "Step (kHz): ");
 	refreshp();
-	scanf("%f", &FrequencyStep);
+	(void) scanf("%f", &FrequencyStep);
 	mvprintw(7, 72, "%5.1f", FrequencyStep);
 	refreshp();
 
@@ -489,13 +489,13 @@ int nbscan(void) {
 	mvprintw(1, 60, "- NOISE BRIDGE -");	// get the parameters
 	mvprintw(5, 60, "Frequency: ");
 	refreshp();
-	scanf("%f", &FromFrequency);
+	(void) scanf("%f", &FromFrequency);
 	mvprintw(5, 72, "%5.1f", FromFrequency);
 	mvprintw(22, 1, "%5.1f", FromFrequency);
 	refreshp();
 	mvprintw(7, 60, "Step (kHz): ");
 	refreshp();
-	scanf("%f", &FrequencyStep);
+	(void) scanf("%f", &FrequencyStep);
 	mvprintw(7, 72, "%5.1f", FrequencyStep);
 	refreshp();
 
@@ -661,12 +661,12 @@ void do_record(int message_nr) {
     strcpy(commands, "rec -r 8000 ");	//G4KNO
     strcat(commands, ph_message[message_nr]);
     strcat(commands, " -q &");	//G4KNO
-    system(commands);
+    (void) system(commands);
     //G4KNO: Loop until <esc> keypress
     while (1) {
 	if (key_get() == 27) {
 	    //kill process (SIGINT=Ctrl-C).
-	    system("pkill -SIGINT -n rec");
+	    (void) system("pkill -SIGINT -n rec");
 	    break;
 	}
     }
@@ -757,9 +757,9 @@ void record(void) {
 
 	    // Start contest recording.
 	    case '1':
-		system("echo " " > ~/.VRlock");
+		(void) system("echo " " > ~/.VRlock");
 
-		system
+		(void) system
 		     ("cd ~/tlf/soundlogs; ./soundlog  > /dev/null 2> /dev/null &");
 
 		mvprintw(15, 20, "Contest recording enabled...");
@@ -773,8 +773,8 @@ void record(void) {
 		mvprintw(15, 20, "Contest recording disabled...");
 		refreshp();
 		sleep(1);
-		system("rm ~/.VRlock");
-		system("pkill -f soundlogs > /dev/null 2> /dev/null ");
+		(void) system("rm ~/.VRlock");
+		(void) system("pkill -f soundlogs > /dev/null 2> /dev/null ");
 		runnit = 0;
 		break;
 
@@ -836,7 +836,7 @@ void record(void) {
 		mvprintw(16, 20, "Use Ctrl-c to stop and return to tlf");
 		mvprintw(18, 20, "");
 		refreshp();
-		system(commands);
+		(void) system(commands);
 		runnit = 0;
 		break;
 	    case 27:

--- a/src/audio.c
+++ b/src/audio.c
@@ -33,10 +33,11 @@
 #include <sys/ioctl.h>
 
 #include "audio.h"
+#include "gettxinfo.h"
+#include "ignore_unused.h"
 #include "tlf.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
-#include "gettxinfo.h"
 
 #ifdef __OpenBSD__
 # include <soundcard.h>
@@ -398,14 +399,14 @@ int panscan(void) {
 	mvprintw(5, 60, "Frequency: ");
 	refreshp();
 	echo();
-	(void) scanf("%f", &FromFrequency);
+	IGNORE(scanf("%f", &FromFrequency));
 	noecho();
 	mvprintw(5, 72, "%5.1f", FromFrequency);
 	mvprintw(22, 1, "%5.1f", FromFrequency);
 	refreshp();
 	mvprintw(7, 60, "Step (kHz): ");
 	refreshp();
-	(void) scanf("%f", &FrequencyStep);
+	IGNORE(scanf("%f", &FrequencyStep));
 	mvprintw(7, 72, "%5.1f", FrequencyStep);
 	refreshp();
 
@@ -489,13 +490,13 @@ int nbscan(void) {
 	mvprintw(1, 60, "- NOISE BRIDGE -");	// get the parameters
 	mvprintw(5, 60, "Frequency: ");
 	refreshp();
-	(void) scanf("%f", &FromFrequency);
+	IGNORE(scanf("%f", &FromFrequency));
 	mvprintw(5, 72, "%5.1f", FromFrequency);
 	mvprintw(22, 1, "%5.1f", FromFrequency);
 	refreshp();
 	mvprintw(7, 60, "Step (kHz): ");
 	refreshp();
-	(void) scanf("%f", &FrequencyStep);
+	IGNORE(scanf("%f", &FrequencyStep));;
 	mvprintw(7, 72, "%5.1f", FrequencyStep);
 	refreshp();
 
@@ -661,12 +662,12 @@ void do_record(int message_nr) {
     strcpy(commands, "rec -r 8000 ");	//G4KNO
     strcat(commands, ph_message[message_nr]);
     strcat(commands, " -q &");	//G4KNO
-    (void) system(commands);
+    IGNORE(system(commands));;
     //G4KNO: Loop until <esc> keypress
     while (1) {
 	if (key_get() == 27) {
 	    //kill process (SIGINT=Ctrl-C).
-	    (void) system("pkill -SIGINT -n rec");
+	    IGNORE(system("pkill -SIGINT -n rec"));;
 	    break;
 	}
     }
@@ -757,10 +758,10 @@ void record(void) {
 
 	    // Start contest recording.
 	    case '1':
-		(void) system("echo " " > ~/.VRlock");
+		IGNORE(system("echo " " > ~/.VRlock"));;
 
-		(void) system
-		     ("cd ~/tlf/soundlogs; ./soundlog  > /dev/null 2> /dev/null &");
+		IGNORE(system
+		     ("cd ~/tlf/soundlogs; ./soundlog  > /dev/null 2> /dev/null &"));
 
 		mvprintw(15, 20, "Contest recording enabled...");
 		refreshp();
@@ -773,8 +774,8 @@ void record(void) {
 		mvprintw(15, 20, "Contest recording disabled...");
 		refreshp();
 		sleep(1);
-		(void) system("rm ~/.VRlock");
-		(void) system("pkill -f soundlogs > /dev/null 2> /dev/null ");
+		IGNORE(system("rm ~/.VRlock"));;
+		IGNORE(system("pkill -f soundlogs > /dev/null 2> /dev/null "));;
 		runnit = 0;
 		break;
 
@@ -836,7 +837,7 @@ void record(void) {
 		mvprintw(16, 20, "Use Ctrl-c to stop and return to tlf");
 		mvprintw(18, 20, "");
 		refreshp();
-		(void) system(commands);
+		IGNORE(system(commands));;
 		runnit = 0;
 		break;
 	    case 27:

--- a/src/background_process.c
+++ b/src/background_process.c
@@ -290,7 +290,6 @@ int cw_simulator(void) {
 
     static int callnumber;
     char callcpy[80];
-    static int x;
 
     if (simulator == 0)
 	return (-1);
@@ -378,7 +377,7 @@ int cw_simulator(void) {
 
 	strcpy(callcpy, CALLMASTERARRAY(callnumber));
 
-	x = getctydata(callcpy);
+	getctydata(callcpy);
 
 	str = g_strdup_printf("TU 5NN %2s", zone_export);
 	sendmessage(str);
@@ -400,7 +399,7 @@ int cw_simulator(void) {
 	write_tone();
 
 	strcpy(callcpy, CALLMASTERARRAY(callnumber));
-	x = getctydata(callcpy);
+	getctydata(callcpy);
 
 	str = g_strdup_printf("DE %s TU 5NN %s",
 			      CALLMASTERARRAY(callnumber), zone_export);

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -453,7 +453,8 @@ int callinput(void) {
 
 			his_rst[1]++;
 
-			no_rst ? : mvprintw(12, 44, his_rst);
+			if (!no_rst)
+			    mvprintw(12, 44, his_rst);
 			mvprintw(12, 29, hiscall);
 		    }
 
@@ -475,7 +476,8 @@ int callinput(void) {
 		    if (his_rst[1] > 49) {
 			his_rst[1]--;
 
-			no_rst ? : mvprintw(12, 44, his_rst);
+			if (!no_rst)
+			    mvprintw(12, 44, his_rst);
 			mvprintw(12, 29, hiscall);
 		    }
 
@@ -876,9 +878,9 @@ int callinput(void) {
 		    shell = "sh";
 		}
 		endwin();
-		system("clear");
-		system(shell);
-		system("clear");
+		(void) system("clear");
+		(void) system(shell);
+		(void) system("clear");
 		set_term(mainscreen);
 		clear_display();
 
@@ -1230,7 +1232,9 @@ int autosend() {
 int play_file(char *audiofile) {
 
     extern int txdelay;
+#ifdef HAVE_LIBHAMLIB
     extern unsigned char rigptt;
+#endif
 
     int fd;
     char playcommand[120];
@@ -1260,7 +1264,7 @@ int play_file(char *audiofile) {
 #endif
 
 	usleep(txdelay * 1000);
-	system(playcommand);
+	(void) system(playcommand);
 	printcall();
 
 #ifdef HAVE_LIBHAMLIB

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -167,7 +167,7 @@ int callinput(void) {
 
 
     int cury, curx;
-    int j, ii, rc, t, x = 0;
+    int j, ii, t, x = 0;
     char instring[2] = { '\0', '\0' };
     static int lastwindow;
 
@@ -876,9 +876,9 @@ int callinput(void) {
 		    shell = "sh";
 		}
 		endwin();
-		rc = system("clear");
-		rc = system(shell);
-		rc = system("clear");
+		system("clear");
+		system(shell);
+		system("clear");
 		set_term(mainscreen);
 		clear_display();
 
@@ -1232,7 +1232,7 @@ int play_file(char *audiofile) {
     extern int txdelay;
     extern unsigned char rigptt;
 
-    int fd, rc;
+    int fd;
     char playcommand[120];
 
     if (*audiofile == '\0')
@@ -1260,7 +1260,7 @@ int play_file(char *audiofile) {
 #endif
 
 	usleep(txdelay * 1000);
-	rc = system(playcommand);
+	system(playcommand);
 	printcall();
 
 #ifdef HAVE_LIBHAMLIB

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -46,6 +46,7 @@
 #include "getctydata.h"
 #include "gettxinfo.h"
 #include "grabspot.h"
+#include "ignore_unused.h"
 #include "lancode.h"
 #include "muf.h"
 #include "netkeyer.h"
@@ -878,9 +879,9 @@ int callinput(void) {
 		    shell = "sh";
 		}
 		endwin();
-		(void) system("clear");
-		(void) system(shell);
-		(void) system("clear");
+		IGNORE(system("clear"));;
+		IGNORE(system(shell));;
+		IGNORE(system("clear"));;
 		set_term(mainscreen);
 		clear_display();
 
@@ -1264,7 +1265,7 @@ int play_file(char *audiofile) {
 #endif
 
 	usleep(txdelay * 1000);
-	(void) system(playcommand);
+	IGNORE(system(playcommand));;
 	printcall();
 
 #ifdef HAVE_LIBHAMLIB

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -37,6 +37,7 @@
 #include "editlog.h"
 #include "fldigixmlrpc.h"
 #include "gettxinfo.h"
+#include "ignore_unused.h"
 #include "lancode.h"
 #include "listmessages.h"
 #include "logview.h"
@@ -370,7 +371,7 @@ int changepars(void) {
 	    }
 
 	    strcat(cmdstring, config_file);
-	    (void) system(cmdstring);
+	    IGNORE(system(cmdstring));;
 
 	    read_logcfg();
 	    read_rules();	/* also reread rules file */
@@ -1057,7 +1058,7 @@ int debug_tty(void) {
     mvprintw(7, 40, "Length = %d characters", strlen(line));
     refreshp();
 
-    (void) write(fdSertnc, line, strlen(line));
+    IGNORE(write(fdSertnc, line, strlen(line)));;
 
     mvprintw(8, 0, "receiving message from trx");
     refreshp();

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -109,7 +109,6 @@ int changepars(void) {
     int maxpar = 50;
     int volumebuffer;
     int currentmode = 0;
-    int rc;
 
     strcpy(parameters[0], "SPOT");
     strcpy(parameters[1], "MAP");
@@ -371,7 +370,7 @@ int changepars(void) {
 	    }
 
 	    strcat(cmdstring, config_file);
-	    rc = system(cmdstring);
+	    system(cmdstring);
 
 	    read_logcfg();
 	    read_rules();	/* also reread rules file */
@@ -949,7 +948,7 @@ int debug_tty(void) {
 
     int fdSertnc;
     int tncport = 0;
-    int i, rc;
+    int i;
     struct termios termattribs;
     char line[20] = "?AF\015";
     char inputline[80] = "";
@@ -1058,7 +1057,7 @@ int debug_tty(void) {
     mvprintw(7, 40, "Length = %d characters", strlen(line));
     refreshp();
 
-    rc = write(fdSertnc, line, strlen(line));
+    write(fdSertnc, line, strlen(line));
 
     mvprintw(8, 0, "receiving message from trx");
     refreshp();

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -370,7 +370,7 @@ int changepars(void) {
 	    }
 
 	    strcat(cmdstring, config_file);
-	    system(cmdstring);
+	    (void) system(cmdstring);
 
 	    read_logcfg();
 	    read_rules();	/* also reread rules file */
@@ -1057,7 +1057,7 @@ int debug_tty(void) {
     mvprintw(7, 40, "Length = %d characters", strlen(line));
     refreshp();
 
-    write(fdSertnc, line, strlen(line));
+    (void) write(fdSertnc, line, strlen(line));
 
     mvprintw(8, 0, "receiving message from trx");
     refreshp();

--- a/src/checklogfile.c
+++ b/src/checklogfile.c
@@ -36,6 +36,7 @@
 
 #include <glib.h>
 
+#include "ignore_unused.h"
 #include "startmsg.h"
 #include "tlf.h"
 #include "tlf_curses.h"
@@ -261,7 +262,7 @@ void checklogfile(void) {
 
 		    while (!(feof(infile))) {
 
-			(void) fgets(inputbuffer, 160, infile);
+			IGNORE(fgets(inputbuffer, 160, infile));;
 
 			if (strlen(inputbuffer) != LOGLINELEN) {
 			    strcat(inputbuffer, backgrnd_str);
@@ -286,7 +287,7 @@ void checklogfile(void) {
 		    fstat(lfile, &statbuf);
 
 		    if (statbuf.st_size > 80) {
-			(void) ftruncate(lfile, statbuf.st_size - LOGLINELEN);
+			IGNORE(ftruncate(lfile, statbuf.st_size - LOGLINELEN));;
 			fsync(lfile);
 
 		    }

--- a/src/checklogfile.c
+++ b/src/checklogfile.c
@@ -261,7 +261,7 @@ void checklogfile(void) {
 
 		    while (!(feof(infile))) {
 
-			fgets(inputbuffer, 160, infile);
+			(void) fgets(inputbuffer, 160, infile);
 
 			if (strlen(inputbuffer) != LOGLINELEN) {
 			    strcat(inputbuffer, backgrnd_str);
@@ -286,7 +286,7 @@ void checklogfile(void) {
 		    fstat(lfile, &statbuf);
 
 		    if (statbuf.st_size > 80) {
-			ftruncate(lfile, statbuf.st_size - LOGLINELEN);
+			(void) ftruncate(lfile, statbuf.st_size - LOGLINELEN);
 			fsync(lfile);
 
 		    }

--- a/src/checklogfile.c
+++ b/src/checklogfile.c
@@ -224,12 +224,9 @@ void checklogfile(void) {
 
     int lfile;
     int qsobytes;
-    int qsolines;
     int errbytes;
-    int rc;
     struct stat statbuf;
     char inputbuffer[800];
-    char *rp;
 
     FILE *infile;
     FILE *outfile;
@@ -243,7 +240,6 @@ void checklogfile(void) {
 
 	fstat(fileno(fp), &statbuf);
 	qsobytes = statbuf.st_size;
-	qsolines = qsobytes / LOGLINELEN;
 	errbytes = qsobytes % LOGLINELEN;
 
 	if (errbytes != 0) {
@@ -265,7 +261,7 @@ void checklogfile(void) {
 
 		    while (!(feof(infile))) {
 
-			rp = fgets(inputbuffer, 160, infile);
+			fgets(inputbuffer, 160, infile);
 
 			if (strlen(inputbuffer) != LOGLINELEN) {
 			    strcat(inputbuffer, backgrnd_str);
@@ -290,7 +286,7 @@ void checklogfile(void) {
 		    fstat(lfile, &statbuf);
 
 		    if (statbuf.st_size > 80) {
-			rc = ftruncate(lfile, statbuf.st_size - LOGLINELEN);
+			ftruncate(lfile, statbuf.st_size - LOGLINELEN);
 			fsync(lfile);
 
 		    }

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -31,6 +31,7 @@
 
 #include "clear_display.h"
 #include "deleteqso.h"
+#include "ignore_unused.h"
 #include "printcall.h"
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h
@@ -65,7 +66,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 	    lseek(qtcfile, 0, SEEK_SET);
 	    while (look == 1) {
 		lseek(qtcfile, ((int)qstatbuf.st_size - (91 + qtclen)), SEEK_SET);
-		(void) read(qtcfile, logline, 90);
+		IGNORE(read(qtcfile, logline, 90));;
 		logline[90] = '\0';
 
 		if (!(strncmp(call, logline + QTCRECVCALLPOS, strlen(call)) == 0
@@ -77,7 +78,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 		    qtc_dec(call, RECV);
 		}
 	    }
-	    (void) ftruncate(qtcfile, qstatbuf.st_size - qtclen);
+	    IGNORE(ftruncate(qtcfile, qstatbuf.st_size - qtclen));;
 	    fsync(qtcfile);
 	}
 	close(qtcfile);
@@ -102,7 +103,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 	    // this works only for fixed length qtc line!
 	    while (s >= 0 && look == 1) {
 		lseek(qtcfile, ((int)qstatbuf.st_size - (95 + qtclen)), SEEK_SET);
-		(void) read(qtcfile, logline, 94);
+		IGNORE(read(qtcfile, logline, 94));;
 		if (!(strncmp(call, logline + QTCSENTCALLPOS, strlen(call)) == 0
 			&& strncmp(bandmode, logline, 5) == 0)) {
 		    // stop searching
@@ -118,7 +119,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 		    }
 		}
 	    }
-	    (void) ftruncate(qtcfile, qstatbuf.st_size - qtclen);
+	    IGNORE(ftruncate(qtcfile, qstatbuf.st_size - qtclen));;
 	    nr_qtcsent--;
 	    fsync(qtcfile);
 	}
@@ -153,7 +154,7 @@ void delete_qso(void) {
 		if (qtcdirection > 0) {
 		    // read band, mode and call from last QSO line
 		    lseek(lfile, ((int)statbuf.st_size - LOGLINELEN), SEEK_SET);
-		    (void) read(lfile, logline, LOGLINELEN - 1);
+		    IGNORE(read(lfile, logline, LOGLINELEN - 1));;
 
 		    g_strlcpy(bandmode, logline, 6);
 		    g_strlcpy(call, logline + 29, 15);

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -65,7 +65,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 	    lseek(qtcfile, 0, SEEK_SET);
 	    while (look == 1) {
 		lseek(qtcfile, ((int)qstatbuf.st_size - (91 + qtclen)), SEEK_SET);
-		read(qtcfile, logline, 90);
+		(void) read(qtcfile, logline, 90);
 		logline[90] = '\0';
 
 		if (!(strncmp(call, logline + QTCRECVCALLPOS, strlen(call)) == 0
@@ -77,7 +77,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 		    qtc_dec(call, RECV);
 		}
 	    }
-	    ftruncate(qtcfile, qstatbuf.st_size - qtclen);
+	    (void) ftruncate(qtcfile, qstatbuf.st_size - qtclen);
 	    fsync(qtcfile);
 	}
 	close(qtcfile);
@@ -102,7 +102,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 	    // this works only for fixed length qtc line!
 	    while (s >= 0 && look == 1) {
 		lseek(qtcfile, ((int)qstatbuf.st_size - (95 + qtclen)), SEEK_SET);
-		read(qtcfile, logline, 94);
+		(void) read(qtcfile, logline, 94);
 		if (!(strncmp(call, logline + QTCSENTCALLPOS, strlen(call)) == 0
 			&& strncmp(bandmode, logline, 5) == 0)) {
 		    // stop searching
@@ -118,7 +118,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 		    }
 		}
 	    }
-	    ftruncate(qtcfile, qstatbuf.st_size - qtclen);
+	    (void) ftruncate(qtcfile, qstatbuf.st_size - qtclen);
 	    nr_qtcsent--;
 	    fsync(qtcfile);
 	}
@@ -153,7 +153,7 @@ void delete_qso(void) {
 		if (qtcdirection > 0) {
 		    // read band, mode and call from last QSO line
 		    lseek(lfile, ((int)statbuf.st_size - LOGLINELEN), SEEK_SET);
-		    read(lfile, logline, LOGLINELEN - 1);
+		    (void) read(lfile, logline, LOGLINELEN - 1);
 
 		    g_strlcpy(bandmode, logline, 6);
 		    g_strlcpy(call, logline + 29, 15);

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -44,7 +44,7 @@
 
 
 void delete_last_qtcs(char *call, char *bandmode) {
-    int rc, look, qtclen, s;
+    int look, qtclen, s;
     int qtcfile;
     struct stat qstatbuf;
     char logline[100];
@@ -65,7 +65,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 	    lseek(qtcfile, 0, SEEK_SET);
 	    while (look == 1) {
 		lseek(qtcfile, ((int)qstatbuf.st_size - (91 + qtclen)), SEEK_SET);
-		rc = read(qtcfile, logline, 90);
+		read(qtcfile, logline, 90);
 		logline[90] = '\0';
 
 		if (!(strncmp(call, logline + QTCRECVCALLPOS, strlen(call)) == 0
@@ -77,7 +77,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 		    qtc_dec(call, RECV);
 		}
 	    }
-	    rc = ftruncate(qtcfile, qstatbuf.st_size - qtclen);
+	    ftruncate(qtcfile, qstatbuf.st_size - qtclen);
 	    fsync(qtcfile);
 	}
 	close(qtcfile);
@@ -102,7 +102,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 	    // this works only for fixed length qtc line!
 	    while (s >= 0 && look == 1) {
 		lseek(qtcfile, ((int)qstatbuf.st_size - (95 + qtclen)), SEEK_SET);
-		rc = read(qtcfile, logline, 94);
+		read(qtcfile, logline, 94);
 		if (!(strncmp(call, logline + QTCSENTCALLPOS, strlen(call)) == 0
 			&& strncmp(bandmode, logline, 5) == 0)) {
 		    // stop searching
@@ -118,7 +118,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 		    }
 		}
 	    }
-	    rc = ftruncate(qtcfile, qstatbuf.st_size - qtclen);
+	    ftruncate(qtcfile, qstatbuf.st_size - qtclen);
 	    nr_qtcsent--;
 	    fsync(qtcfile);
 	}
@@ -129,7 +129,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 
 void delete_qso(void) {
 
-    int x, rc;
+    int x;
     struct stat statbuf;
     int lfile;
     char logline[100];
@@ -153,7 +153,7 @@ void delete_qso(void) {
 		if (qtcdirection > 0) {
 		    // read band, mode and call from last QSO line
 		    lseek(lfile, ((int)statbuf.st_size - LOGLINELEN), SEEK_SET);
-		    rc = read(lfile, logline, LOGLINELEN - 1);
+		    read(lfile, logline, LOGLINELEN - 1);
 
 		    g_strlcpy(bandmode, logline, 6);
 		    g_strlcpy(call, logline + 29, 15);
@@ -162,7 +162,7 @@ void delete_qso(void) {
 		    // delete QTC's for that combination of band, mode and call
 		    delete_last_qtcs(call, bandmode);
 		}
-		rc = ftruncate(lfile, statbuf.st_size - LOGLINELEN);
+		ftruncate(lfile, statbuf.st_size - LOGLINELEN);
 	    }
 
 	    fsync(lfile);

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -163,7 +163,7 @@ void delete_qso(void) {
 		    // delete QTC's for that combination of band, mode and call
 		    delete_last_qtcs(call, bandmode);
 		}
-		ftruncate(lfile, statbuf.st_size - LOGLINELEN);
+		IGNORE(ftruncate(lfile, statbuf.st_size - LOGLINELEN));
 	    }
 
 	    fsync(lfile);

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -48,7 +48,6 @@ int logedit(void) {
     int qsobytes;
     int qsolines;
     int errbytes;
-    int rc;
     struct stat statbuf;
     FILE *infile;
     FILE *outfile;
@@ -65,7 +64,7 @@ int logedit(void) {
 	strcat(comstr, "e3  ");
 
     strcat(comstr, logfile);
-    rc = system(comstr);
+    system(comstr);
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     erase();
     refreshp();
@@ -112,7 +111,7 @@ int logedit(void) {
 
 			rp = fgets(inputbuffer, 160, infile);
 
-			if (strlen(inputbuffer) != LOGLINELEN) {
+			if (rp != NULL && strlen(inputbuffer) != LOGLINELEN) {
 			    strcat(inputbuffer, backgrnd_str);
 			    inputbuffer[LOGLINELEN] = '\0';
 			}
@@ -135,7 +134,7 @@ int logedit(void) {
 		    fstat(lfile, &statbuf);
 
 		    if (statbuf.st_size > 80) {
-			rc = ftruncate(lfile, statbuf.st_size - LOGLINELEN);
+			ftruncate(lfile, statbuf.st_size - LOGLINELEN);
 			fsync(lfile);
 
 		    }

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 
 #include "clear_display.h"
+#include "ignore_unused.h"
 #include "scroll_log.h"
 #include "tlf.h"
 #include "tlf_curses.h"
@@ -64,7 +65,7 @@ int logedit(void) {
 	strcat(comstr, "e3  ");
 
     strcat(comstr, logfile);
-    (void) system(comstr);
+    IGNORE(system(comstr));;
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     erase();
     refreshp();
@@ -134,7 +135,7 @@ int logedit(void) {
 		    fstat(lfile, &statbuf);
 
 		    if (statbuf.st_size > 80) {
-			(void) ftruncate(lfile, statbuf.st_size - LOGLINELEN);
+			IGNORE(ftruncate(lfile, statbuf.st_size - LOGLINELEN));;
 			fsync(lfile);
 
 		    }

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -64,7 +64,7 @@ int logedit(void) {
 	strcat(comstr, "e3  ");
 
     strcat(comstr, logfile);
-    system(comstr);
+    (void) system(comstr);
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     erase();
     refreshp();
@@ -134,7 +134,7 @@ int logedit(void) {
 		    fstat(lfile, &statbuf);
 
 		    if (statbuf.st_size > 80) {
-			ftruncate(lfile, statbuf.st_size - LOGLINELEN);
+			(void) ftruncate(lfile, statbuf.st_size - LOGLINELEN);
 			fsync(lfile);
 
 		    }

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -67,7 +67,10 @@ extern int use_fldigi;
 
 int fldigi_var_carrier = 0;
 int fldigi_var_shift_freq = 0;
+#ifdef HAVE_LIBXMLRPC
 static int initialized = 0;
+static int fldigi_sending = 0;
+#endif
 static int connerr = 0;
 
 char thiscall[20] = "";

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -69,7 +69,6 @@ int fldigi_var_carrier = 0;
 int fldigi_var_shift_freq = 0;
 #ifdef HAVE_LIBXMLRPC
 static int initialized = 0;
-static int fldigi_sending = 0;
 #endif
 static int connerr = 0;
 

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -420,15 +420,17 @@ int fldigi_xmlrpc_get_carrier() {
     return 0;
 #else
 
-    extern int rigmode;
-    extern int trx_control;
-    extern float freq;
     int rc;
     xmlrpc_res result;
     xmlrpc_env env;
+#ifdef HAVE_LIBHAMLIB
+    extern int rigmode;
+    extern int trx_control;
+    extern float freq;
     int signum;
     int modeshift;
     char fldigi_mode[6] = "";
+#endif
 
     rc = fldigi_xmlrpc_query(&result, &env, "modem.get_carrier", "");
     if (rc != 0) {

--- a/src/freq_display.c
+++ b/src/freq_display.c
@@ -31,7 +31,6 @@ int freq_display(void) {
 
     int x_position = 40;
     int y_position = 17;
-    int location = 0;
     char fbuffer[8];
 
     print_space(y_position, x_position);
@@ -43,8 +42,6 @@ int freq_display(void) {
     print_dot(y_position + 4, 28 + x_position + 1);
 
     sprintf(fbuffer, "%7.1f", freq);
-
-    location = 32;
 
     if (fbuffer[0] != ' ')
 	print_big_number(fbuffer[0] - 48, y_position, x_position, 4);

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -298,7 +298,8 @@ int getexchange(void) {
 		    if (my_rst[1] <= 56) {
 			my_rst[1]++;
 
-			no_rst ? : mvprintw(12, 49, my_rst);
+			if (!no_rst)
+			    mvprintw(12, 49, my_rst);
 		    }
 		} else {	/* speed up */
 		    speedup();
@@ -315,7 +316,8 @@ int getexchange(void) {
 		    if (my_rst[1] > 49) {
 			my_rst[1]--;
 
-			no_rst ? : mvprintw(12, 49, my_rst);
+			if (!no_rst)
+			    mvprintw(12, 49, my_rst);
 		    }
 		} else {	/* speed down */
 		    speeddown();

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -110,7 +110,6 @@ int getexchange(void) {
     int x = 0;
     char instring[2];
     char commentbuf[40] = "";
-    int retval = 0;
     char *gridmult = "";
 
     instring[1] = '\0';
@@ -121,13 +120,13 @@ int getexchange(void) {
     }
 
     if (recall_mult == 1)
-	retval = recall_exchange();
+	recall_exchange();
 
     if ((arrldx_usa == 1) && (trxmode != CWMODE))
-	retval = recall_exchange();
+	recall_exchange();
 
     if (arrl_fd == 1)
-	retval = recall_exchange();
+	recall_exchange();
 
     if (((cqww == 1) || (wazmult == 1) || (itumult == 1))
 	    && (*comment == '\0') && (strlen(hiscall) != 0)) {
@@ -142,7 +141,7 @@ int getexchange(void) {
     }
 
     if (stewperry_flg == 1) {
-	retval = recall_exchange();
+	recall_exchange();
     }
 
     /* parse input and modify exchange field accordingly */

--- a/src/getmessages.c
+++ b/src/getmessages.c
@@ -105,7 +105,7 @@ int getmessages(void) {
 
 	if (fseek(fp, -1L * i * LOGLINELEN, SEEK_END) == 0) {
 
-	    fgets(logline[ii], 85, fp);
+	    (void) fgets(logline[ii], 85, fp);
 	} else {
 	    strncpy(logline[ii], backgrnd_str, 81);
 	}

--- a/src/getmessages.c
+++ b/src/getmessages.c
@@ -34,6 +34,7 @@
 #include "getctydata.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "qsonr_to_str.h"
+#include "ignore_unused.h"
 #include "tlf_curses.h"
 
 /* get countrynumber, QTH, CQ zone and continent for myself */
@@ -105,7 +106,7 @@ int getmessages(void) {
 
 	if (fseek(fp, -1L * i * LOGLINELEN, SEEK_END) == 0) {
 
-	    (void) fgets(logline[ii], 85, fp);
+	    IGNORE(fgets(logline[ii], 85, fp));;
 	} else {
 	    strncpy(logline[ii], backgrnd_str, 81);
 	}

--- a/src/getmessages.c
+++ b/src/getmessages.c
@@ -72,7 +72,6 @@ int getmessages(void) {
     int i, ii;
     char logline[5][82];
     char printcall[12] = "";
-    char *rp;
 
     printw("\n     Call = ");
 
@@ -106,7 +105,7 @@ int getmessages(void) {
 
 	if (fseek(fp, -1L * i * LOGLINELEN, SEEK_END) == 0) {
 
-	    rp = fgets(logline[ii], 85, fp);
+	    fgets(logline[ii], 85, fp);
 	} else {
 	    strncpy(logline[ii], backgrnd_str, 81);
 	}

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -27,6 +27,7 @@
 #include <sys/time.h>
 #include <pthread.h>
 
+#include "bands.h"
 #include "fldigixmlrpc.h"
 #include "gettxinfo.h"
 #include "tlf.h"

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -82,7 +82,9 @@ static int outfreq = 0;
 static pthread_mutex_t outfreq_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 
+#ifdef HAVE_LIBHAMLIB
 static double get_current_seconds();
+#endif
 static void handle_trx_bandswitch(int freq);
 
 void set_outfreq(double hertz) {
@@ -121,8 +123,10 @@ void gettxinfo(void) {
 #endif
 
     static int oldbandinx;
+#ifdef HAVE_LIBXMLRPC
     static int fldigi_carrier;
     static int fldigi_shift_freq;
+#endif
 
 
     if (!trx_control)
@@ -279,11 +283,13 @@ void gettxinfo(void) {
 }
 
 
+#ifdef HAVE_LIBHAMLIB
 static double get_current_seconds() {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return tv.tv_sec + tv.tv_usec / 1e6;
 }
+#endif
 
 
 static void handle_trx_bandswitch(int freq) {

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -123,7 +123,7 @@ void gettxinfo(void) {
 #endif
 
     static int oldbandinx;
-#ifdef HAVE_LIBXMLRPC
+#ifdef HAVE_LIBHAMLIB		// Code for Hamlib interface
     static int fldigi_carrier;
     static int fldigi_shift_freq;
 #endif

--- a/src/ignore_unused.h
+++ b/src/ignore_unused.h
@@ -2,11 +2,8 @@
 #define IGNORE_UNUSED_H
 
 #define IGNORE(x) do { \
-	_Pragma("GCC diagnostic push");                            \
-	_Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"");    \
-	_Pragma("GCC diagnostic ignored \"-Wunused-result\"");       \
-	x;                                                            \
-	_Pragma("GCC diagnostic pop");                                 \
+	if (x);         \
+		(void)0; \
 } while(0)
 
 #endif

--- a/src/ignore_unused.h
+++ b/src/ignore_unused.h
@@ -1,0 +1,12 @@
+#ifndef IGNORE_UNUSED_H
+#define IGNORE_UNUSED_H
+
+#define IGNORE(x) do { \
+	_Pragma("GCC diagnostic push");                            \
+	_Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"");    \
+	_Pragma("GCC diagnostic ignored \"-Wunused-result\"");       \
+	x;                                                            \
+	_Pragma("GCC diagnostic pop");                                 \
+} while(0)
+
+#endif

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -295,9 +295,6 @@ int keyer(void) {
 		    sendmessage("\b");          /* ASCII BS */
 		    break;
 		}
-
-		default:
-		    x = x;
 	    }
 
 	}

--- a/src/logview.c
+++ b/src/logview.c
@@ -26,6 +26,7 @@
 #include <string.h>
 
 #include "clear_display.h"
+#include "ignore_unused.h"
 #include "tlf.h"
 #include "tlf_curses.h"
 
@@ -41,7 +42,7 @@ int logview(void) {
     strcat(comstr,  logfile);
 
     endwin();
-    (void) system(comstr);
+    IGNORE(system(comstr));;
     refreshp();
 
     clear_display();

--- a/src/logview.c
+++ b/src/logview.c
@@ -35,13 +35,13 @@ int logview(void) {
     extern char backgrnd_str[];
 
     char comstr[40]  = "";
-    int j, rc;
+    int j;
 
     strcat(comstr,  "less  +G ");
     strcat(comstr,  logfile);
 
     endwin();
-    rc = system(comstr);
+    system(comstr);
     refreshp();
 
     clear_display();

--- a/src/logview.c
+++ b/src/logview.c
@@ -41,7 +41,7 @@ int logview(void) {
     strcat(comstr,  logfile);
 
     endwin();
-    system(comstr);
+    (void) system(comstr);
     refreshp();
 
     clear_display();

--- a/src/muf.c
+++ b/src/muf.c
@@ -159,12 +159,11 @@ int muf(void) {
     int row;
     static double la, l, mf, lh;
     static long ve, ho;
-    static int correct;
     char mycountry[40];
     char country[40];
     int i;
     char time_buf[25];
-    int su, sd, su_min, sd_min, iv;
+    int su, sd, su_min, sd_min;
     double ab;
     double n;
     double td;
@@ -175,7 +174,6 @@ int muf(void) {
     win = newwin(25, 80, 0, 0);
     pan = new_panel(win);
 
-    correct = 0;
     n = 0.0;
 
     xt = QTH_Lat;
@@ -301,7 +299,6 @@ int muf(void) {
 
 	if (ff < mf)
 	    mf = ff;
-	iv = (int) floor(mf / 2.0 + 0.5);
 	ve = 21 - (long) floor(mf / 2.0 + 0.5);
 
 	ho = t + 1;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -299,8 +299,10 @@ int parse_logcfg(char *inputbuffer) {
     extern int bmautoadd;
     extern int bmautograb;
     extern int sprint_mode;
+#ifdef HAVE_LIBXMLRPC
     extern char fldigi_url[50];
     extern int use_fldigi;
+#endif
     extern unsigned char rigptt;
     extern int minitest;
     extern int unique_call_multi;

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -1507,7 +1507,7 @@ void clear_help_block() {
     }
 }
 
-void show_help_msg(msgidx) {
+void show_help_msg(int msgidx) {
     int i = 0, j = 0;
     char buff[80];
     int currqtc;

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -276,7 +276,7 @@ void stop_qtc_recording() {
     if (qtcrec_record == 1 && strlen((char *)qtcrec_record_command_shutdown) > 0) {
 	strcpy(reccommand, "pkill -SIGINT -n ");
 	strcat(reccommand, qtcrec_record_command_shutdown);
-	system(reccommand);
+	(void) system(reccommand);
 	record_run = -1;
 	if (qtcrec_record == 1) {
 	    mvwprintw(qtcwin, 2, 11, "RECORD OFF  ");

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -31,6 +31,7 @@
 #include "cw_utils.h"
 #include "genqtclist.h"
 #include "get_time.h"
+#include "ignore_unused.h"
 #include "keyer.h"
 #include "lancode.h"
 #include "nicebox.h"		// Includes curses.h
@@ -276,7 +277,7 @@ void stop_qtc_recording() {
     if (qtcrec_record == 1 && strlen((char *)qtcrec_record_command_shutdown) > 0) {
 	strcpy(reccommand, "pkill -SIGINT -n ");
 	strcat(reccommand, qtcrec_record_command_shutdown);
-	(void) system(reccommand);
+	IGNORE(system(reccommand));;
 	record_run = -1;
 	if (qtcrec_record == 1) {
 	    mvwprintw(qtcwin, 2, 11, "RECORD OFF  ");

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -29,16 +29,17 @@
 #include <time.h>
 #include "tlf_curses.h"
 
-#include "cabrillo_utils.h"
 #include "addcall.h"
-#include "makelogline.h"
-#include "store_qso.h"
-#include "cleanup.h"
-#include "startmsg.h"
 #include "addmult.h"
-#include "getexchange.h"
-#include "qtc_log.h"
 #include "bands.h"
+#include "cabrillo_utils.h"
+#include "cleanup.h"
+#include "getexchange.h"
+#include "makelogline.h"
+#include "qtc_log.h"
+#include "startmsg.h"
+#include "store_qso.h"
+#include "time.h"
 
 #define MAX_CABRILLO_LEN 255
 

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -17,15 +17,15 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE
+#endif
 #include "readcabrillo.h"
 #include "globalvars.h"
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
-#ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE
-#endif
 #include <time.h>
 #include "tlf_curses.h"
 
@@ -39,7 +39,6 @@
 #include "qtc_log.h"
 #include "startmsg.h"
 #include "store_qso.h"
-#include "time.h"
 
 #define MAX_CABRILLO_LEN 255
 

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -638,7 +638,6 @@ int synclog(char *synclogfile) {
     extern char logfile[];
     extern struct tm *time_ptr;
 
-    int rc;
     char wgetcmd[120] = "wget ftp://";	//user:password@hst/dir/file
     char date_buf[60];
 
@@ -685,8 +684,8 @@ int synclog(char *synclogfile) {
 	exit(1);
     }
     sleep(1);
-    rc = system("rm log1");
-    rc = system("rm log2");
+    system("rm log1");
+    system("rm log2");
 
     return (0);
 }

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -36,6 +36,7 @@
 #include "getctydata.h"
 #include "getpx.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "ignore_unused.h"
 #include "paccdx.h"
 #include "startmsg.h"
 #include "tlf_curses.h"
@@ -684,8 +685,8 @@ int synclog(char *synclogfile) {
 	exit(1);
     }
     sleep(1);
-    (void) system("rm log1");
-    (void) system("rm log2");
+    IGNORE(system("rm log1"));;
+    IGNORE(system("rm log2"));;
 
     return (0);
 }

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -684,8 +684,8 @@ int synclog(char *synclogfile) {
 	exit(1);
     }
     sleep(1);
-    system("rm log1");
-    system("rm log2");
+    (void) system("rm log1");
+    (void) system("rm log2");
 
     return (0);
 }

--- a/src/score.c
+++ b/src/score.c
@@ -371,7 +371,7 @@ int score() {
 	    calc_continent(zone);	// sets continent
 	}
 
-	if ((countrynr == mycountrynr)) {
+	if (countrynr == mycountrynr) {
 	    points = 0;
 
 	    return points;

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "ignore_unused.h"
 #include "qsonr_to_str.h"
 #include "tlf_curses.h"
 
@@ -52,7 +53,7 @@ void scroll_log(void) {
 	inputbuffer[0] = '\0';
 
 	if (fseek(fp, -1L * ii * LOGLINELEN, SEEK_END) == 0)
-	    (void) fgets(inputbuffer, 90, fp);
+	    IGNORE(fgets(inputbuffer, 90, fp));
 	else
 	    strcpy(inputbuffer,
 		   "                                                                                ");
@@ -60,7 +61,7 @@ void scroll_log(void) {
 	kk = 5 - ii;
 
 	if (strlen(inputbuffer) <= 10)	/* log repair */
-	    (void) fgets(inputbuffer, 90, fp);
+	    IGNORE(fgets(inputbuffer, 90, fp));;
 
 //              if (strlen(inputbuffer) != LOGLINELEN)
 //                      strcat (inputbuffer, backgrnd_str);

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -34,7 +34,6 @@
 
 void scroll_log(void) {
 
-    char *rp;
     char inputbuffer[800];
     static int ii, kk;
     int mm;
@@ -53,7 +52,7 @@ void scroll_log(void) {
 	inputbuffer[0] = '\0';
 
 	if (fseek(fp, -1L * ii * LOGLINELEN, SEEK_END) == 0)
-	    rp = fgets(inputbuffer, 90, fp);
+	    fgets(inputbuffer, 90, fp);
 	else
 	    strcpy(inputbuffer,
 		   "                                                                                ");
@@ -61,7 +60,7 @@ void scroll_log(void) {
 	kk = 5 - ii;
 
 	if (strlen(inputbuffer) <= 10)	/* log repair */
-	    rp = fgets(inputbuffer, 90, fp);
+	    fgets(inputbuffer, 90, fp);
 
 //              if (strlen(inputbuffer) != LOGLINELEN)
 //                      strcat (inputbuffer, backgrnd_str);

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -52,7 +52,7 @@ void scroll_log(void) {
 	inputbuffer[0] = '\0';
 
 	if (fseek(fp, -1L * ii * LOGLINELEN, SEEK_END) == 0)
-	    fgets(inputbuffer, 90, fp);
+	    (void) fgets(inputbuffer, 90, fp);
 	else
 	    strcpy(inputbuffer,
 		   "                                                                                ");
@@ -60,7 +60,7 @@ void scroll_log(void) {
 	kk = 5 - ii;
 
 	if (strlen(inputbuffer) <= 10)	/* log repair */
-	    fgets(inputbuffer, 90, fp);
+	    (void) fgets(inputbuffer, 90, fp);
 
 //              if (strlen(inputbuffer) != LOGLINELEN)
 //                      strcat (inputbuffer, backgrnd_str);

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -290,7 +290,7 @@ void sendbuf(void) {
 
 	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
-	if ((simulator_mode == 0)) {
+	if (simulator_mode == 0) {
 	    mvprintw(5, 0, printlinebuffer);
 	    refreshp();
 	}

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "bands.h"
 #include "sendqrg.h"
 #include "startmsg.h"
 #include "gettxinfo.h"

--- a/src/show_help.c
+++ b/src/show_help.c
@@ -30,6 +30,7 @@
 #include <glib/gstdio.h>
 
 #include "clear_display.h"
+#include "ignore_unused.h"
 #include "tlf_curses.h"
 
 extern SCREEN *mainscreen;
@@ -59,9 +60,9 @@ int show_help(void) {
     cmdstr = g_strdup_printf("less %s", helpfile);
 
     endwin();
-    (void) system("clear");
-    (void) system(cmdstr);
-    (void) system("clear");
+    IGNORE(system("clear"));;
+    IGNORE(system(cmdstr));;
+    IGNORE(system("clear"));;
 
     g_free(helpfile);
     g_free(cmdstr);

--- a/src/show_help.c
+++ b/src/show_help.c
@@ -59,9 +59,9 @@ int show_help(void) {
     cmdstr = g_strdup_printf("less %s", helpfile);
 
     endwin();
-    system("clear");
-    system(cmdstr);
-    system("clear");
+    (void) system("clear");
+    (void) system(cmdstr);
+    (void) system("clear");
 
     g_free(helpfile);
     g_free(cmdstr);

--- a/src/show_help.c
+++ b/src/show_help.c
@@ -41,7 +41,6 @@ extern SCREEN *mainscreen;
  * in PKG_DATA_DIR
  */
 int show_help(void) {
-    int rc;
     char filename[] = "help.txt";
     char *helpfile;
     char *cmdstr;
@@ -60,9 +59,9 @@ int show_help(void) {
     cmdstr = g_strdup_printf("less %s", helpfile);
 
     endwin();
-    rc = system("clear");
-    rc = system(cmdstr);
-    rc = system("clear");
+    system("clear");
+    system(cmdstr);
+    system("clear");
 
     g_free(helpfile);
     g_free(cmdstr);

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -224,7 +224,7 @@ void start_editing(void) {
 
 void delete_prev_char(void) {
     int i, j;
-    int c, cc;
+    chtype c, cc;
     if (currow != 0 || curcol != 0) {
 	if (curcol-- == 0) {
 	    curcol = COLS - 1;
@@ -1108,7 +1108,7 @@ int packet() {
 	    if (packetinterface == TNC_INTERFACE) {
 		line[strlen(line) - 1] = 13;
 		line[strlen(line)] = '\0';
-		write(fdSertnc, line, strlen(line));
+		(void) write(fdSertnc, line, strlen(line));
 	    }
 
 	    curattr = attr[NORMAL_ATTR];
@@ -1224,7 +1224,7 @@ int send_cluster(void) {
 	    line[strlen(line) - 1] = '\r';
 	    line[strlen(line)] = '\0';	/* not needed */
 
-	    write(fdSertnc, line, strlen(line));
+	    (void) write(fdSertnc, line, strlen(line));
 	} else if ((packetinterface == TELNET_INTERFACE) && (prsock > 0))
 	    usputs(prsock, line);
     }

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -1106,10 +1106,9 @@ int packet() {
 	    }
 
 	    if (packetinterface == TNC_INTERFACE) {
-		int rc;
 		line[strlen(line) - 1] = 13;
 		line[strlen(line)] = '\0';
-		rc = write(fdSertnc, line, strlen(line));
+		write(fdSertnc, line, strlen(line));
 	    }
 
 	    curattr = attr[NORMAL_ATTR];
@@ -1222,11 +1221,10 @@ int send_cluster(void) {
 	strcat(line, "\n");
 
 	if (packetinterface == TNC_INTERFACE) {
-	    int rc;
 	    line[strlen(line) - 1] = '\r';
 	    line[strlen(line)] = '\0';	/* not needed */
 
-	    rc = write(fdSertnc, line, strlen(line));
+	    write(fdSertnc, line, strlen(line));
 	} else if ((packetinterface == TELNET_INTERFACE) && (prsock > 0))
 	    usputs(prsock, line);
     }

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -41,6 +41,7 @@
 #include "clear_display.h"
 #include "get_time.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "ignore_unused.h"
 #include "lancode.h"
 #include "splitscreen.h"
 #include "sockserv.h"
@@ -1108,7 +1109,7 @@ int packet() {
 	    if (packetinterface == TNC_INTERFACE) {
 		line[strlen(line) - 1] = 13;
 		line[strlen(line)] = '\0';
-		(void) write(fdSertnc, line, strlen(line));
+		IGNORE(write(fdSertnc, line, strlen(line)));;
 	    }
 
 	    curattr = attr[NORMAL_ATTR];
@@ -1224,7 +1225,7 @@ int send_cluster(void) {
 	    line[strlen(line) - 1] = '\r';
 	    line[strlen(line)] = '\0';	/* not needed */
 
-	    (void) write(fdSertnc, line, strlen(line));
+	    IGNORE(write(fdSertnc, line, strlen(line)));;
 	} else if ((packetinterface == TELNET_INTERFACE) && (prsock > 0))
 	    usputs(prsock, line);
     }

--- a/src/write_keyer.c
+++ b/src/write_keyer.c
@@ -26,6 +26,7 @@
 #include <glib.h>
 
 #include "clear_display.h"
+#include "ignore_unused.h"
 #include "netkeyer.h"
 #include "tlf.h"
 #include "tlf_curses.h"
@@ -110,7 +111,7 @@ int write_keyer(void) {
 	    }
 	    sprintf(outstring, "echo -n \"\n%s\" >> %s",
 		    tosend, rttyoutput);
-	    (void) system(outstring);
+	    IGNORE(system(outstring));;
 	}
 
 	g_free(tosend);

--- a/src/write_keyer.c
+++ b/src/write_keyer.c
@@ -66,7 +66,6 @@ int write_keyer(void) {
     extern char rttyoutput[];
 
     FILE *bfp = NULL;
-    int rc;
     char outstring[420] =
 	"";	// this was only 120 char length, but wkeyerbuffer is 400
     char *tosend = NULL;
@@ -111,7 +110,7 @@ int write_keyer(void) {
 	    }
 	    sprintf(outstring, "echo -n \"\n%s\" >> %s",
 		    tosend, rttyoutput);
-	    rc = system(outstring);
+	    system(outstring);
 	}
 
 	g_free(tosend);

--- a/src/write_keyer.c
+++ b/src/write_keyer.c
@@ -110,7 +110,7 @@ int write_keyer(void) {
 	    }
 	    sprintf(outstring, "echo -n \"\n%s\" >> %s",
 		    tosend, rttyoutput);
-	    system(outstring);
+	    (void) system(outstring);
 	}
 
 	g_free(tosend);


### PR DESCRIPTION
While many of these return codes should be checked, none of them
actually are, so having the return codes stored in variables is
pointless.