### PR TITLE
add lan port config directive

### DIFF
--- a/src/lancode.c
+++ b/src/lancode.c
@@ -65,6 +65,8 @@ int send_error_limit[MAXNODES];
 //--------------------------------------
 /* default port to listen for incomming packets and to send packet to */
 char default_lan_service[16] = "6788";
+/* lan port parsed from config */
+int lan_port = 0; 
 
 int lan_active = 0;
 int send_error[MAXNODES];
@@ -91,13 +93,22 @@ int resolveService(const char *service) {
     struct servent *service_ent;
     service_ent = getservbyname(service, "udp");
     int port = 0;
-    if (service_ent != NULL) {
-	port = service_ent->s_port;
-    } else if (strlen(service) > 0) {
-	port = atoi(service);
-    }
-    if (port == 0) {
-	port = atoi(default_lan_service);
+    extern int lan_port;
+    /* if we have no lan port from parse config */
+    if(lan_port == 0 ) {
+      /* lookup port based on services db - does .. this ever work? */
+      if (service_ent != NULL) {
+  	port = service_ent->s_port;
+      } else if (strlen(service) > 0) {
+  	port = atoi(service);
+      }
+      /* if no port was returned from service entry, use the default port */
+      if (port == 0) {
+        /* any reason not to store default port as int instead of char arr?*/
+        port = atoi(default_lan_service);
+      }
+    } else {
+	port = lan_port;
     }
     return port;
 }

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -66,7 +66,7 @@ int send_error_limit[MAXNODES];
 /* default port to listen for incomming packets and to send packet to */
 char default_lan_service[16] = "6788";
 /* lan port parsed from config */
-int lan_port = 0; 
+int lan_port = 0;
 
 int lan_active = 0;
 int send_error[MAXNODES];
@@ -98,9 +98,9 @@ int resolveService(const char *service) {
     if(lan_port == 0 ) {
       /* lookup port based on services db - does .. this ever work? */
       if (service_ent != NULL) {
-  	port = service_ent->s_port;
+	    port = service_ent->s_port;
       } else if (strlen(service) > 0) {
-  	port = atoi(service);
+	    port = atoi(service);
       }
       /* if no port was returned from service entry, use the default port */
       if (port == 0) {

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -571,7 +571,7 @@ int parse_logcfg(char *inputbuffer) {
 	"DKF12",
 	"DKCQM",			/* 250 */
 	"DKSPM",
-	"DKSPC"
+	"DKSPC",
 	"ALT_DK1",			/* 253 */
 	"ALT_DK2",
 	"ALT_DK3",
@@ -631,7 +631,6 @@ int parse_logcfg(char *inputbuffer) {
 	    break;
 	}
     }
-
     switch (ii) {
 
 	case 0: {
@@ -2005,12 +2004,11 @@ int parse_logcfg(char *inputbuffer) {
 	    }
 	    break;
 	}
-        case 263: {
+	case 263: {
 	    PARAMETER_NEEDED(teststring);
 	    lan_port = atoi(fields[1]);
-            lan_active = 1;
-          break;
-        }
+	    break;
+	}
 	default: {
 	    KeywordNotSupported(g_strstrip(inputbuffer));
 	    break;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -315,6 +315,7 @@ int parse_logcfg(char *inputbuffer) {
     extern unsigned char rigptt;
     extern int minitest;
     extern int unique_call_multi;
+    extern int lan_port;
 
     char *commands[] = {
 	"enable",		/* 0 */		/* deprecated */
@@ -580,7 +581,8 @@ int parse_logcfg(char *inputbuffer) {
 	"ALT_DK7",
 	"ALT_DK8",
 	"ALT_DK9",
-	"ALT_DK10"
+	"ALT_DK10",
+        "LAN_PORT"                     /* 263 */
     };
 
     char **fields;
@@ -1988,7 +1990,7 @@ int parse_logcfg(char *inputbuffer) {
 		    *nl = ' ';
 	    }
 	    break;
-	case 253 ... 263: {
+	case 253 ... 262: {
 	    PARAMETER_NEEDED(teststring);
 	    if (digi_message[ii - 239]) {
 		KeywordRepeated(commands[ii]);
@@ -2003,6 +2005,12 @@ int parse_logcfg(char *inputbuffer) {
 	    }
 	    break;
 	}
+        case 263: {
+	    PARAMETER_NEEDED(teststring);
+	    lan_port = atoi(fields[1]);
+            lan_active = 1;
+          break;
+        }
 	default: {
 	    KeywordNotSupported(g_strstrip(inputbuffer));
 	    break;


### PR DESCRIPTION
This is a WORK IN PROGRESS, I am having trouble getting the lan port to parse from parse_logcfg.c

I added an extern declaration of lan_port within the parse function, as well as declaring it globally in lancode.c, and then again as extern within resolveService().

I double checked the command array, and ALT_DK10 was def. index 262, not 263, so i modified the switch statement and added the LAN_PORT config directive to both the commands array, and the case, as 263.  

In lancode.c I modified resolveService() to utilize the parsed directive via the extern declaration of lan_port.  I left the code in place to auto resolve based on service entry if the lan_port was not set.

Any help / pointers on getting this working would be appreciated.  

The end goal is to be able to run multiple networked instances of TLF on the same server.