### PR TITLE
Make Hamlib mandatory 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - rm -rf cmocka-1.0.1 cmocka-1.0.1.tar.xz
   
 script: 
-  - autoreconf -i && ./configure --enable-hamlib && make   
-  - make clean && ./configure --enable-hamlib --enable-fldigi-xmlrpc && make
+  - autoreconf -i && ./configure && make
+  - make clean && ./configure --enable-fldigi-xmlrpc && make
   - make check; rc=$?; cat test/run_*.log; exit $rc
 

--- a/INSTALL
+++ b/INSTALL
@@ -47,13 +47,6 @@ autoreconf --install
 before the above commands.
 
 
-If support for Hamlib (>=1.2.8) is wanted, use 
-
-----
-./configure --enable-hamlib
-----
-
-
 By default, tlf will install into /usr/local/bin, together with the
 shell-scripts from the scripts directory. Data files will install into
 /usr/local/share/tlf.

--- a/configure.ac
+++ b/configure.ac
@@ -75,44 +75,32 @@ AS_IF([test "x$ax_cv_panel" != xyes],
 	[AC_MSG_ERROR([the Curses Panel library is required])])
 
 
-dnl Check if we want to link the Hamradio control libraries (hamlib)
-AC_MSG_CHECKING([whether to build Hamlib support])
-AC_ARG_ENABLE([hamlib],
-	[AS_HELP_STRING([--enable-hamlib],
-		[Add support for Ham Radio Control Libraries])],
-	[wanthamlib=true],
-	[wanthamlib=false])
+dnl Check the Hamradio control libraries (hamlib)
 
