### PR TITLE
Add lan port config directive

### DIFF
--- a/src/lancode.c
+++ b/src/lancode.c
@@ -65,6 +65,8 @@ int send_error_limit[MAXNODES];
 //--------------------------------------
 /* default port to listen for incomming packets and to send packet to */
 char default_lan_service[16] = "6788";
+/* lan port parsed from config */
+int lan_port = 6788;
 
 int lan_active = 0;
 int send_error[MAXNODES];
@@ -106,6 +108,7 @@ int lanrecv_init(void) {
     if (lan_active == 0)
 	return (1);
 
+    sprintf(default_lan_service, "%d", lan_port);
     bzero(&lan_sin, sizeof(lan_sin));
     lan_sin.sin_family = AF_INET;
     lan_sin.sin_addr.s_addr = htonl(INADDR_ANY);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -306,6 +306,7 @@ int parse_logcfg(char *inputbuffer) {
     extern unsigned char rigptt;
     extern int minitest;
     extern int unique_call_multi;
+    extern int lan_port;
 
     char *commands[] = {
 	"enable",		/* 0 */		/* deprecated */
@@ -572,7 +573,8 @@ int parse_logcfg(char *inputbuffer) {
 	"ALT_DK8",			/* 260 */
 	"ALT_DK9",
 	"ALT_DK10",
-	"CALLMASTER"
+	"CALLMASTER",
+        "LAN_PORT"                     /* 264 */
     };
 
     char **fields;
@@ -1983,6 +1985,11 @@ int parse_logcfg(char *inputbuffer) {
 	    }
 	    callmaster_filename = g_strdup(fields[1]);
 
+	    break;
+	}
+        case 264: {
+	    PARAMETER_NEEDED(teststring);
+	    lan_port = atoi(fields[1]);
 	    break;
 	}
 	default: {

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1073,6 +1073,11 @@ ID on the network it will exit and ask you to pick another one!  Range:
 A\(enH.
 .
 .TP
+\fBLAN_PORT\fR=\fIPortnumber\fR
+Specifies on which portnumber (default \(lq6788\(rq) @PACKAGE_NAME@ is 
+listening for broadcasts from other instances.
+.
+.TP
 .B LANDEBUG
 Switches on the debug function.  Dumps all @PACKAGE_NAME@ net traffic received
 on this node into a file named


### PR DESCRIPTION
- Allows to specify on which port number TLF is listening for incoming
  broadcasts from other instances.

- Allows even to run multiple instances of TLF  on the same server.