### PR TITLE
Allow setting of callmaster file from logcfg.dat

### DIFF
--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -38,6 +38,7 @@
 #include "setcontest.h"
 #include "startmsg.h"
 #include "tlf_curses.h"
+#include "searchlog.h"
 
 #include <config.h>
 #include <hamlib/rig.h>
@@ -569,9 +570,10 @@ int parse_logcfg(char *inputbuffer) {
 	"ALT_DK5",
 	"ALT_DK6",
 	"ALT_DK7",
-	"ALT_DK8",
+	"ALT_DK8",			/* 260 */
 	"ALT_DK9",
-	"ALT_DK10"
+	"ALT_DK10",
+	"CALLMASTER"
     };
 
     char **fields;
@@ -1976,7 +1978,7 @@ int parse_logcfg(char *inputbuffer) {
 		    *nl = ' ';
 	    }
 	    break;
-	case 253 ... 263: {
+	case 253 ... 262: {
 	    PARAMETER_NEEDED(teststring);
 	    if (digi_message[ii - 239]) {
 		KeywordRepeated(commands[ii]);
@@ -1989,6 +1991,16 @@ int parse_logcfg(char *inputbuffer) {
 		if (nl)
 		    *nl = ' ';
 	    }
+	    break;
+	}
+	case 263: {
+	    PARAMETER_NEEDED(teststring);
+	    g_strchomp(fields[1]);
+	    if (callmaster_filename != NULL) {
+		g_free(callmaster_filename);
+	    }
+	    callmaster_filename = g_strdup(fields[1]);
+
 	    break;
 	}
 	default: {

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -43,6 +43,7 @@
 #include "get_time.h"
 
 
+char *callmaster_filename = NULL;
 GPtrArray *callmaster = NULL;
 
 char searchresult[MAX_CALLS][82];
@@ -755,11 +756,15 @@ int load_callmaster(void) {
 
     init_callmaster();
 
-    strcpy(callmaster_location, "callmaster");
+    if (callmaster_filename == NULL)
+	callmaster_filename = g_strdup("callmaster");
+
+    strcpy(callmaster_location, callmaster_filename);
     if ((cfp = fopen(callmaster_location, "r")) == NULL) {
 	callmaster_location[0] = '\0';
 	strcpy(callmaster_location, PACKAGE_DATA_DIR);
-	strcat(callmaster_location, "/callmaster");
+	strcat(callmaster_location, "/");
+	strcat(callmaster_location, callmaster_filename);
 
 	if ((cfp = fopen(callmaster_location, "r")) == NULL) {
 	    mvprintw(24, 0, "Error opening callmaster file.\n");

--- a/src/searchlog.h
+++ b/src/searchlog.h
@@ -28,6 +28,9 @@
 extern GPtrArray *callmaster;
 #define CALLMASTERARRAY(n) ((char *) g_ptr_array_index(callmaster, n))
 
+#define CALLMASTER_DEFAULT "callmaster"
+extern char *callmaster_filename;
+
 int load_callmaster(void);
 
 void searchlog(char *searchstring);

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -106,6 +106,8 @@ int setup_default(void **state) {
     searchflg = SEARCHWINDOW;
     trxmode = CWMODE;
 
+    callmaster_filename = NULL;
+
     partials = 1;
     use_part = 0;
 
@@ -185,6 +187,15 @@ void test_callmaster_ok_arrlss(void **state) {
     assert_int_equal(n, 2);
     assert_string_equal(CALLMASTERARRAY(0), "A1AA");
     assert_string_equal(CALLMASTERARRAY(1), "N2BB");
+}
+
+void test_use_different_callmaster(void **state) {
+    write_callmaster("callmaster", " # data \n A1AA \n A2BB \n\n");
+    write_callmaster("master.scp", " # data \n A1CC \n A2DD \n\n");
+    callmaster_filename = "master.scp";
+    int n = load_callmaster();
+    assert_int_equal(n, 2);
+    assert_string_equal(CALLMASTERARRAY(0), "A1CC");
 }
 
 void test_init_search_panel_no_contest(void **state) {

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -129,8 +129,8 @@ static void check_mvprintw_output(int index, int y, int x, const char *text) {
 
 // callmaster is checked first in current directory,
 // create it there
-static void write_callmaster(const char *content) {
-    FILE *f = fopen("callmaster", "w");
+static void write_callmaster(const char *filename, const char *content) {
+    FILE *f = fopen(filename, "w");
     assert_non_null(f);
     fputs(content, f);
     fclose(f);
@@ -155,7 +155,7 @@ int teardown_default(void **state) {
 //}
 
 void test_callmaster_ok(void **state) {
-    write_callmaster("# data\nA1AA\nA2BB\n\n");
+    write_callmaster("callmaster", "# data\nA1AA\nA2BB\n\n");
     int n = load_callmaster();
     assert_int_equal(n, 2);
     assert_string_equal(CALLMASTERARRAY(0), "A1AA");
@@ -163,7 +163,7 @@ void test_callmaster_ok(void **state) {
 }
 
 void test_callmaster_ok_dos(void **state) {
-    write_callmaster("# data\r\nA1AA\r\nA2BB\r\n\r\n");
+    write_callmaster("callmaster", "# data\r\nA1AA\r\nA2BB\r\n\r\n");
     int n = load_callmaster();
     assert_int_equal(n, 2);
     assert_string_equal(CALLMASTERARRAY(0), "A1AA");
@@ -171,7 +171,7 @@ void test_callmaster_ok_dos(void **state) {
 }
 
 void test_callmaster_ok_spaces(void **state) {
-    write_callmaster(" # data \n A1AA \n A2BB \n\n");
+    write_callmaster("callmaster", " # data \n A1AA \n A2BB \n\n");
     int n = load_callmaster();
     assert_int_equal(n, 2);
     assert_string_equal(CALLMASTERARRAY(0), "A1AA");
@@ -179,7 +179,7 @@ void test_callmaster_ok_spaces(void **state) {
 }
 
 void test_callmaster_ok_arrlss(void **state) {
-    write_callmaster("# data\nA1AA\nG0CC\nN2BB\n\n");
+    write_callmaster("callmaster", "# data\nA1AA\nG0CC\nN2BB\n\n");
     arrlss = 1;
     int n = load_callmaster();
     assert_int_equal(n, 2);
@@ -251,7 +251,7 @@ void test_UsePartialFromLogNotUnique (void **state) {
 }
 
 void test_UsePartialFromCallmaster(void **state) {
-    write_callmaster("# data\nA1AA\nA2BB\n\n");
+    write_callmaster("callmaster", "# data\nA1AA\nA2BB\n\n");
     load_callmaster();
     use_part = 1;
     strcpy(hiscall, "A1");
@@ -261,7 +261,7 @@ void test_UsePartialFromCallmaster(void **state) {
 }
 
 void test_UsePartialNotUnique(void **state) {
-    write_callmaster("# data\nA1AA\nA2BB\nA3BB\n");
+    write_callmaster("callmaster", "# data\nA1AA\nA2BB\nA3BB\n");
     load_callmaster();
     use_part = 1;
     strcpy(hiscall, "A3");

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1725,6 +1725,11 @@ exchange, like e.g. the FOC Marathon.  The module also recognises embedded
 calls (CT3/PA0R/QRP).
 .
 .TP
+.B CALLMASTER\fR=\fIcallmaster\fR
+Allow to name a different file used as callmaster database 
+(default is '\fIcallmaster\fR'). See FILES section.
+.
+.TP
 .B CONTINENT_EXCHANGE
 Exchange is continent (NA, SA, EU, AS, AF, OC).
 .
@@ -1968,7 +1973,9 @@ Save the
 .I master.scp
 file as
 .I callmaster
-in the working directory.  It will take precedence over the system installed
+in the working directory (or use \fBCALLMASTER\fR=\fImaster.scp\fR to use
+that file).  
+It will take precedence over the system installed
 .IR callmaster .
 .
 .P


### PR DESCRIPTION
Add a new keyword CALLMASTER=filename which allows the use of 'filename' as callmaster database file. The file has to be in the current directory or in /usr/(local/)share/tlf.