### PR TITLE
Fix frequency adjustment function (Ctrl-F)

### DIFF
--- a/src/changefreq.c
+++ b/src/changefreq.c
@@ -33,7 +33,6 @@ void change_freq(void) {
     extern int trx_control;
 
     int brkflg = 0;
-    int x;
 
     if (trx_control == 0)
 	return;
@@ -46,7 +45,7 @@ void change_freq(void) {
 
 	if (get_outfreq() == 0) {
             // last request has been processed, check keys again
-	    x = key_get();
+	    int x = key_poll();
 
 	    int deltaf = 0;
 
@@ -88,6 +87,11 @@ void change_freq(void) {
 		    break;
 		}
 
+                // no key
+                case ERR: {
+		    break;
+                }
+
                 // any other key: exit frequency change mode
 		default: {
 		    brkflg = 1;
@@ -105,9 +109,10 @@ void change_freq(void) {
 	    break;
 	}
 
-	freq_display();
 
 	time_update();
+
+	freq_display();
 
 	usleep(100 * 1000);
 

--- a/src/freq_display.c
+++ b/src/freq_display.c
@@ -24,38 +24,38 @@
 #include "tlf.h"
 #include "ui_utils.h"
 
+static void print_dot(int y, int x);
+static void clear_freq_display(int y, int x);
+static void print_big_number(int number, int y_position, int x_position, int location);
 
-int freq_display(void) {
+void freq_display(void) {
 
     extern freq_t freq;
     extern int trxmode;
 
-    int x_position = 40;
-    int y_position = 17;
-    char fbuffer[8];
+    const int x_position = 40;
+    const int y_position = 17;
 
-    print_space(y_position, x_position);
-    print_space(y_position + 1, x_position);
-    print_space(y_position + 2, x_position);
-    print_space(y_position + 3, x_position);
-    print_space(y_position + 4, x_position);
+    clear_freq_display(y_position, x_position);
     nicebox(16, 39, 5, 35, "TRX");
     print_dot(y_position + 4, 28 + x_position + 1);
 
+    char fbuffer[8];
     sprintf(fbuffer, "%7.1f", freq / 1000.0);
 
-    if (fbuffer[0] != ' ')
-	print_big_number(fbuffer[0] - 48, y_position, x_position, 4);
-    if (fbuffer[1] != ' ')
-	print_big_number(fbuffer[1] - 48, y_position, x_position, 9);
-    if (fbuffer[2] != ' ')
-	print_big_number(fbuffer[2] - 48, y_position, x_position, 14);
-    if (fbuffer[3] != ' ')
-	print_big_number(fbuffer[3] - 48, y_position, x_position, 19);
-    if (fbuffer[4] != ' ')
-	print_big_number(fbuffer[4] - 48, y_position, x_position, 24);
-    if (fbuffer[6] != ' ')
-	print_big_number(fbuffer[6] - 48, y_position, x_position, 31);
+    // display the digits
+    int x_offset = 4;
+    for(int i = 0; i <= 6; ++i) {
+        if (i == 5) {   // skip decimal dot
+            x_offset += 2;
+            continue;
+        }
+        const int digit = fbuffer[i] - '0';
+        if (digit >= 0) {
+            print_big_number(digit, y_position, x_position, x_offset);
+        }
+        x_offset += 5;
+    }
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 
@@ -67,11 +67,10 @@ int freq_display(void) {
 	mvprintw(19, 41, "DIG");
 
     refreshp();
-
-    return (0);
 }
 
-int print_big_number(int number, int y_position, int x_position,
+
+void print_big_number(int number, int y_position, int x_position,
 		     int location) {
 
     switch (number) {
@@ -254,25 +253,23 @@ int print_big_number(int number, int y_position, int x_position,
 	}
 
     }
-    refreshp();
 
-    return (0);
 }
 
-int print_dot(int y, int x) {
+void print_dot(int y, int x) {
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
     mvprintw(y, x, " ");
 
-    return (0);
 }
 
-int print_space(int y, int x) {
+void clear_freq_display(int y, int x) {
 
     attroff(A_STANDOUT);
     attron(modify_attr(COLOR_PAIR(C_LOG)));
 
-    mvprintw(y, x, "                                   ");
+    for(int i = 0; i < 5; ++i) {
+        mvprintw(y + i, x, "                                   ");
+    }
 
-    return (0);
 }

--- a/src/freq_display.h
+++ b/src/freq_display.h
@@ -21,9 +21,6 @@
 #ifndef FREQ_DISPLAY_H
 #define FREQ_DISPLAY_H
 
-int freq_display(void);
-int print_dot(int y, int x);
-int print_space(int y, int x);
-int print_big_number(int number, int y_position, int x_position, int location);
+void freq_display(void);
 
 #endif /* FREQ_DISPLAY_H */


### PR DESCRIPTION
The issue with Ctrl-F is that as it waits for a key press between the updates the 3  frequency values (shown in big digits, the normal TRX display, and the actual one on the rig) can get quite out of sync. I was able to produce a state when all 3 were different by pressing `Up` twice in short succession. This can be rather annoying when one is operating remotely, without actually seeing the rig. Of course after leaving frequency adjustment things sync up but the resulting frequency can be different from the one "set" in Ctrl-F.

The main fix is to replace `key_get()` with `key_poll()`. In order to avoid flickering the order of `freq_display()` and `time_update()` was reversed.
Minor code cleanup was done in `freq_display.c`.

Ctrl-F is now completely live in the sense that it also takes over freq changes from the rig. The cluster display below Ctrl-F is also updated and the displayed values are all in sync. For TRX there is a delay of 1 sec but that's tolerable as it's the normal behavior.