### PR TITLE
Vertical resize

### DIFF
--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -48,6 +48,14 @@
 #define DISTANCE(x, y) \
     ( x < y ? y - x : x -y )
 
+extern int ymax;
+#define TOPLINE 14
+#define LASTLINE (ymax - 2)
+
+#define LINELENGTH 80
+#define COLUMNS ((LINELENGTH - 14) / SPOT_COLUMN_WIDTH)
+#define NR_SPOTS ((LASTLINE - TOPLINE + 1) * COLUMNS)
+
 pthread_mutex_t bm_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /** \brief sorted list of all recent DX spots
@@ -69,6 +77,7 @@ bm_config_t bm_config = {
 };
 short	bm_initialized = 0;
 
+extern int ymax;
 extern freq_t freq;
 extern int trx_control;
 extern int bandinx;
@@ -488,7 +497,7 @@ void bm_show_info() {
 
     /* show info field on the right */
     attrset(COLOR_PAIR(CB_DUPE) | A_BOLD);
-    move(14, 66);
+    move(TOPLINE, 66);
     vline(ACS_VLINE, 10);
 
     mvprintw(18, 68, "bands: %s", bm_config.allband ? "all" : "own");
@@ -600,8 +609,8 @@ void show_spot_on_qrg(spot *data) {
  */
 void next_spot_position(int *y, int *x) {
     *y += 1;
-    if (*y == 24) {
-	*y = 14;
+    if (*y == LASTLINE + 1) {
+	*y = TOPLINE;
 	*x += SPOT_COLUMN_WIDTH;
     }
 }
@@ -727,8 +736,8 @@ void bandmap_show() {
 
     getyx(stdscr, cury, curx);		/* remember cursor */
 
-    /* start in line 14, column 0 */
-    bm_y = 14;
+    /* start in TOPLINE, column 0 */
+    bm_y = TOPLINE;
     bm_x = 0;
 
     /* clear space for bandmap */
@@ -738,7 +747,7 @@ void bandmap_show() {
     for (j = 0; j < 67; j++)
 	addch(' ');
 
-    for (i = bm_y + 1; i < bm_y + 10; i++) {
+    for (i = bm_y + 1; i < LASTLINE + 1; i++) {
 	move(i, 0);
 	for (j = 0; j < 80; j++)
 	    addch(' ');
@@ -784,18 +793,18 @@ void bandmap_show() {
 	unsigned int max_below;
 	unsigned int above_qrg = spots->len - below_qrg - on_qrg;
 
-	if (above_qrg < 14) {
-	    max_below = 30 - above_qrg - 1;
+	if (above_qrg < ((NR_SPOTS - 1)/2) ) {
+	    max_below = NR_SPOTS - above_qrg - 1;
 	} else
-	    max_below = 15;
+	    max_below = NR_SPOTS/2;
 
 	startindex = (below_qrg < max_below) ? 0 : (below_qrg - max_below);
     }
 
     /* calculate the index+1 of the last spot to show */
-    stopindex  = (spots->len < startindex + 30 - (1 - on_qrg))
+    stopindex  = (spots->len < startindex + NR_SPOTS - (1 - on_qrg))
 		 ? spots->len
-		 : (startindex + 30 - (1 - on_qrg));
+		 : (startindex + NR_SPOTS - (1 - on_qrg));
 
     /* correct calculations if we have no rig frequency to show */
     if (trx_control == 0) {

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -498,21 +498,21 @@ void bm_show_info() {
     /* show info field on the right */
     attrset(COLOR_PAIR(CB_DUPE) | A_BOLD);
     move(TOPLINE, 66);
-    vline(ACS_VLINE, 10);
+    vline(ACS_VLINE, LINES - TOPLINE -1);
 
-    mvprintw(18, 68, "bands: %s", bm_config.allband ? "all" : "own");
-    mvprintw(19, 68, "modes: %s", bm_config.allmode ? "all" : "own");
-    mvprintw(20, 68, "dupes: %s", bm_config.showdupes ? "yes" : "no");
-    mvprintw(21, 68, "onl.ml: %s", bm_config.onlymults ? "yes" : "no");
+    mvprintw(LASTLINE - 5, 67, " bands: %s", bm_config.allband ? "all" : "own");
+    mvprintw(LASTLINE - 4, 67, " modes: %s", bm_config.allmode ? "all" : "own");
+    mvprintw(LASTLINE - 3, 67, " dupes: %s", bm_config.showdupes ? "yes" : "no");
+    mvprintw(LASTLINE - 2, 67, " onl.ml: %s", bm_config.onlymults ? "yes" : "no");
 
     attrset(COLOR_PAIR(CB_NEW) | A_STANDOUT);
-    mvprintw(22, 69, "MULTI");
+    mvprintw(LASTLINE - 1, 67, "  MULTI");
 
     attrset(COLOR_PAIR(CB_NEW) | A_BOLD);
     printw(" NEW");
 
     attrset(COLOR_PAIR(CB_NORMAL));
-    mvprintw(23, 67, "SPOT");
+    mvprintw(LASTLINE, 67, "SPOT");
 
     attrset(COLOR_PAIR(CB_OLD));
     printw(" OLD");
@@ -862,7 +862,7 @@ void bm_menu() {
 
     attrset(COLOR_PAIR(C_LOG) | A_STANDOUT);
     mvprintw(13, 0, "  Toggle <B>and, <M>ode, <D>upes or <O>nly multi filter");
-    printw(" | any other - leave");
+    printw(" | any other - leave ");
 
     c = toupper(key_get());
     switch (c) {

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -161,7 +161,7 @@ int callinput(void) {
 
 
     int cury, curx;
-    int j, ii, t, x = 0;
+    int j, t, x = 0;
     char instring[2] = { '\0', '\0' };
     static int lastwindow;
 
@@ -674,20 +674,8 @@ int callinput(void) {
 		    cluster = CLUSTER;	// alt-A
 		    announcefilter = FILTER_ALL;
 		} else if (cluster == CLUSTER) {
-		    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-
-		    for (ii = 14; ii < 24; ii++)
-			mvprintw(ii, 0, backgrnd_str);
-		    refreshp();
-
 		    cluster = MAP;
 		} else if (cluster == MAP) {
-		    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-
-		    for (ii = 14; ii < 24; ii++)
-			mvprintw(ii, 0, backgrnd_str);
-		    refreshp();
-
 		    cluster = NOCLUSTER;
 		}
 

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -546,7 +546,7 @@ int callinput(void) {
 	    case '#': {
 		if (mem == 0.0) {
 		    mem = freq;
-		    mvprintw(14, 68, "MEM: %7.1f", mem);
+		    mvprintw(14, 68, "MEM: %7.1f", mem/1000.);
 		} else {
 		    freq = mem;
 

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -546,14 +546,14 @@ int callinput(void) {
 	    case '#': {
 		if (mem == 0.0) {
 		    mem = freq;
-		    mvprintw(14, 68, "MEM: %7.1f", mem/1000.);
+		    mvprintw(14, 67, " MEM: %7.1f", mem/1000.);
 		} else {
 		    freq = mem;
 
 		    set_outfreq(mem);
 
 		    mem = 0.0;
-		    mvprintw(14, 68, "            ");
+		    mvprintw(14, 67, "             ");
 		}
 		mvprintw(29, 12, " ");
 		mvprintw(29, 12, "");

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -64,6 +64,7 @@
 
 
 int debug_tty(void);
+void wipe_display();
 
 int changepars(void) {
 
@@ -716,7 +717,7 @@ int changepars(void) {
 
 /* -------------------------------------------------------------- */
 
-int networkinfo(void) {
+void networkinfo(void) {
 
     extern int use_bandoutput;
     extern int recv_packets;
@@ -733,15 +734,9 @@ int networkinfo(void) {
     extern char *rigportname;
     extern char logfile[];
 
-    int i, j, inode;
+    int inode;
 
-    clear();
-
-    attron(modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
-
-    for (j = 0; j <= 24; j++)
-	mvprintw(j, 0,
-		 "                                                                                ");
+    wipe_display();
 
     if (lan_active == 1)
 	mvprintw(1, 10, "Network status: on");
@@ -779,20 +774,13 @@ int networkinfo(void) {
 
     (void)key_get();
 
-    attron(modify_attr(COLOR_PAIR(C_LOG) | A_STANDOUT));
-    for (i = 0; i <= 24; i++)
-	mvprintw(i, 0,
-		 "                                                                                ");
-
     clear_display();
-
-    return (0);
-
+    return;
 }
 
 /* -------------------------------------------------------------- */
 
-int multiplierinfo(void) {
+void multiplierinfo(void) {
 
     extern int arrlss;
     extern int serial_section_mult;
@@ -803,13 +791,7 @@ int multiplierinfo(void) {
     int j, k, vert, hor, cnt, found;
     char mprint[50];
 
-    clear();
-
-    attron(modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
-
-    for (j = 0; j <= 24; j++)
-	mvprintw(j, 0,
-		 "                                                                                ");
+    wipe_display();
 
     if (arrlss == 1) {
 	int attributes;
@@ -904,16 +886,8 @@ int multiplierinfo(void) {
 
     (void)key_get();
 
-    attron(modify_attr(COLOR_PAIR(C_LOG) | A_STANDOUT));
-
-    for (j = 0; j <= 24; j++)
-	mvprintw(j, 0,
-		 "                                                                                ");
-
     clear_display();
-
-    return (0);
-
+    return;
 }
 
 /* ------------------------- radio link debug ------------------------------ */
@@ -1078,4 +1052,15 @@ int debug_tty(void) {
 	close(fdSertnc);
 
     return (0);
+}
+
+
+void wipe_display() {
+    int j;
+    extern char backgrnd_str[];
+
+    attron(modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
+
+    for (j = 0; j < LINES; j++)
+	mvprintw(j, 0, backgrnd_str);
 }

--- a/src/changepars.h
+++ b/src/changepars.h
@@ -24,8 +24,8 @@
 #define RITCLEAR 1
 
 int changepars(void);
-int networkinfo(void);
-int multiplierinfo(void);
+void networkinfo(void);
+void multiplierinfo(void);
 
 
 #endif /* end of include guard: CHANGEPARS_H */

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -37,6 +37,7 @@
 #include "tlf_curses.h"
 #include "ui_utils.h"
 
+extern int ymax;
 
 void clear_display(void) {
     extern char mode[];
@@ -151,7 +152,7 @@ void clear_display(void) {
     printcall();
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-    mvprintw(24, 0, backgrnd_str);
+    mvprintw(ymax-1, 0, backgrnd_str);
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
     mvprintw(cury, curx, "");

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -74,6 +74,15 @@ void clusterinfo(void) {
 
     mvprintw(12, 0, "");
 
+    if (cluster == NOCLUSTER) {
+	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
+
+	for (int i = 14; i < LINES-1; i++)
+	    mvprintw(i, 0, backgrnd_str);
+	refreshp();
+
+    }
+
     if (cluster == MAP) {
 
 	attron(COLOR_PAIR(C_WINDOW) | A_STANDOUT);
@@ -105,7 +114,7 @@ void clusterinfo(void) {
 
 	g_strlcpy(inputbuffer, backgrnd_str, 79);
 
-	for (j = 15; j <= 22; j++) {
+	for (j = 15; j <= LINES-3; j++) {
 	    mvprintw(j, 1, "%s", inputbuffer);
 	}
 
@@ -113,24 +122,20 @@ void clusterinfo(void) {
 	/** \todo minimize lock time */
 	pthread_mutex_lock(&spot_ptr_mutex);
 
-	getclusterinfo();
+	k = getclusterinfo();
 
-	k = 0;
-
-	while (spotarray[k] > -1) {
-	    k++;
-	    if (k > (MAX_SPOTS - 2))
-		break;
+	if (k > (MAX_SPOTS - 1)) {
+		k = MAX_SPOTS - 1;
 	}
 
-	k -= 9;
+	k -= (LINES-3 - 14) + 1;
 	if (k < 0)
 	    k = -1;
 
 
-	for (j = 15; j <= 22; j++) {
-
-	    if (k < (MAX_SPOTS - 2) && spotarray[++k] > -1) {
+	for (j = 15; j <= LINES-3; j++) {
+	    k++;
+	    if (k < (MAX_SPOTS - 1) && spotarray[k] > -1) {
 		if (k > MAX_SPOTS - 1)
 		    k = MAX_SPOTS - 1;
 
@@ -150,7 +155,7 @@ void clusterinfo(void) {
 
 	pthread_mutex_unlock(&spot_ptr_mutex);
 
-	nicebox(14, 0, 8, 78, "Cluster");
+	nicebox(14, 0, LINES-3 - 14, 78, "Cluster");
 	refreshp();
     }
     printcall();
@@ -414,43 +419,34 @@ int getclusterinfo(void) {
     while (1) {
 
 	if (strstr(spot_ptr[i], "DX de") != NULL) {
-
 	    spotarray[si] = i;
 	    si++;
-	    i++;
 
 	} else if (strstr(spot_ptr[i], calldupe) != NULL) {
 	    if ((announcefilter <= 2)) {
 		spotarray[si] = i;
 		si++;
-		i++;
-	    } else
-		i++;
+	    }
 
 	} else if (strstr(spot_ptr[i], "To ALL") != NULL) {
 	    if ((announcefilter <= 1)) {
 		spotarray[si] = i;
 		si++;
 	    }
-	    i++;
 
 	} else if ((announcefilter == 0)
 		   && (strlen(spot_ptr[i]) > 20)) {
-
 	    spotarray[si] = i;
 	    si++;
+	}
 
-	    i++;
-
-	} else
-	    i++;
+	i++;
 
 	if (i > (nr_of_spots - 1))
 	    break;
-
     }
 
-    return (si - 1);
+    return si;
 }
 
 

--- a/src/err_utils.c
+++ b/src/err_utils.c
@@ -24,6 +24,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#define YPOS (LINES - 1)
+
 void handle_logging(enum log_lvl lvl, ...) {
     char *fmt;
     char *str;
@@ -34,10 +36,10 @@ void handle_logging(enum log_lvl lvl, ...) {
     str = g_strdup_vprintf(fmt, args);
     va_end(args);
 
-    move(24,0);
+    move(YPOS, 0);
     for (int i = 0; i < 80; i++)
 	printw(" ");
-    mvprintw(24, 0, str);
+    mvprintw(YPOS, 0, str);
     refreshp();
 
     g_free(str);

--- a/src/err_utils.c
+++ b/src/err_utils.c
@@ -38,8 +38,8 @@ void handle_logging(enum log_lvl lvl, ...) {
     str = g_strdup_vprintf(fmt, args);
     va_end(args);
 
-    mvprintw(YPOS, 0, str);
     mvprintw(YPOS, 0, backgrnd_str);
+    mvprintw(YPOS, 0, str);
     refreshp();
 
     g_free(str);

--- a/src/getwwv.c
+++ b/src/getwwv.c
@@ -27,6 +27,10 @@
 #include "tlf.h"
 #include "tlf_curses.h"
 
+extern int ymax;
+
+#define YPOS (ymax -1)
+#define LINELENGTH 80
 
 int getwwv(void) {
 
@@ -45,9 +49,6 @@ int getwwv(void) {
 
     time_t now;
     struct tm *ptr1;
-
-    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-    mvprintw(24, 0, backgrnd_str);
 
     if (strlen(lastwwv) >= 2) {
 
@@ -97,7 +98,13 @@ int getwwv(void) {
 		strcat(printbuffer, "   AURORA!");
 
 	    strcpy(lastwwv, printbuffer);
-	    mvprintw(24, 0, lastwwv);	/* print WWV info  */
+
+
+	    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+	    mvprintw(YPOS, 0, backgrnd_str);
+
+	    mvprintw(YPOS, 0, printbuffer);	/* print WWV info  */
+	    printw(" ");
 
 	    d = dxcc_by_index(mycountrynr) -> timezone;
 
@@ -105,8 +112,7 @@ int getwwv(void) {
 	    ptr1 = gmtime(&now);
 	    strftime(timebuff, 80, "%H:%M", ptr1);
 
-	    printbuffer[0] = '\0';
-	    mvprintw(24, 64, "local time %s", timebuff);
+	    mvprintw(YPOS, LINELENGTH - 17, " local time %s", timebuff);
 	}
 
 	printcall();

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -109,7 +109,7 @@ static freq_t execute_grab(spot *data) {
 	cqmode = S_P;
 	strcpy(mode, "S&P     ");
 	mem = freq;
-	mvprintw(14, 68, "MEM: %7.1f", mem/1000.);
+	mvprintw(14, 67, " MEM: %7.1f", mem/1000.);
     }
 
     refreshp();

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -109,7 +109,7 @@ static freq_t execute_grab(spot *data) {
 	cqmode = S_P;
 	strcpy(mode, "S&P     ");
 	mem = freq;
-	mvprintw(14, 68, "MEM: %7.1f", mem);
+	mvprintw(14, 68, "MEM: %7.1f", mem/1000.);
     }
 
     refreshp();

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -88,6 +88,8 @@ int time_master;
 char thisnode = 'A'; 		/*  start with 'A' if not defined in
 				    logcfg.dat */
 
+extern char backgrnd_str[];
+
 //---------------------end lan globals --------------
 
 int resolveService(const char *service) {
@@ -336,14 +338,12 @@ int send_lan_message(int opcode, char *message) {
 }
 
 /* ----------------- send talk message ----------*/
-
-int talk(void) {
+void talk(void) {
 
     char talkline[61] = "";
 
-    mvprintw(24, 0,
-	     "                                                                           ");
-    mvprintw(24, 0, "T>");
+    mvprintw(LINES-1, 0, backgrnd_str);
+    mvprintw(LINES - 1, 0, "T>");
     refreshp();
     echo();
     getnstr(talkline, 60);
@@ -355,11 +355,8 @@ int talk(void) {
 
     talkline[0] = '\0';
     attron(COLOR_PAIR(C_HEADER));
-    mvprintw(24, 0,
-	     "                                                                               ");
+    mvprintw(LINES-1, 0, backgrnd_str);
     refreshp();
-
-    return (0);
 }
 
 /* ----------------- send freq. message ----------*/

--- a/src/lancode.h
+++ b/src/lancode.h
@@ -43,7 +43,7 @@ int lan_send_init(void);
 int lan_send_close(void);
 int lan_send(char *buffer) ;
 int send_lan_message(int opcode, char *message);
-int talk(void);
+void talk(void);
 int send_freq(freq_t freq);
 int send_time(void) ;
 

--- a/src/main.c
+++ b/src/main.c
@@ -950,7 +950,7 @@ int main(int argc, char *argv[]) {
 
     clear_display();		/* tidy up the display */
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-    for (j = 13; j <= 23; j++) {	/* wipe lower window */
+    for (j = 13; j <= ymax-1; j++) {	/* wipe lower window */
 	mvprintw(j, 0, backgrnd_str);
     }
     refreshp();

--- a/src/muf.c
+++ b/src/muf.c
@@ -154,6 +154,7 @@ int muf(void) {
     extern int mycountrynr;
     extern int countrynr;
     extern char lastwwv[];
+    extern char backgrnd_str[];
 
     dxcc_data *dx;
     int row;
@@ -171,7 +172,7 @@ int muf(void) {
     PANEL *pan;
     WINDOW *win;
 
-    win = newwin(25, 80, 0, 0);
+    win = newwin(LINES, 80, 0, 0);
     pan = new_panel(win);
 
     n = 0.0;
@@ -228,9 +229,8 @@ int muf(void) {
     wclear(win);
     wattron(win, modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
 
-    for (i = 0; i < 25; i++)
-	mvwprintw(win, i, 0,
-		  "                                                                                ");
+    for (i = 0; i < LINES; i++)
+	mvwprintw(win, i, 0, backgrnd_str);
 
     mvwprintw(win, 1, 40, "%s", country);
     mvwprintw(win, 1, 0, "        SSN: %3.0f ", r);
@@ -322,7 +322,6 @@ int muf(void) {
     }
     mvwprintw(win, 23, 0, " --- Press a key to continue --- ");
     refreshp();
-
     (void)key_get();
 
     hide_panel(pan);

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -125,7 +125,6 @@ void showinfo(int x) {
     getyx(stdscr, cury, curx);
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 
-#if 1
     mvprintw(YPOS, 0, backgrnd_str);
 
     if (contstr[0] != '-') {
@@ -141,27 +140,7 @@ void showinfo(int x) {
 
 	mvprintw(YPOS, LINELENGTH-17, "   DX time: %s", timebuff);
     }
-#else
-    if (contstr[0] != '-') {
-
-        mvprintw(YPOS, 0, " %-2s  %s             ", pxstr, countrystr);
-
-        mvprintw(YPOS, 26,
-                 " %s %s                                           ",
-                 contstr, zonestr);
-
-        if (x != 0 && x != mycountrynr && 0 == get_qrb(&range, &bearing)) {
-            mvprintw(YPOS, 35, "%.0f km/%.0f deg ", range, bearing);
-        }
-
-        mvprintw(YPOS, 64, "  DX time: %s", timebuff);
-
-    } else {
-        mvprintw(YPOS, 0, backgrnd_str);      // no valid info, clear line
-    }
-#endif
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
-
     mvprintw(cury, curx, "");
 }

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -43,6 +43,8 @@
 #include "tlf_curses.h"
 #include "ui_utils.h"
 
+#define YPOS (LINES - 1)
+#define LINELENGTH 80
 
 int showinfo(int x) {
 
@@ -122,18 +124,22 @@ int showinfo(int x) {
     getyx(stdscr, cury, curx);
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 
-    mvprintw(24, 0, " %s  %s             ", pxstr, countrystr);
+    move(YPOS, 0);
+    for (int i = 0; i < LINELENGTH; i++)
+	printw(" ");
 
-    mvprintw(24, 26,
-	     " %s %s                                           ",
+    mvprintw(YPOS, 0, " %s  %s", pxstr, countrystr);
+
+    mvprintw(YPOS, 26,
+	     " %s %s",
 	     contstr, zonestr);
 
     if (x != 0 && x != mycountrynr) {
 	qrb_(&range, &bearing);
-	mvprintw(24, 35, "%.0f km/%.0f deg ", range, bearing);
+	mvprintw(YPOS, 35, "%.0f km/%.0f deg ", range, bearing);
     }
 
-    mvprintw(24, 64, "  DX time: %s", timebuff);
+    mvprintw(YPOS, LINELENGTH-17, "   DX time: %s", timebuff);
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -48,6 +48,9 @@
 #include "tlf_curses.h"
 #include "tlf_panel.h"
 #include "ui_utils.h"
+#include "err_utils.h"
+
+extern char backgrnd_str[];
 
 struct tln_logline {
     struct tln_logline *next;
@@ -113,7 +116,7 @@ void addlog(char *s) {
 
 	if (clusterlog == 1) {
 	    if ((fp = fopen("clusterlog", "a")) == NULL) {
-		mvprintw(24, 0, "Opening clusterlog not possible.");
+		TLF_LOG_INFO("Opening clusterlog not possible.");
 	    } else {
 		if (strlen(lastmsg) > 20) {
 		    fputs(lastmsg, fp);
@@ -648,14 +651,13 @@ void addtext(char *s) {
     if (strncmp(s, call, strlen(call) - 1) == 0
 	    && strlen(s) < 81 && strchr(s, '>') == NULL) {
 
-	mvprintw(24, 0,
-		 "                                                                                ");
+	mvprintw(LINES - 1, 0, backgrnd_str);
 
 	if ((strlen(s) + strlen(call) + 3) < 80) {
 	    strcpy(dxtext, s + strlen(call) + 3);
 	    if (dxtext[strlen(dxtext) - 1] == '\n')
 		dxtext[strlen(dxtext) - 1] = '\0';	// remove the newline
-	    mvprintw(24, 0, dxtext);
+	    mvprintw(LINES - 1, 0, dxtext);
 	    mvprintw(12, 29, hiscall);
 	}
 	refreshp();
@@ -1240,9 +1242,8 @@ int send_cluster(void) {
     char line[MAX_CMD_LEN + 2] = "";
 
     cluster = CLUSTER;
-    mvprintw(24, 0,
-	     "                                                                           ");
-    mvprintw(24, 0, ">");
+    mvprintw(LINES - 1, 0, backgrnd_str);
+    mvprintw(LINES - 1, 0, ">");
     refreshp();
     echo();
     getnstr(line, MAX_CMD_LEN);
@@ -1262,8 +1263,7 @@ int send_cluster(void) {
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 
-    mvprintw(24, 0,
-	     "                                                                           ");
+    mvprintw(LINES - 1, 0, backgrnd_str);
     refreshp();
     line[0] = '\0';	/* not needed */
 

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -567,6 +567,10 @@ void setup_splitlayout() {
 }
 
 void refresh_splitlayout() {
+    if (!initialized) {
+	return;
+    }
+
     WINDOW* oldwin = packet_win;
 
     packet_win = newwin(LINES, COLS, 0, 0);

--- a/src/splitscreen.h
+++ b/src/splitscreen.h
@@ -26,6 +26,7 @@ int packet(void);
 int send_cluster(void);
 void addtext(char *s);
 int receive_packet(void);
+void refresh_splitlayout();
 
 
 #ifdef SPLITSCREEN_H_PRIVATE

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -101,12 +101,12 @@ void show_freq(void) {
 	attron(modify_attr(COLOR_PAIR(C_LOG)));
 
 	if ((showfreq == 0) || (showscore_flag == 1))
-	    mvprintw(13, 68, "TRX: %7.1f", freq / 1000.0);
+	    mvprintw(13, 67, " TRX: %7.1f", freq / 1000.0);
 
 	if (mem > 0.0)
-	    mvprintw(14, 68, "MEM: %7.1f", mem / 1000.0);
+	    mvprintw(14, 67, " MEM: %7.1f", mem / 1000.0);
 	else
-	    mvprintw(14, 68, "            ");
+	    mvprintw(14, 67, "             ");
 
 	if ((showfreq == 1) && (showscore_flag == 0)) {
 

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -96,9 +96,9 @@ void show_freq(void) {
     extern int trx_control;
     extern freq_t freq;
 
-    if (trx_control == 1) {
+    attron(modify_attr(COLOR_PAIR(C_LOG)));
 
-	attron(modify_attr(COLOR_PAIR(C_LOG)));
+    if (trx_control == 1) {
 
 	if ((showfreq == 0) || (showscore_flag == 1))
 	    mvprintw(13, 67, " TRX: %7.1f", freq / 1000.0);
@@ -112,6 +112,10 @@ void show_freq(void) {
 
 	    freq_display();
 	}
+    }
+    else {
+	mvprintw(13, 67, "             ");
+	mvprintw(14, 67, "             ");
     }
 }
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -29,6 +29,7 @@
 
 
 extern int use_rxvt;
+extern int ymax, xmax;
 
 int key_kNXT3 = 0;
 int key_kPRV3 = 0;
@@ -140,6 +141,9 @@ static int getkey(int wait) {
     nodelay(stdscr, wait ? FALSE : TRUE);
 
     x = onechar();
+
+    if (x == KEY_RESIZE)
+	getmaxyx(stdscr, ymax, xmax);
 
     nodelay(stdscr, FALSE);
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -23,6 +23,8 @@
 #include <pthread.h>
 #include <unistd.h>
 
+#include "bandmap.h"
+#include "clear_display.h"
 #include "stoptx.h"
 #include "tlf_panel.h"
 #include "startmsg.h"
@@ -142,8 +144,11 @@ static int getkey(int wait) {
 
     x = onechar();
 
-    if (x == KEY_RESIZE)
+    if (x == KEY_RESIZE) {
 	getmaxyx(stdscr, ymax, xmax);
+	clear_display();
+	bandmap_show();
+    }
 
     nodelay(stdscr, FALSE);
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -28,6 +28,7 @@
 #include "stoptx.h"
 #include "tlf_panel.h"
 #include "startmsg.h"
+#include "splitscreen.h"
 
 
 extern int use_rxvt;
@@ -42,7 +43,7 @@ pthread_mutex_t panel_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static int getkey(int wait);
 static int onechar(void);
-
+void resize_layout(void);
 
 /** fake refresh code to use update logic for panels */
 void refreshp() {
@@ -145,9 +146,7 @@ static int getkey(int wait) {
     x = onechar();
 
     if (x == KEY_RESIZE) {
-	getmaxyx(stdscr, ymax, xmax);
-	clear_display();
-	clusterinfo();
+	resize_layout();
     }
 
     nodelay(stdscr, FALSE);
@@ -326,4 +325,16 @@ static int onechar(void) {
     }
 
     return x;
+}
+
+
+/* Handles resizing of windows
+ * As ncurses handles most of it itself, it just redraws the main
+ * display and resizes only the packet panel windows
+ */
+void resize_layout(void) {
+    	getmaxyx(stdscr, ymax, xmax);
+	clear_display();
+	clusterinfo();
+	refresh_splitlayout();
 }

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -23,8 +23,8 @@
 #include <pthread.h>
 #include <unistd.h>
 
-#include "bandmap.h"
 #include "clear_display.h"
+#include "clusterinfo.h"
 #include "stoptx.h"
 #include "tlf_panel.h"
 #include "startmsg.h"
@@ -147,7 +147,7 @@ static int getkey(int wait) {
     if (x == KEY_RESIZE) {
 	getmaxyx(stdscr, ymax, xmax);
 	clear_display();
-	bandmap_show();
+	clusterinfo();
     }
 
     nodelay(stdscr, FALSE);

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -36,6 +36,7 @@ void lookup_keys();
 
 int key_get();
 int key_poll();
+void resize_layout();
 
 
 #endif /* UI_UTILS_H */

--- a/test/test_clusterinfo.c
+++ b/test/test_clusterinfo.c
@@ -11,6 +11,9 @@
 // OBJECT ../src/get_time.o
 // OBJECT ../src/err_utils.o
 
+
+int LINES=25;   /* test for 25 lines */
+
 long timecorr;
 int getctynr(char *checkcall) {
     return 0;


### PR DESCRIPTION
Enables vertical resizing of TLFs display.

You can resize the terminal before the start of TLF and also during it is working. Resize should work in the main panel and in the packet window. Resize during display of multis, propagation infos and during scroll in packet window results simple in a stop of that display and return to the normal main or packet display.

Vertical resize should be working down to 23 lines without problems. Making it smaller will result in a distorted display. 

The code could need some testing before merge. Please report back. Thanks.