### PR TITLE
switch back to CQ after working a grabbed station

### DIFF
--- a/src/callinput.h
+++ b/src/callinput.h
@@ -26,5 +26,8 @@
 int callinput(void);
 int play_file(char *audiofile);
 void send_bandswitch(freq_t freq);
+void swap_mem();
+void change_mode();
+void update_mode();
 
 #endif /* CALLINPUT_H */

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -30,6 +30,7 @@
 #include "tlf.h"
 #include "tlf_curses.h"
 #include "gettxinfo.h"
+#include "callinput.h"
 
 void send_bandswitch(freq_t outfreq);
 
@@ -90,9 +91,10 @@ freq_t grab_next(void) {
  */
 static freq_t execute_grab(spot *data) {
     extern char hiscall[];
-    extern char mode[];
     extern int cqmode;
     extern freq_t mem;
+    extern int mem_cqmode;
+    extern int mem_grab;
     extern freq_t freq;
 
     freq_t f = data->freq - fldigi_get_carrier();
@@ -106,10 +108,11 @@ static freq_t execute_grab(spot *data) {
 
     /* if in CQ mode switch to S&P and remember QRG */
     if (cqmode == CQ) {
-	cqmode = S_P;
-	strcpy(mode, "S&P     ");
 	mem = freq;
+        mem_cqmode = CQ;
+        mem_grab = 1;   // stored due to a grab
 	mvprintw(14, 68, "MEM: %7.1f", mem/1000.);
+        change_mode();
     }
 
     refreshp();

--- a/src/main.c
+++ b/src/main.c
@@ -411,6 +411,8 @@ struct tm *time_ptr, time_ptr_cabrillo;
 
 freq_t freq;
 freq_t mem;
+int mem_cqmode = CQ;    // cqmode of the stored frequency
+int mem_grab = 0;       // frequency was stored due to a grab
 int logfrequency = 0;
 int rit;
 int trx_control = 0;


### PR DESCRIPTION
This is my best effort for "automatically switch back to 'Run' mode from "grab spot" after QSO".
While designing it I realized that it's impossible to implement this behavior as one has to wait at least until the end of the SP_TU message before switching back to CQing. It is actually even worse, as there could be still repeats happenning after this message (either exchange or callsign not received correctly). So one can switch to CQ only on operation action.
The solution is that after a completed grabbed S&P QSO pressing Esc reverts to CQ frequency. It is not too much effort from the op and gives the freedom of finishing the QSO correctly. Esc is normally next to F1, so no big movement is involved.
In addition, now `#`  restores the operating mode also (CQ/S&P). I think this makes sense.

Changes:
- main.c : `mem_cqmode` and `mem_grab` hold info on the mode at the time of storing mem and if it was due to a grab.
- logit.c: `change_mode()` moved to callinput.c; a bit restructured the logit() mega-function, reducing the indent depth for readability.
- callinput.c: added helper functions for mode change and VFO-MEM operations. They still mix logic with display code, this needs to be fixed when UI is refactored. update_mode() should be called instead of setting mode string in other places.
- grabspot.c: store cqmode and grab info into MEM along with the freq.

A note regarding VFO-MEM: now it's in fact a stack with `#` pushing (VFO->MEM) or popping (MEM->VFO) depending whether the stack if empty or not. It may also make sense to add an exchange operation VFO<->MEM. This would allow switching back and forth between CQ and S&P freqs without losing them. We could use `$` key for it, as it's just next to `#`.
