### PR TITLE
Alias for multis

### DIFF
--- a/src/addmult.c
+++ b/src/addmult.c
@@ -34,7 +34,7 @@
 #include "tlf_curses.h"
 #include "bands.h"
 
-#define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))
+GPtrArray *mults_possible;
 
 enum { ALL_BAND, PER_BAND };
 

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -55,18 +55,18 @@ int addmult(void) {
 
 	/* check all possible mults for match and remember the longest one */
 	for (i = 0; i < mults_possible->len; i++) {
-	    if ((strstr(ssexchange, MULTS_POSSIBLE(i)) != NULL)
-		    && (strlen(MULTS_POSSIBLE(i)) > 1)) {
+	    if ((strstr(ssexchange, get_mult(i)) != NULL)
+		    && (strlen(get_mult(i)) > 1)) {
 
-		if (strlen(MULTS_POSSIBLE(i)) > matching_len) {
-		    matching_len = strlen(MULTS_POSSIBLE(i));
+		if (strlen(get_mult(i)) > matching_len) {
+		    matching_len = strlen(get_mult(i));
 		    idx = i;
 		}
 	    }
 	}
 
 	if (idx >= 0) {
-	    remember_multi(MULTS_POSSIBLE(idx), bandinx, ALL_BAND);
+	    remember_multi(get_mult(idx), bandinx, ALL_BAND);
 	}
     }
 
@@ -76,7 +76,7 @@ int addmult(void) {
 	/* is it a possible mult? */
 	for (i = 0; i < mults_possible->len; i++) {
 	    // check if valid mult....
-	    if (strcmp(ssexchange, MULTS_POSSIBLE(i)) == 0) {
+	    if (strcmp(ssexchange, get_mult(i)) == 0) {
 		idx = i;
 		break;
 	    }
@@ -84,7 +84,7 @@ int addmult(void) {
 
 	if (idx >= 0) {
 	    shownewmult =
-		remember_multi(MULTS_POSSIBLE(idx), bandinx, PER_BAND);
+		remember_multi(get_mult(idx), bandinx, PER_BAND);
 	}
     }
 
@@ -94,10 +94,10 @@ int addmult(void) {
 
 	/* check all possible mults for match and remember the longest one */
 	for (i = 0; i < mults_possible->len; i++) {
-	    if (strstr(ssexchange, MULTS_POSSIBLE(i)) != NULL) {
+	    if (strstr(ssexchange, get_mult(i)) != NULL) {
 
-		if (strlen(MULTS_POSSIBLE(i)) > matching_len) {
-		    matching_len = strlen(MULTS_POSSIBLE(i));
+		if (strlen(get_mult(i)) > matching_len) {
+		    matching_len = strlen(get_mult(i));
 		    idx = i;
 		}
 	    }
@@ -105,7 +105,7 @@ int addmult(void) {
 
 	if (idx >= 0) {
 	    shownewmult =
-		remember_multi(MULTS_POSSIBLE(idx), bandinx, PER_BAND);
+		remember_multi(get_mult(idx), bandinx, PER_BAND);
 	}
     }
 
@@ -156,18 +156,18 @@ int addmult2(void) {
 
 	/* check all possible mults for match and remember the longest one */
 	for (i = 0; i < mults_possible->len; i++) {
-	    if ((strstr(ssexchange, MULTS_POSSIBLE(i)) != NULL)
-		    && (strlen(MULTS_POSSIBLE(i)) > 1)) {
+	    if ((strstr(ssexchange, get_mult(i)) != NULL)
+		    && (strlen(get_mult(i)) > 1)) {
 
-		if (strlen(MULTS_POSSIBLE(i)) > matching_len) {
-		    matching_len = strlen(MULTS_POSSIBLE(i));
+		if (strlen(get_mult(i)) > matching_len) {
+		    matching_len = strlen(get_mult(i));
 		    idx = i;
 		}
 	    }
 	}
 
 	if (idx >= 0) {
-	    remember_multi(MULTS_POSSIBLE(idx), bandinx, ALL_BAND);
+	    remember_multi(get_mult(idx), bandinx, ALL_BAND);
 	}
     }
 
@@ -203,6 +203,17 @@ int addmult2(void) {
 }
 
 
+/* look up n-th position in list of possible mults and
+ * return pointer to data */
+char *get_mult(int n) {
+    return (char *)g_ptr_array_index(mults_possible, n);
+}
+
+/* return number of possible mults */
+int get_mult_count(void) {
+    return mults_possible->len;
+}
+
 /* compare functions to sort multi by aphabetic order  */
 gint	cmp_size(char **a, char **b) {
 
@@ -223,7 +234,6 @@ gint	cmp_size(char **a, char **b) {
  * \return number of loaded multipliers (nr of entries in mults_possible)
  * */
 int init_and_load_multipliers(void) {
-    extern GPtrArray *mults_possible;
     extern char multsfile[];	// Set by parse_logcfg()
 
     FILE *cfp;

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -217,6 +217,11 @@ char *get_mult(int n) {
     return get_mult_base(n)->name;
 }
 
+/* get alias list on n-th position of possible mults */
+GSList *get_aliases(int n) {
+    return get_mult_base(n)->aliases;
+}
+
 /* return number of possible mults */
 int get_mult_count(void) {
     return mults_possible->len;

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -56,13 +56,10 @@ int addmult(void) {
 
 	/* check all possible mults for match and remember the longest one */
 	for (i = 0; i < mults_possible->len; i++) {
-	    if ((strstr(ssexchange, get_mult(i)) != NULL)
-		    && (strlen(get_mult(i)) > 1)) {
-
-		if (strlen(get_mult(i)) > matching_len) {
-		    matching_len = strlen(get_mult(i));
-		    idx = i;
-		}
+	    int len = get_matching_length(ssexchange, i);
+	    if (len > matching_len) {
+		matching_len = len;
+		idx = i;
 	    }
 	}
 
@@ -76,8 +73,7 @@ int addmult(void) {
 
 	/* is it a possible mult? */
 	for (i = 0; i < mults_possible->len; i++) {
-	    // check if valid mult....
-	    if (strcmp(ssexchange, get_mult(i)) == 0) {
+	    if (get_matching_length(ssexchange, i) == strlen(ssexchange)) {
 		idx = i;
 		break;
 	    }
@@ -95,12 +91,10 @@ int addmult(void) {
 
 	/* check all possible mults for match and remember the longest one */
 	for (i = 0; i < mults_possible->len; i++) {
-	    if (strstr(ssexchange, get_mult(i)) != NULL) {
-
-		if (strlen(get_mult(i)) > matching_len) {
-		    matching_len = strlen(get_mult(i));
-		    idx = i;
-		}
+	    int len = get_matching_length(ssexchange, i);
+	    if (len > matching_len) {
+		matching_len = len;
+		idx = i;
 	    }
 	}
 
@@ -157,13 +151,10 @@ int addmult2(void) {
 
 	/* check all possible mults for match and remember the longest one */
 	for (i = 0; i < mults_possible->len; i++) {
-	    if ((strstr(ssexchange, get_mult(i)) != NULL)
-		    && (strlen(get_mult(i)) > 1)) {
-
-		if (strlen(get_mult(i)) > matching_len) {
-		    matching_len = strlen(get_mult(i));
-		    idx = i;
-		}
+	    int len = get_matching_length(ssexchange, i);
+	    if (len > matching_len) {
+		matching_len = len;
+		idx = i;
 	    }
 	}
 
@@ -210,14 +201,13 @@ possible_mult_t *get_mult_base(int n) {
     return (possible_mult_t *)g_ptr_array_index(mults_possible, n);
 }
 
-
 /* look up n-th position in list of possible mults and
  * return pointer to multname */
 char *get_mult(int n) {
     return get_mult_base(n)->name;
 }
 
-/* get alias list on n-th position of possible mults */
+/* return alias list on n-th position of possible mults */
 GSList *get_aliases(int n) {
     return get_mult_base(n)->aliases;
 }
@@ -225,6 +215,24 @@ GSList *get_aliases(int n) {
 /* return number of possible mults */
 int get_mult_count(void) {
     return mults_possible->len;
+}
+
+/* get best matching lenght of of name or aliaslist of mult 'n' in 'str' */
+unsigned int get_matching_length(char *str, unsigned int n) {
+    unsigned len = 0;
+
+    if (strstr(str, get_mult(n)) != NULL) {
+	len = strlen(get_mult(n));
+    }
+
+    for (int i = 0; i < g_slist_length(get_aliases(n)); i++) {
+	char *tmp =g_slist_nth_data(get_aliases(n), i);
+	if (strstr(str, tmp) != NULL) {
+	    if (strlen(tmp) >= len)
+		len = strlen(tmp);
+	}
+    }
+    return len;
 }
 
 

--- a/src/addmult.h
+++ b/src/addmult.h
@@ -22,11 +22,11 @@
 #define ADDMULT_H
 #include "glib.h"
 
-extern GPtrArray *mults_possible;
-#define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))
 
 int addmult(void);
 int addmult2(void);
+char *get_mult(int n);
+int get_mult_count(void);
 int init_and_load_multipliers(void);
 int remember_multi(char *multiplier, int band, int show_new_band);
 void init_mults();

--- a/src/addmult.h
+++ b/src/addmult.h
@@ -20,7 +20,17 @@
 
 #ifndef ADDMULT_H
 #define ADDMULT_H
-#include "glib.h"
+
+#include <glib.h>
+
+/** possible multi
+ *
+ * name of possible multiplier and
+ * list of belonging aliases */
+typedef struct {
+    char *name;
+    GSList *aliases;
+} possible_mult_t;
 
 
 int addmult(void);

--- a/src/addmult.h
+++ b/src/addmult.h
@@ -37,6 +37,7 @@ int addmult(void);
 int addmult2(void);
 char *get_mult(int n);
 int get_mult_count(void);
+unsigned int get_matching_length(char *str, unsigned int n);
 int init_and_load_multipliers(void);
 int remember_multi(char *multiplier, int band, int show_new_band);
 void init_mults();

--- a/src/addmult.h
+++ b/src/addmult.h
@@ -20,6 +20,10 @@
 
 #ifndef ADDMULT_H
 #define ADDMULT_H
+#include "glib.h"
+
+extern GPtrArray *mults_possible;
+#define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))
 
 int addmult(void);
 int addmult2(void);

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -59,8 +59,7 @@
 #include "ui_utils.h"
 #include "writecabrillo.h"
 #include "writeparas.h"
-
-#define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))
+#include "addmult.h"
 
 
 int debug_tty(void);

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -801,7 +801,6 @@ int multiplierinfo(void) {
     extern int sectn_mult;
     extern struct mults_t multis[MAX_MULTS];
     extern int nr_multis;
-    extern GPtrArray *mults_possible;
 
     int j, k, vert, hor, cnt, found;
     char mprint[50];
@@ -823,14 +822,14 @@ int multiplierinfo(void) {
 	cnt = 0;
 	for (vert = 9; vert < 18; vert++) {
 
-	    if (cnt >= mults_possible->len)
+	    if (cnt >= get_mult_count())
 		break;
 
 	    for (hor = 5; hor < 15; hor++) {
-		if (cnt >= mults_possible->len)
+		if (cnt >= get_mult_count())
 		    break;
 
-		g_strlcpy(chmult, MULTS_POSSIBLE(cnt), sizeof(chmult));
+		g_strlcpy(chmult, get_mult(cnt), sizeof(chmult));
 
 		/* check if in worked multis */
 		found = 0;
@@ -848,7 +847,7 @@ int multiplierinfo(void) {
 
 		attron(modify_attr(attributes));
 
-		g_strlcpy(mprint, MULTS_POSSIBLE(cnt), 5);
+		g_strlcpy(mprint, get_mult(cnt), 5);
 		mvprintw(vert, hor * 4, "%s", mprint);
 
 		cnt++;
@@ -863,24 +862,24 @@ int multiplierinfo(void) {
 	mvprintw(0, 30, "REMAINING SECTIONS");
 	cnt = 0;
 	for (vert = 2; vert < 22; vert++) {
-	    if (cnt >= mults_possible->len)
+	    if (cnt >= get_mult_count())
 		break;
 
 	    for (hor = 0; hor < 7; hor++) {
-		if (cnt >= mults_possible->len)
+		if (cnt >= get_mult_count())
 		    break;
 
 		worked_at = 0;
 
 		/* lookup if already worked */
 		for (k = 0; k < nr_multis; k++) {
-		    if (strstr(multis[k].name, MULTS_POSSIBLE(cnt)) != NULL) {
+		    if (strstr(multis[k].name, get_mult(cnt)) != NULL) {
 			worked_at = multis[k].band;
 			break;
 		    }
 		}
 
-		tmp = g_strndup(MULTS_POSSIBLE(cnt), 4);
+		tmp = g_strndup(get_mult(cnt), 4);
 		sprintf(mprint, "%-4s", tmp);
 		g_free(tmp);
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -906,12 +906,10 @@ int checkexchange(int x) {
 		    }
 
 		    for (jj = 0; jj < get_mult_count(); jj++) {
-
-			if ((strlen(get_mult(jj)) >= 1)
-				&& (strcmp(checksection, get_mult(jj)) ==
-				    0)) {
+			if (get_matching_length(checksection, jj) ==
+				strlen(checksection)) {
 			    strcpy(section, get_mult(jj));
-			    break;	// new
+			    break;
 			}
 		    }
 		}
@@ -925,14 +923,19 @@ int checkexchange(int x) {
 
 		strncpy(checksection, comment, 3);
 		checksection[3] = '\0';
+
+		int best_len = 0;
+		int idx = -1;
 		for (jj = 0; jj < get_mult_count(); jj++) {
-
-		    if ((strlen(get_mult(jj)) >= 1)
-			    && (strstr(checksection, get_mult(jj)) !=
-				NULL)) {
-
-			strcpy(section, get_mult(jj));
+		    int len = get_matching_length(checksection, jj);
+		    if (len > best_len) {
+			best_len = len;
+			idx = jj;
 		    }
+		}
+
+		if (idx >= 0) {
+		    strcpy(section, get_mult(idx));
 		}
 	    }
 
@@ -947,12 +950,7 @@ int checkexchange(int x) {
 		checksection[3] = '\0';
 
 		for (jj = 0; jj < get_mult_count(); jj++) {
-
-		    if ((strlen(get_mult(jj)) ==
-			    strlen(checksection))
-			    && (strstr(checksection, get_mult(jj)) !=
-				NULL)) {
-
+		    if (get_matching_length(checksection, jj) == strlen(checksection)) {
 			strcpy(section, get_mult(jj));
 
 			// if (strlen(section) == strlen(mults_possible[jj])) break;

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -47,10 +47,10 @@
 #include "time_update.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
+#include "addmult.h"
 
 #include "getexchange.h"
 
-#define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))
 #define LEN(array) (sizeof(array) / sizeof(array[0]))
 
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -509,7 +509,6 @@ int checkexchange(int x) {
 
     extern char comment[];
     extern char ssexchange[];
-    extern GPtrArray *mults_possible;
     extern int cqww;
     extern int arrlss;
     extern int stewperry_flg;
@@ -822,9 +821,9 @@ int checkexchange(int x) {
 		g_strlcpy(checksection, comment + hr, 4);
 		g_strchomp(checksection);
 
-		for (jj = 0; jj < mults_possible->len; jj++) {
+		for (jj = 0; jj < get_mult_count(); jj++) {
 
-		    char *multi = g_strdup(MULTS_POSSIBLE(jj));
+		    char *multi = g_strdup(get_mult(jj));
 		    g_strchomp(multi);
 
 		    if ((strlen(multi) >= 1) &&
@@ -906,12 +905,12 @@ int checkexchange(int x) {
 			checksection[strlen(checksection) - 1] = '\0';
 		    }
 
-		    for (jj = 0; jj < mults_possible->len; jj++) {
+		    for (jj = 0; jj < get_mult_count(); jj++) {
 
-			if ((strlen(MULTS_POSSIBLE(jj)) >= 1)
-				&& (strcmp(checksection, MULTS_POSSIBLE(jj)) ==
+			if ((strlen(get_mult(jj)) >= 1)
+				&& (strcmp(checksection, get_mult(jj)) ==
 				    0)) {
-			    strcpy(section, MULTS_POSSIBLE(jj));
+			    strcpy(section, get_mult(jj));
 			    break;	// new
 			}
 		    }
@@ -926,13 +925,13 @@ int checkexchange(int x) {
 
 		strncpy(checksection, comment, 3);
 		checksection[3] = '\0';
-		for (jj = 0; jj < mults_possible->len; jj++) {
+		for (jj = 0; jj < get_mult_count(); jj++) {
 
-		    if ((strlen(MULTS_POSSIBLE(jj)) >= 1)
-			    && (strstr(checksection, MULTS_POSSIBLE(jj)) !=
+		    if ((strlen(get_mult(jj)) >= 1)
+			    && (strstr(checksection, get_mult(jj)) !=
 				NULL)) {
 
-			strcpy(section, MULTS_POSSIBLE(jj));
+			strcpy(section, get_mult(jj));
 		    }
 		}
 	    }
@@ -947,14 +946,14 @@ int checkexchange(int x) {
 		strncpy(checksection, comment, 3);
 		checksection[3] = '\0';
 
-		for (jj = 0; jj < mults_possible->len; jj++) {
+		for (jj = 0; jj < get_mult_count(); jj++) {
 
-		    if ((strlen(MULTS_POSSIBLE(jj)) ==
+		    if ((strlen(get_mult(jj)) ==
 			    strlen(checksection))
-			    && (strstr(checksection, MULTS_POSSIBLE(jj)) !=
+			    && (strstr(checksection, get_mult(jj)) !=
 				NULL)) {
 
-			strcpy(section, MULTS_POSSIBLE(jj));
+			strcpy(section, get_mult(jj));
 
 			// if (strlen(section) == strlen(mults_possible[jj])) break;
 		    }

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -82,7 +82,6 @@ extern char continent[];
 extern char zone_export[];
 extern int itumult;
 
-extern GPtrArray *mults_possible;	/* growing array of possible mutlipliers */
 extern char ssexchange[];
 extern int shownewmult;
 extern char comment[];

--- a/src/main.c
+++ b/src/main.c
@@ -387,8 +387,6 @@ int zones[MAX_ZONES];		/* same for cq zones or itu zones;
 struct mults_t multis[MAX_MULTS]; /**< worked multis */
 int nr_multis = 0;		/**< number of multis in multis[] */
 
-GPtrArray *mults_possible;
-
 int multlist = 0;
 
 int callareas[20];

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -264,7 +264,7 @@ void prepare_specific_part(void) {
 
     } else if (sectn_mult == 1) {
 	//-------------------------section only---------------
-	strncat(logline4, section, 22);
+	strncat(logline4, comment, 22);
 	section[0] = '\0';
 
     } else if ((cqww == 1) || (wazmult == 1) || (itumult == 1)) {

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -61,7 +61,7 @@ int readcalls(void) {
     int i = 0, l = 0, n = 0, r = 0, s = 0;
     unsigned int k = 0;
     int m = 0;
-    int t = 0, tt = 0;
+    int t = 0;
     int z = 0;
     int add_ok;
     char multbuffer[40];
@@ -250,16 +250,16 @@ int readcalls(void) {
 
 		} else if (serial_section_mult == 1) {
 
-		    tt = 0;
-
 		    memset(multbuffer, 0, 39);
 
-		    for (t = 54; t < 64; t++) {
-			if (inputbuffer[t] >= 'A' && inputbuffer[t] <= 'Z') {
-			    multbuffer[tt] = inputbuffer[t];
-			    tt++;
-			}
-		    }
+		    strncpy(multbuffer, inputbuffer + 68, 3);
+		    g_strchomp(multbuffer);
+
+		} else if (sectn_mult == 1) {
+		    memset(multbuffer, 0, 39);
+
+		    strncpy(multbuffer, inputbuffer + 68, 3);
+		    g_strchomp(multbuffer);
 
 		} else if (serial_grid4_mult == 1) {
 

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -807,7 +807,6 @@ void show_needed_sections(void) {
     extern int arrlss;
     extern int nr_multis;
     extern struct mults_t multis[MAX_MULTS];
-    extern GPtrArray *mults_possible;
 
     int j, vert, hor, cnt, found;
     char mprint[50];
@@ -821,14 +820,14 @@ void show_needed_sections(void) {
 	    mvwprintw(search_win, j, 1, "                                     ");
 
 	for (vert = 1; vert < 7; vert++) {
-	    if (cnt >= mults_possible->len)
+	    if (cnt >= get_mult_count())
 		break;
 
 	    for (hor = 0; hor < 9; hor++) {
-		if (cnt >= mults_possible->len)
+		if (cnt >= get_mult_count())
 		    break;
 
-		strcpy(mprint, g_ptr_array_index(mults_possible, cnt));
+		strcpy(mprint, get_mult(cnt));
 
 		found = 0;
 		for (j = 0; j < nr_multis; j++) {

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -41,6 +41,7 @@
 #include "zone_nr.h"
 #include "searchcallarray.h"
 #include "get_time.h"
+#include "addmult.h"
 
 
 char *callmaster_filename = NULL;

--- a/test/data.c
+++ b/test/data.c
@@ -336,8 +336,6 @@ char mults[MAX_MULTS][12];
 int mult_bands[MAX_MULTS];
 int multarray_nr = 0;
 
-GPtrArray *mults_possible;
-
 int multlist = 0;
 
 int callareas[20];

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -118,14 +118,13 @@ void test_remember_mult_same_2x_newband(void **state) {
 
 /* helper for checking content of mults_possible array */
 void check_multi(int pos, char * str) {
-    assert_string_equal(MULTS_POSSIBLE(pos), str);
+    assert_string_equal(get_mult(pos), str);
 }
 
 /* tests for load_multipliers */
 void test_load_multi_no_file(void **state) {
     assert_int_equal(init_and_load_multipliers(), 0);
-    assert_non_null(mults_possible);
-    assert_int_equal(mults_possible->len, 0);
+    assert_int_equal(get_mult_count(), 0);
 }
 
 /** \todo better would be to return -1 if multsfile could not be found */

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -179,6 +179,30 @@ void test_load_multi_sorted(void **state) {
     check_multi(2, "ZH");
 }
 
+void test_load_multi_redefined(void **state) {
+    write_testfile(testfile, "AB\nKL\nZH\nKL\n");
+    strcpy(multsfile, testfile);
+    assert_int_equal(init_and_load_multipliers(), 3);
+    check_multi(0, "AB");
+    check_multi(2, "ZH");
+}
+
+
+void test_load_multi_with_emptyalias(void **state) {
+    write_testfile(testfile, "AB\nLZ :\nZH\nKL\n");
+    strcpy(multsfile, testfile);
+    assert_int_equal(init_and_load_multipliers(), 4);
+    check_multi(0, "AB");
+    check_multi(2, "LZ");
+}
+
+void test_load_multi_with_alias(void **state) {
+    write_testfile(testfile, "AB\nLZ: NH, ZD,AA\nZH\nKL\n");
+    strcpy(multsfile, testfile);
+    assert_int_equal(init_and_load_multipliers(), 4);
+    check_multi(0, "AB");
+    check_multi(2, "LZ");
+}
 
 /* addmult tests */
 void test_wysiwyg_once(void **state) {

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -204,6 +204,28 @@ void test_load_multi_with_alias(void **state) {
     assert_int_equal(g_slist_length(get_aliases(2)), 3);
 }
 
+/* test matching of mults and aliases */
+void test_match_length_no_match(void **state) {
+    setup_multis("ZH:NHA,ZDL,AA,AAC\n");
+    assert_int_equal(get_matching_length("ABC",0), 0);
+}
+
+void test_match_length_match_mult(void **state) {
+    setup_multis("ZH:NHA,ZDL,AA,AAC\n");
+    assert_int_equal(get_matching_length("12aZHXc",0), 2);
+}
+
+void test_match_length_match_alias(void **state) {
+    setup_multis("ZH:NHA,ZDL,AA,AAC\n");
+    assert_int_equal(get_matching_length("12aAAX2",0), 2);
+}
+
+void test_match_length_match_alias2(void **state) {
+    setup_multis("ZH:NHA,ZDL,AA,AAC\n");
+    assert_int_equal(get_matching_length("12aAAC2",0), 3);
+}
+
+
 /* addmult tests */
 void test_wysiwyg_once(void **state) {
     wysiwyg_once = 1;

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -116,6 +116,13 @@ void test_remember_mult_same_2x_newband(void **state) {
 }
 
 
+/* helper for checking content of mults_possible array */
+#define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))
+
+void check_multi(int pos, char * str) {
+    assert_string_equal(MULTS_POSSIBLE(pos), str);
+}
+
 /* tests for load_multipliers */
 void test_load_multi_no_file(void **state) {
     assert_int_equal(init_and_load_multipliers(), 0);
@@ -146,16 +153,16 @@ void test_load_multi(void **state) {
     write_testfile(testfile, "AB\n#LZ is not active\nKL\n 	\nZH\n");
     strcpy(multsfile, testfile);
     assert_int_equal(init_and_load_multipliers(), 3);
-    assert_string_equal(mults_possible->pdata[0], "AB");
-    assert_string_equal(mults_possible->pdata[2], "ZH");
+    check_multi(0, "AB");
+    check_multi(2, "ZH");
 }
 
 void test_load_multi_dos(void **state) {
     write_testfile(testfile, "AB\r\n#LZ is not active\r\nKL\r\n 	\r\nZH\r\n");
     strcpy(multsfile, testfile);
     assert_int_equal(init_and_load_multipliers(), 3);
-    assert_string_equal(mults_possible->pdata[0], "AB");
-    assert_string_equal(mults_possible->pdata[2], "ZH");
+    check_multi(0, "AB");
+    check_multi(2, "ZH");
 }
 
 // leading space both on comment and data lines
@@ -163,16 +170,16 @@ void test_load_multi_leading_space(void **state) {
     write_testfile(testfile, " AB\n   #LZ is not active\nKL\n 	\nZH\n");
     strcpy(multsfile, testfile);
     assert_int_equal(init_and_load_multipliers(), 3);
-    assert_string_equal(mults_possible->pdata[0], "AB");
-    assert_string_equal(mults_possible->pdata[2], "ZH");
+    check_multi(0, "AB");
+    check_multi(2, "ZH");
 }
 
 void test_load_multi_sorted(void **state) {
     write_testfile(testfile, "AB\n#LZ is not active\nZH\n 	\nKL\n");
     strcpy(multsfile, testfile);
     assert_int_equal(init_and_load_multipliers(), 3);
-    assert_string_equal(mults_possible->pdata[0], "AB");
-    assert_string_equal(mults_possible->pdata[2], "ZH");
+    check_multi(0, "AB");
+    check_multi(2, "ZH");
 }
 
 

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -117,8 +117,6 @@ void test_remember_mult_same_2x_newband(void **state) {
 
 
 /* helper for checking content of mults_possible array */
-#define MULTS_POSSIBLE(n) ((char *)g_ptr_array_index(mults_possible, n))
-
 void check_multi(int pos, char * str) {
     assert_string_equal(MULTS_POSSIBLE(pos), str);
 }

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -7,6 +7,8 @@
 #include "../src/searchlog.h"
 #include "../src/dxcc.h"
 
+// OBJECT ../src/addmult.o
+// OBJECT ../src/bands.o
 // OBJECT ../src/searchlog.o
 // OBJECT ../src/zone_nr.o
 // OBJECT ../src/searchcallarray.o

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1674,7 +1674,17 @@ Multiplier is the DXCC entity (per band).
 .TP
 \fBMULT_LIST\fR=\fIfile_name\fR
 Name of multipliers file (often sections, provinces, states, counties).  May
-contain comment lines starting with \(lq#\(rq in the first column.
+contain comment lines starting with \(lq#\(rq in the first column. Each
+multiplier resides on a single line by itself. 
+.IP
+Starting from Tlf-1.4 on you can also use aliases for the multipliers. Define
+the aliases as 
+.IP
+    \fImultiplier:alias1,alias2,alias3\fR
+.IP
+If you log a QSO with one of the aliases  it will be counted
+for as the according multiplier. You can have more 
+than one line for the same multiplier.
 .
 .TP
 .B SECTION_MULT
@@ -1980,7 +1990,7 @@ It will take precedence over the system installed
 .P
 \fISection files\fR contain a flat ASCII database of multpliers like states,
 sections, provinces, districts, names, ages, etc.  They are invoked by
-including \fBMULT_LIST\fR=\fIsection_file_name\fR in the rules file.
+including \fBMULT_LIST\fR=\fIsection_file_name\fR in the rules file. 
 .
 .SH DOCUMENTATION
 .


### PR DESCRIPTION
While you can define a list of plain multipliers by using MULT_LIST=<filename> until now it is not possible to use aliases for some of the multis.

The patch introduces a new syntax for the multfile. It allows to add aliases to each of the multis. e.g.

multiplier:alias1, alias2, alias 3

You can have more than one line with the same multiplier and different aliases.

When receiving one of the aliases it will counted as if you have a QSO with the original multiplier. The comment field will record the received original alias but the section column will show only the multiplier. 

Aliases are not shown when you list the needed/worked multis (:mult or Alt-M).