-AS_IF([test "x$wanthamlib" = xtrue], [
-	dnl Look for hamlib
-	AC_MSG_RESULT([yes])
-	hamlib_modules="hamlib >= 1.2.8"
-	PKG_CHECK_MODULES([HAMLIB], [$hamlib_modules], [],
-		[AC_MSG_ERROR([Hamradio control libraries 1.2.8 or later not found...])])
+hamlib_modules="hamlib >= 1.2.8"
+PKG_CHECK_MODULES([HAMLIB], [$hamlib_modules], [],
+        [AC_MSG_ERROR([Hamradio control libraries 1.2.8 or later not found...])])
 
-	tlf_saved_LIBS=$LIBS
-	LIBS="$LIBS $HAMLIB_LIBS"
+tlf_saved_LIBS=$LIBS
+LIBS="$LIBS $HAMLIB_LIBS"
 
-	AC_CHECK_LIB([hamlib], [rig_open], [
-		AC_DEFINE([HAVE_LIBHAMLIB], [1],
-			[Define to 1 if you have the `hamlib' library (-lhamlib).])], [
-		AC_MSG_ERROR([Hamradio control libraries not found!])])
+AC_CHECK_LIB([hamlib], [rig_open], [
+        AC_DEFINE([HAVE_LIBHAMLIB], [1],
+                [Define to 1 if you have the `hamlib' library (-lhamlib).])], [
+        AC_MSG_ERROR([Hamradio control libraries not found!])])
 
-	LIBS=$tlf_saved_LIBS
+LIBS=$tlf_saved_LIBS
 
-	tlf_saved_CFLAGS=$CFLAGS
-	tlf_saved_CPPFLAGS=$CPPFLAGS
-	CFLAGS="$CFLAGS $HAMLIB_CFLAGS"
-	CPPFLAGS="$CPPFLAGS `$PKG_CONFIG --cflags-only-I hamlib 2>&1`"
+tlf_saved_CFLAGS=$CFLAGS
+tlf_saved_CPPFLAGS=$CPPFLAGS
+CFLAGS="$CFLAGS $HAMLIB_CFLAGS"
+CPPFLAGS="$CPPFLAGS `$PKG_CONFIG --cflags-only-I hamlib 2>&1`"
 
-	AC_CHECK_HEADERS([hamlib/rig.h], [], [
-		AC_MSG_ERROR([Hamlib headers not found...])])
+AC_CHECK_HEADERS([hamlib/rig.h], [], [
+        AC_MSG_ERROR([Hamlib headers not found...])])
 
-	CPPFLAGS=$tlf_saved_CPPFLAGS
-	CFLAGS=$tlf_saved_CFLAGS], [
-
-	dnl else Hamlib not wanted
-	AC_MSG_RESULT([no])])
+CPPFLAGS=$tlf_saved_CPPFLAGS
+CFLAGS=$tlf_saved_CFLAGS
 
 
 dnl Check if we want to use xmlrpc to read carrier from Fldigi
@@ -187,7 +175,6 @@ echo \
 
  Package features:
 
- With Hamlib	$wanthamlib
  With XML RPC	$wantfldigixmlrpc
 
 -----------------------------------------------------------------------"

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -75,14 +75,6 @@
 
 #include <math.h>
 
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
-
-#ifdef HAVE_LIBHAMLIB
-# include <hamlib/rig.h>
-#endif
-
 #define TUNE_UP 6	/* tune up for 6 s (no more than 10) */
 
 void send_bandswitch(int freq);
@@ -1223,9 +1215,7 @@ int autosend() {
 int play_file(char *audiofile) {
 
     extern int txdelay;
-#ifdef HAVE_LIBHAMLIB
     extern unsigned char rigptt;
-#endif
 
     int fd;
     char playcommand[120];
@@ -1242,37 +1232,29 @@ int play_file(char *audiofile) {
 	} else {
 	    sprintf(playcommand, "play_vk %s", audiofile);
 	}
-#ifdef HAVE_LIBHAMLIB
 	/* CAT PTT wanted and available, use it. */
 	if (rigptt == 0x03) {
 	    /* Request PTT On */
 	    rigptt |= (1 << 3);		/* 0x0b */
 	} else {		/* Fall back to netkeyer interface */
-#endif
 	    netkeyer(K_PTT, "1");	// ptt on
-#ifdef HAVE_LIBHAMLIB
 	}
-#endif
 
 	usleep(txdelay * 1000);
 	IGNORE(system(playcommand));;
 	printcall();
 
-#ifdef HAVE_LIBHAMLIB
 	/* CAT PTT wanted, available, and active. */
 	if (rigptt == 0x07) {
 
 	    /* Request PTT Off */
 	    rigptt |= (1 << 4);		/* 0x17 */
 	} else {		/* Fall back to netkeyer interface */
-#endif
 	    netkeyer(K_PTT, "0");	// ptt off
-#ifdef HAVE_LIBHAMLIB
 	}
-#endif
     }
 
-    return (0);
+    return 0;
 }
 
 

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -60,14 +60,6 @@
 #include "writecabrillo.h"
 #include "writeparas.h"
 
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
-
-#ifdef HAVE_LIBHAMLIB
-# include <hamlib/rig.h>
-#endif
-
 #define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))
 
 

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -28,9 +28,7 @@
 #include <glib.h>
 #include <ctype.h>
 
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
+#include <config.h>
 
 #include "fldigixmlrpc.h"
 #include "printcall.h"
@@ -46,9 +44,7 @@
 # include <xmlrpc-c/client_global.h>
 #endif
 
-#ifdef HAVE_LIBHAMLIB
-# include <hamlib/rig.h>
-#endif
+#include <hamlib/rig.h>
 
 #define NAME "Tlf"
 #define XMLRPCVERSION "1.0"
@@ -466,14 +462,12 @@ int fldigi_xmlrpc_get_carrier() {
     int rc;
     xmlrpc_res result;
     xmlrpc_env env;
-#ifdef HAVE_LIBHAMLIB
     extern int rigmode;
     extern int trx_control;
     extern float freq;
     int signum;
     int modeshift;
     char fldigi_mode[6] = "";
-#endif
 
     rc = fldigi_xmlrpc_query(&result, &env, "modem.get_carrier", "");
     if (rc != 0) {
@@ -485,7 +479,6 @@ int fldigi_xmlrpc_get_carrier() {
     /* if mode == RTTY(R), and Hamlib configured, set VFO to new freq where the signal
      * will placed on 2210 Hz - the FSK center freq
      */
-#ifdef HAVE_LIBHAMLIB
     if (trx_control > 0) {
 	if (rigmode == RIG_MODE_RTTY || rigmode == RIG_MODE_RTTYR) {
 	    if (fldigi_var_carrier != CENTER_FREQ &&
@@ -556,7 +549,7 @@ int fldigi_xmlrpc_get_carrier() {
 	    }
 	}
     }
-#endif
+
     return 0;
 #endif
 

--- a/src/getsummary.c
+++ b/src/getsummary.c
@@ -31,10 +31,6 @@
 #include "nicebox.h"		// Includes curses.h
 #include "showscore.h"
 
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
-
 
 extern char call[];
 
@@ -133,5 +129,5 @@ int getsummary(FILE *fp) {
     if (*buffer != '\0')
 	fprintf(fp, "SOAPBOX: %s\n", buffer);
 
-    return (0);
+    return 0;
 }

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -4,9 +4,7 @@
 
 #include <glib.h>
 
-#ifdef HAVE_LIBHAMLIB
-# include <hamlib/rig.h>
-#endif
+#include <hamlib/rig.h>
 
 extern char qsos[MAX_QSOS][LOGLINELEN + 1];
 					// array of log lines of QSOs so far;
@@ -119,9 +117,7 @@ extern int three_point;
 extern int dxped;
 extern int addzone;
 extern int do_cabrillo;
-#ifdef HAVE_LIBHAMLIB
 extern rmode_t digi_mode;
-#endif
 
 extern char message[][80];
 extern char *digi_message[];

--- a/src/logit.c
+++ b/src/logit.c
@@ -36,7 +36,7 @@
 #include "recall_exchange.h"
 #include "searchlog.h"		// Includes glib.h
 #include "sendbuf.h"
-#include "sendqrg.h"		// Sets HAVE_LIBHAMLIB if enabled
+#include "sendqrg.h"
 #include "sendspcall.h"
 #include "set_tone.h"
 #include "tlf.h"

--- a/src/main.c
+++ b/src/main.c
@@ -52,7 +52,7 @@
 #include "rules.h"
 #include "scroll_log.h"
 #include "searchlog.h"		// Includes glib.h
-#include "sendqrg.h"		// Sets HAVE_LIBHAMLIB if enabled
+#include "sendqrg.h"
 #include "set_tone.h"
 #include "splitscreen.h"
 #include "startmsg.h"
@@ -60,13 +60,8 @@
 #include "ui_utils.h"
 #include "readcabrillo.h"
 
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
-
-#ifdef HAVE_LIBHAMLIB
-# include <hamlib/rig.h>
-#endif
+#include <config.h>
+#include <hamlib/rig.h>
 
 
 SCREEN *mainscreen;
@@ -187,9 +182,8 @@ char multsfile[80] = "";	/* name of file with a list of allowed
 char exchange_list[40] = "";
 int timeoffset = 0;
 int trxmode = CWMODE;
-int rigmode = 0;		/* RIG_MODE_NONE in hamlib/rig.h,
-				   but if hamlib not compiled,
-				   then no dependency */
+int rigmode = RIG_MODE_NONE;
+
 int mixedmode = 0;
 char his_rst[4] = "599";
 char my_rst[4] = "599";
@@ -326,9 +320,7 @@ int keyer_backspace = 0;        // disabled
 
 char controllerport[80] = "/dev/ttyS0"; // for GMFSK or MFJ-1278
 char rttyoutput[120];		// where to GMFSK digimode output
-#ifdef HAVE_LIBHAMLIB
 rmode_t digi_mode = RIG_MODE_NONE;
-#endif
 
 int txdelay = 0;
 int weight = 0;
@@ -358,14 +350,12 @@ int bmautoadd = 0;
 int bmautograb = 0;
 
 /*-------------------------------------rigctl-------------------------------*/
-#ifdef HAVE_LIBHAMLIB
-rig_model_t myrig_model = 351;
+rig_model_t myrig_model = 351;  /* Ten-Tec Omni VI Plus */
 RIG *my_rig;			/* handle to rig (instance) */
 rmode_t rmode;			/* radio mode of operation */
 pbwidth_t width;
 vfo_t vfo;			/* vfo selection */
 port_t myport;
-#endif
 int ssb_bandwidth = 3000;
 int cw_bandwidth = 0;
 int serial_rate = 2400;
@@ -727,10 +717,7 @@ int databases_load() {
 
 void hamlib_init() {
 
-#ifdef HAVE_LIBHAMLIB		// Code for hamlib interface
     int status;
-
-    showmsg("HAMLIB compiled in");
 
     if (no_trx_control == 1) {
 	trx_control = 0;
@@ -756,13 +743,6 @@ void hamlib_init() {
 	    sleep(1);
 	}
     }
-#else
-    showmsg("No Hamlib compiled in!");
-
-    trx_control = 0;
-    showmsg("Disabling rig control!");
-    sleep(1);
-#endif				/* HAVE_LIBHAMLIB */
 }
 
 void fldigi_init() {
@@ -877,13 +857,9 @@ void tlf_cleanup() {
     else
 	deinit_controller();
 
-#ifdef HAVE_LIBHAMLIB
-
     if (my_rig) {
 	close_tlf_rig(my_rig);
     }
-
-#endif
 
 #ifdef HAVE_LIBXMLRPC
     if (digikeyer == FLDIGI) {

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -39,13 +39,7 @@
 #include "startmsg.h"
 #include "tlf_curses.h"
 
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
-
-#ifdef HAVE_LIBHAMLIB
-# include <hamlib/rig.h>
-#endif
+#include <hamlib/rig.h>
 
 
 extern int cwkeyer;
@@ -60,9 +54,7 @@ extern int packetinterface;
 extern int tncport;
 extern int shortqsonr;
 extern char *cabrillo;
-#ifdef HAVE_LIBHAMLIB
 extern rmode_t digi_mode;
-#endif
 
 int exist_in_country_list();
 int continent_found();
@@ -216,9 +208,7 @@ int parse_logcfg(char *inputbuffer) {
     extern int tnc_serial_rate;
     extern char lastwwv[];
     extern int serial_rate;
-#ifdef HAVE_LIBHAMLIB
     extern rig_model_t myrig_model;
-#endif
     extern char *rigportname;
     extern int rignumber;
     extern char rigconf[];
@@ -1014,9 +1004,8 @@ int parse_logcfg(char *inputbuffer) {
 		rignumber = 2000;
 	    else
 		rignumber = atoi(buff);
-#ifdef HAVE_LIBHAMLIB
+
 	    myrig_model = (rig_model_t) rignumber;
-#endif
 
 	    break;
 	}
@@ -1911,7 +1900,6 @@ int parse_logcfg(char *inputbuffer) {
 	    break;
 	}
 	case 237: {
-#ifdef HAVE_LIBHAMLIB
 	    PARAMETER_NEEDED(teststring);
 	    g_strchomp(fields[1]);
 	    if (strcmp(fields[1], "USB") == 0)
@@ -1928,7 +1916,6 @@ int parse_logcfg(char *inputbuffer) {
 		sleep(5);
 		exit(1);
 	    }
-#endif
 	    break;
 	}
 	case 238 ... 249: {

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -39,6 +39,7 @@
 #include "startmsg.h"
 #include "tlf_curses.h"
 
+#include <config.h>
 #include <hamlib/rig.h>
 
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -19,7 +19,10 @@
 * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE	// For asprintf()
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -61,7 +61,6 @@ int sendqrg(void) {
 }
 
 /**************************************************************************/
-#ifdef HAVE_LIBHAMLIB		//code for Hamlib interface
 
 int init_tlf_rig(void) {
     extern RIG *my_rig;
@@ -244,5 +243,4 @@ int close_tlf_rig(RIG *my_rig) {
     return (0);
 }
 
-#endif				// end code for Hamlib interface
 

--- a/src/sendqrg.h
+++ b/src/sendqrg.h
@@ -21,16 +21,10 @@
 #ifndef SENDQRG_H
 #define SENDQRG_H
 
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
-
-#ifdef HAVE_LIBHAMLIB
-# include <hamlib/rig.h>
+#include <hamlib/rig.h>
 
 int init_tlf_rig(void);
 int close_tlf_rig(RIG *my_rig);
-#endif
 
 int sendqrg(void);
 

--- a/src/tlf_curses.h
+++ b/src/tlf_curses.h
@@ -26,9 +26,7 @@
 #ifndef TLF_CURSES_H
 #define TLF_CURSES_H
 
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
+#include <config.h>
 
 #if defined HAVE_NCURSESW_CURSES_H
 # include <ncursesw/curses.h>

--- a/src/tlf_panel.h
+++ b/src/tlf_panel.h
@@ -28,9 +28,7 @@
 #ifndef TLF_PANEL_H
 #define TLF_PANEL_H
 
-#ifdef HAVE_CONFIG_H
-# include <config.h>
-#endif
+#include <config.h>
 
 #if defined HAVE_NCURSESW_PANEL_H
 # include <ncursesw/panel.h>


### PR DESCRIPTION
As is makes not much sense to use Tlf without rig control and Hamlib is readily available it is made mandatory. Rig control still has to be explicity enable using the RADIO_CONTROL config.
This saves us a number of #if/#endif's cluttering the code.

On mid term we shall consider using Hamlib's freq_t (double, in Hz units) to store frequencies instead of float in kHz. Fractional values in float can lead to loss of precision.

I've also removed guards from config.h includes as this file should be always present.
It has been kept only where needed (e.g. files using HAVE_LIBXMLRPC).

Also added a guard to avoid compilation warning about redefining _GNU_SOURCE.