### PR TITLE
Do not highlight exch field on CQ<->S&P

### DIFF
--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -48,8 +48,10 @@ int cleanup(void) {
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
     mvprintw(12, 29, "            ");
-    mvprintw(12, 54, "                        ");
     mvprintw(12, 29, "");
+
+    attron(COLOR_PAIR(C_WINDOW));
+    mvprintw(12, 54, "                        ");
 
     attron(COLOR_PAIR(C_LOG | A_STANDOUT));
 


### PR DESCRIPTION
Upon CQ<->S&P switch (`+` key) exchange field gets unnecessarily highlighted. 
Before switch:
![Screenshot - 06142019 - 10:27:34 PM](https://user-images.githubusercontent.com/15141948/59539387-5bd3fb80-8efd-11e9-9cf6-22925c162ee2.png)
After switch:
![Screenshot - 06142019 - 10:28:21 PM](https://user-images.githubusercontent.com/15141948/59539504-cd13ae80-8efd-11e9-9e22-2c3cc80d46b8.png)

This fix removes exch highlighting.

_A side note:_ CQ<->S&P switch is only possible if callsign field is empty. This can cause a problem if one forgets to switch to CQ/S&P and realizes it only after having entered a call. Then one has to remember the already typed call, delete it, do the switch and re-type (correctly!) the call.
I see no reason why a switch couldn't be allowed even if callsign field is non-empty.
 
