### PR TITLE
Clean up various race conditions in fldigi stuff, and most importantly,

### DIFF
--- a/src/background_process.c
+++ b/src/background_process.c
@@ -67,7 +67,6 @@ extern char call[];
 extern int trxmode;
 extern int digikeyer;
 extern int trx_control;
-extern int use_fldigi;
 
 int cw_simulator(void);
 
@@ -118,7 +117,7 @@ void *background_process(void *ptr) {
 	 *   fldigi_get_log_call() reads the callsign, if user clicks to a string in Fldigi's RX window
 	 *   fldigi_get_log_serial_number() reads the exchange
 	 */
-	if (digikeyer == FLDIGI && use_fldigi == 1
+	if (digikeyer == FLDIGI && fldigi_get()
 		&& trx_control == 1) {
 	    if (fldigi_rpc_cnt == 0) {
 		fldigi_xmlrpc_get_carrier();

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -100,7 +100,6 @@ int changepars(void) {
     extern char sc_volume[];
     extern int cwstart;
     extern int digikeyer;
-    extern int use_fldigi;
 
     char parameterstring[20];
     char parameters[52][19];
@@ -699,13 +698,11 @@ int changepars(void) {
 	}
         case 51: {              /* FLDIGI - turn on/off */
 	    if (digikeyer == FLDIGI) {
-		if (use_fldigi == 0) {
-		    use_fldigi = 1;
+		if (fldigi_toggle()) {
 		    fldigi_clear_connerr();
 		    mvprintw(13, 29, "FLDIGI ON");
 	        }
 	        else {
-		    use_fldigi = 0;
 		    mvprintw(13, 29, "FLDIGI OFF");
 		}
 		refreshp();

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -63,7 +63,7 @@ typedef struct xmlrpc_res_s {
 				   it back to RIG carrier */
 
 extern char fldigi_url[50];
-extern int use_fldigi;
+static int use_fldigi;
 
 int fldigi_var_carrier = 0;
 int fldigi_var_shift_freq = 0;
@@ -74,6 +74,7 @@ char thiscall[20] = "";
 char tcomment[20] = "";
 
 pthread_mutex_t xmlrpc_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t xmlrpc_get_rx_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /*
  * Used XML RPC methods, and its formats of arguments
@@ -110,7 +111,28 @@ xmlrpc_server_info *serverInfoP = NULL;
 #endif
 
 void fldigi_clear_connerr() {
+    pthread_mutex_lock(&xmlrpc_mutex);
     connerr = 0;
+    pthread_mutex_unlock(&xmlrpc_mutex);
+}
+
+int fldigi_toggle(void) {
+    int ret;
+
+    pthread_mutex_lock(&xmlrpc_mutex);
+    use_fldigi = !use_fldigi;
+    ret = use_fldigi;
+    pthread_mutex_unlock(&xmlrpc_mutex);
+    return ret;
+}
+
+int fldigi_get(void) {
+    int ret;
+
+    pthread_mutex_lock(&xmlrpc_mutex);
+    ret = use_fldigi;
+    pthread_mutex_unlock(&xmlrpc_mutex);
+    return ret;
 }
 
 void xmlrpc_res_init(xmlrpc_res *res) {
@@ -123,6 +145,7 @@ void xmlrpc_res_init(xmlrpc_res *res) {
 
 int fldigi_xmlrpc_init() {
 #ifdef HAVE_LIBXMLRPC
+    pthread_mutex_lock(&xmlrpc_mutex);
     xmlrpc_client_init2(&env, XMLRPC_CLIENT_NO_FLAGS, NAME,
 			XMLRPCVERSION, NULL, 0);
     serverInfoP = xmlrpc_server_info_new(&env, fldigi_url);
@@ -133,17 +156,20 @@ int fldigi_xmlrpc_init() {
     }
 
     initialized = 1;
+    pthread_mutex_unlock(&xmlrpc_mutex);
 #endif
     return 0;
 }
 
 int fldigi_xmlrpc_cleanup() {
 #ifdef HAVE_LIBXMLRPC
+    pthread_mutex_lock(&xmlrpc_mutex);
     if (serverInfoP != NULL) {
 	xmlrpc_server_info_free(serverInfoP);
 	serverInfoP = NULL;
 	initialized = 0;
     }
+    pthread_mutex_unlock(&xmlrpc_mutex);
 #endif
     return 0;
 }
@@ -159,13 +185,15 @@ int fldigi_xmlrpc_query(xmlrpc_res *local_result, xmlrpc_env *local_env,
     va_list argptr;
     int restype;
     size_t bytesize = 0;
+    int ret;
 
-
-    if (initialized == 0) {
-	return -1;
-    }
 
     pthread_mutex_lock(&xmlrpc_mutex);
+
+    if (initialized == 0) {
+	pthread_mutex_unlock(&xmlrpc_mutex);
+	return -1;
+    }
     /*
     if connerr had been set up to 1, that means an error
     occured at last xmlrpc_call() method
@@ -201,15 +229,15 @@ int fldigi_xmlrpc_query(xmlrpc_res *local_result, xmlrpc_env *local_env,
 		va_param = xmlrpc_string_new(local_env, s);
 		if (local_env->fault_occurred) {
 		    va_end(argptr);
-		    pthread_mutex_unlock(&xmlrpc_mutex);
 		    connerr = 1;
+		    pthread_mutex_unlock(&xmlrpc_mutex);
 		    return -1;
 		}
 		xmlrpc_array_append_item(local_env, pcall_array, va_param);
 		if (local_env->fault_occurred) {
 		    va_end(argptr);
-		    pthread_mutex_unlock(&xmlrpc_mutex);
 		    connerr = 1;
+		    pthread_mutex_unlock(&xmlrpc_mutex);
 		    return -1;
 		}
 		xmlrpc_DECREF(va_param);
@@ -219,8 +247,8 @@ int fldigi_xmlrpc_query(xmlrpc_res *local_result, xmlrpc_env *local_env,
 		xmlrpc_array_append_item(local_env, pcall_array, va_param);
 		if (local_env->fault_occurred) {
 		    va_end(argptr);
-		    pthread_mutex_unlock(&xmlrpc_mutex);
 		    connerr = 1;
+		    pthread_mutex_unlock(&xmlrpc_mutex);
 		    return -1;
 		}
 		xmlrpc_DECREF(va_param);
@@ -230,8 +258,8 @@ int fldigi_xmlrpc_query(xmlrpc_res *local_result, xmlrpc_env *local_env,
 		xmlrpc_array_append_item(local_env, pcall_array, va_param);
 		if (local_env->fault_occurred) {
 		    va_end(argptr);
-		    pthread_mutex_unlock(&xmlrpc_mutex);
 		    connerr = 1;
+		    pthread_mutex_unlock(&xmlrpc_mutex);
 		    return -1;
 		}
 		xmlrpc_DECREF(va_param);
@@ -284,12 +312,12 @@ int fldigi_xmlrpc_query(xmlrpc_res *local_result, xmlrpc_env *local_env,
 
 	xmlrpc_DECREF(pcall_array);
     }
+    if (connerr == 0 && use_fldigi)
+	ret = 0;
+    else
+	ret = -1;
     pthread_mutex_unlock(&xmlrpc_mutex);
-    if (connerr == 0) {
-	return 0;
-    } else {
-	return -1;
-    }
+    return ret;
 }
 #endif
 
@@ -323,6 +351,7 @@ int fldigi_send_text(char *line) {
     // if the RX success, clear the previous message from TX text window
     if (strcmp(result.stringval, "TX") == 0) {
 	free((void *)result.stringval);
+	result.stringval = NULL;
 	rc = fldigi_xmlrpc_query(&result, &env, "main.rx", "");
 	if (rc != 0) {
 	    return -1;
@@ -362,6 +391,10 @@ int fldigi_send_text(char *line) {
 }
 
 /* read the text from Fldigi's RX window, from last read position */
+/*
+ * Since this uses a static variable, it is not thread-safe and must
+ * use a protective mutex.
+ */
 int fldigi_get_rx_text(char *line, int len) {
 #ifdef HAVE_LIBXMLRPC
     int rc;
@@ -372,8 +405,10 @@ int fldigi_get_rx_text(char *line, int len) {
     int retval = 0;
     int linelen = 0;
 
+    pthread_mutex_lock(&xmlrpc_get_rx_mutex);
     rc = fldigi_xmlrpc_query(&result, &env, "text.get_rx_length", "");
     if (rc != 0) {
+	pthread_mutex_unlock(&xmlrpc_get_rx_mutex);
 	return -1;
     }
 
@@ -385,6 +420,7 @@ int fldigi_get_rx_text(char *line, int len) {
 	    rc = fldigi_xmlrpc_query(&result, &env, "text.get_rx", "dd",
 				     lastpos, textlen);
 	    if (rc != 0) {
+		pthread_mutex_unlock(&xmlrpc_get_rx_mutex);
 		return -1;
 	    }
 
@@ -403,6 +439,7 @@ int fldigi_get_rx_text(char *line, int len) {
 	}
     }
     lastpos = textlen;
+    pthread_mutex_unlock(&xmlrpc_get_rx_mutex);
     return retval;
 
 #else

--- a/src/fldigixmlrpc.h
+++ b/src/fldigixmlrpc.h
@@ -38,5 +38,7 @@ void xmlrpc_showinfo();
 int fldigi_get_log_call();
 int fldigi_get_log_serial_number();
 void fldigi_clear_connerr();
+int fldigi_toggle(void);
+int fldigi_get(void);
 
 #endif /* end of include guard: FLDIGIXMLRPC_H */

--- a/src/main.c
+++ b/src/main.c
@@ -373,7 +373,6 @@ int rig_comm_success = 0;
 
 /*----------------------------------fldigi---------------------------------*/
 char fldigi_url[50] = "http://localhost:7362/RPC2";
-int use_fldigi = 0;
 
 /*---------------------------------simulator-------------------------------*/
 int simulator = 0;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -28,6 +28,7 @@
 
 #include "bandmap.h"
 #include "cw_utils.h"
+#include "fldigixmlrpc.h"
 #include "getctydata.h"
 #include "getpx.h"
 #include "lancode.h"
@@ -300,7 +301,6 @@ int parse_logcfg(char *inputbuffer) {
     extern int bmautograb;
     extern int sprint_mode;
     extern char fldigi_url[50];
-    extern int use_fldigi;
     extern unsigned char rigptt;
     extern int minitest;
     extern int unique_call_multi;
@@ -1831,7 +1831,8 @@ int parse_logcfg(char *inputbuffer) {
 			  sizeof(fldigi_url));
 	    }
 	    digikeyer = FLDIGI;
-	    use_fldigi = 1;
+	    if (!fldigi_get())
+		fldigi_toggle();
 #endif
 	    break;
 	}


### PR DESCRIPTION
have fldigi_xmlrpc_query() return -1 when use_fldigi is false.

Returning success resulted in uninitialized data being used by callers,
making it unsafe to ever turn off fldigi from tlf.