### PR TITLE
Fix keyer clearing exchange field

### DIFF
--- a/src/callinput.c
+++ b/src/callinput.c
@@ -106,9 +106,8 @@ int callinput(void) {
     extern int early_started;
     extern char hiscall_sent[];
     extern char comment[];
-    extern int cqmode;
+    extern cqmode_t cqmode;
     extern int trxmode;
-    extern char mode[];
     extern char lastcall[];
     extern int cqdelay;
     extern char his_rst[];
@@ -294,15 +293,7 @@ int callinput(void) {
 			cqmode = CQ;
 
 		    /* and show new mode */
-		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-
-		    if (cqmode == CQ) {
-			mvprintw(0, 2, "Log     ");
-			strcpy(mode, "Log     ");
-		    } else {
-			mvprintw(0, 2, "S&P     ");
-			strcpy(mode, "S&P     ");
-		    }
+		    show_header_line();
 
 		} else {
 
@@ -589,7 +580,7 @@ int callinput(void) {
 	    case KEY_F(1): {
 		if (trxmode == CWMODE || trxmode == DIGIMODE) {
 
-		    if (cqmode == 0) {
+		    if (cqmode == S_P) {
 			sendspcall();
 		    } else {
 			send_standard_message(0);	/* CQ */
@@ -601,7 +592,7 @@ int callinput(void) {
 		    }
 		} else {
 
-		    if (cqmode == 0)
+		    if (cqmode == S_P)
 			play_file(ph_message[5]);	/* S&P */
 		    else
 			play_file(ph_message[0]);
@@ -746,7 +737,7 @@ int callinput(void) {
 		    if (x == 240)	// Alt-P (M-p)
 			netkeyer(K_PTT, "0");	// ptt off
 		    k_ptt = 0;
-		    mvprintw(0, 2, "%s", mode);
+		    show_header_line();
 		    refreshp();
 		} else
 		    netkeyer(K_PTT, "0");	// ptt off in any case.
@@ -772,14 +763,14 @@ int callinput(void) {
 
 		while (count != 0) {
 		    usleep(250000);
-		    if ((key_poll()) != -1)	// any key pressed ?
+		    if (key_poll() != -1)	// any key pressed ?
 			break;
 		    count--;
 		}
 
 		netkeyer(K_ABORT, "");	// cw abort
 
-		mvprintw(0, 2, "%s", mode);
+		show_header_line();
 		refreshp();
 
 		break;
@@ -915,8 +906,7 @@ int callinput(void) {
 		if (f > 0.0) {
 		    grab.state = IN_PROGRESS;
 		    grab.spotfreq = f;
-		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-		    mvprintw(0, 2, "%s", mode);
+		    show_header_line();
 		    freqstore = 0;
 		}
 
@@ -929,8 +919,7 @@ int callinput(void) {
 		if (f > 0.0) {
 		    grab.state = IN_PROGRESS;
 		    grab.spotfreq = f;
-		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-		    mvprintw(0, 2, "%s", mode);
+		    show_header_line();
 		    freqstore = 0;
 		}
 

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -95,7 +95,7 @@ int changepars(void) {
     extern char sc_volume[];
     extern int cwstart;
     extern int digikeyer;
-    extern int cqmode;
+    extern cqmode_t cqmode;
 
     char parameterstring[20] = "";
     char parameters[52][19];

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -38,10 +38,35 @@
 #include "ui_utils.h"
 
 
-void clear_display(void) {
-    extern char mode[];
+void show_header_line() {
+    extern cqmode_t cqmode;
     extern int cqdelay;
     extern char headerline[];
+
+    char *mode = "";
+    switch (cqmode) {
+	case CQ:
+	    mode = "Log";
+	    break;
+	case S_P:
+	    mode = "S&P";
+	    break;
+	case AUTO_CQ:
+	    mode = "AUTO_CQ";
+	    break;
+	case KEYBOARD:
+	    mode = "Keyboard";
+	    break;
+    }
+
+    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+    mvprintw(0, 0, "                             ");
+    mvprintw(0, 0, "  %-8s  S=%2i D=%i ", mode, GetCWSpeed(), cqdelay);
+    mvprintw(0, 21, headerline);
+}
+
+
+void clear_display(void) {
     extern char terminal1[];
     extern char terminal2[];
     extern char terminal3[];
@@ -64,17 +89,11 @@ void clear_display(void) {
     extern int no_rst;
 
     char time_buf[80];
-    char speedbuf[4] = "  ";
     int cury, curx;
-
-    snprintf(speedbuf, 3, "%2u", GetCWSpeed());
 
     getyx(stdscr, cury, curx);
 
-    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-    mvprintw(0, 0, "                             ");
-    mvprintw(0, 0, "  %s  S=%s D=%i ", mode, speedbuf, cqdelay);
-    mvprintw(0, 21, headerline);
+    show_header_line();
 
     attron(modify_attr(COLOR_PAIR(C_LOG) | A_STANDOUT));
     mvaddstr(1, 0, terminal1);

--- a/src/clear_display.h
+++ b/src/clear_display.h
@@ -21,6 +21,7 @@
 #ifndef CLEAR_DISPLAY_H
 #define CLEAR_DISPLAY_H
 
+void show_header_line(void);
 void clear_display(void);
 
 #endif /* CLEAR_DISPLAY_H */

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -73,7 +73,7 @@ freq_t grab_next(void) {
     data = bandmap_next(dir, freq);
 
     if (data == NULL) {		/* nothing in that direction */
-				/* try other one */
+	/* try other one */
 	dir = 1 - dir;
 	data = bandmap_next(dir, freq);
     }
@@ -90,8 +90,7 @@ freq_t grab_next(void) {
  */
 static freq_t execute_grab(spot *data) {
     extern char hiscall[];
-    extern char mode[];
-    extern int cqmode;
+    extern cqmode_t cqmode;
     extern freq_t mem;
     extern freq_t freq;
 
@@ -107,7 +106,6 @@ static freq_t execute_grab(spot *data) {
     /* if in CQ mode switch to S&P and remember QRG */
     if (cqmode == CQ) {
 	cqmode = S_P;
-	strcpy(mode, "S&P     ");
 	mem = freq;
 	mvprintw(14, 67, " MEM: %7.1f", mem / 1000.);
     }

--- a/src/keyer.h
+++ b/src/keyer.h
@@ -21,6 +21,6 @@
 #ifndef KEYER_H
 #define KEYER_H
 
-int keyer(void);
+void keyer(void);
 
 #endif /* end of include guard: KEYER_H */

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -59,7 +59,7 @@ int log_to_disk(int from_lan) {
     extern char lan_logline[];
     extern int rit;
     extern int trx_control;
-    extern int cqmode;
+    extern cqmode_t cqmode;
     extern int block_part;
     extern char lan_message[];
     extern char thisnode;
@@ -84,7 +84,7 @@ int log_to_disk(int from_lan) {
 	    addspot();		/* add call to bandmap if in S&P and
 				   no need to ask for frequency */
 
-	strncpy(last_rst, his_rst, sizeof(last_rst)); /* remember last report */
+	strcpy(last_rst, his_rst); /* remember last report */
 
 	cleanup_qso();		/* reset qso related parameters */
     } else {			// qso from lan

--- a/src/logit.c
+++ b/src/logit.c
@@ -49,10 +49,9 @@ void refresh_comment(void);
 void change_mode(void);
 
 void logit(void) {
-    extern char mode[];
     extern int trxmode;
     extern char hiscall[];
-    extern int cqmode;
+    extern cqmode_t cqmode;
     extern int contest;
     extern char ph_message[14][80];
     extern char comment[];
@@ -73,7 +72,6 @@ void logit(void) {
     int cury, curx;
     int qrg_out = 0;
 
-    strcpy(mode, "Log     ");
     clear_display();
     defer_store = 0;
 
@@ -230,8 +228,7 @@ void refresh_comment(void) {
 }
 
 void change_mode(void) {
-    extern char mode[];
-    extern int cqmode;
+    extern cqmode_t cqmode;
 
     /* switch to other mode */
     if (cqmode == CQ) {
@@ -241,13 +238,5 @@ void change_mode(void) {
     }
 
     /* and show new mode */
-    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-
-    if (cqmode == CQ) {
-	mvprintw(0, 2, "Log     ");
-	strcpy(mode, "Log     ");
-    } else {
-	mvprintw(0, 2, "S&P     ");
-	strcpy(mode, "S&P     ");
-    }
+    show_header_line();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -197,7 +197,7 @@ int cluster = NOCLUSTER;	/* 0 = OFF, 1 = FOLLOW, 2  = spots  3 = all */
 int clusterlog = 0;		/* clusterlog on/off */
 int searchflg = 0;		/* 1  = display search  window */
 int show_time = 0;
-int cqmode = CQ;		/* 1  = CQ  0 = S&P  */
+cqmode_t cqmode = CQ;
 int demode = 0;			/* 1 =  send DE  before s&p call  */
 int contest = 0;		/* 0 =  General,  1  = contest */
 int announcefilter = FILTER_ANN; /*  filter cluster  announcements */
@@ -281,7 +281,6 @@ char qsonrstr[5] = "0001";
 char band[NBANDS][4] =
 { "160", " 80", " 40", " 30", " 20", " 17", " 15", " 12", " 10", "???" };
 char comment[80];
-char mode[20] = "Log     ";
 char cqzone[3] = "";
 char mycqzone[3] = "";
 char ituzone[3] = "";
@@ -420,9 +419,9 @@ freq_t bandfrequency[NBANDS] = {
     28025000, 0.
 };
 
-char headerline[81] =
-    "   1=CQ  2=DE  3=RST 4=73  5=HIS  6=MY  7=B4   8=AGN  9=?  \n";
-char backgrnd_str[81] =
+const char headerline[] =
+    "   1=CQ  2=DE  3=RST 4=73  5=HIS  6=MY  7=B4   8=AGN  9=?  ";
+const char backgrnd_str[81] =
     "                                                                                ";
 
 char logline_edit[5][LOGLINELEN + 1];
@@ -657,7 +656,7 @@ int databases_load() {
 
     if (*call == '\0') {
 	showmsg
-	    ("WARNING: No callsign defined in logcfg.dat! exiting...\n");
+	("WARNING: No callsign defined in logcfg.dat! exiting...\n");
 	return EXIT_FAILURE;
     }
 
@@ -837,22 +836,14 @@ void show_GPL() {
     printw("             T    L      FFFFF\n");
     printw("             T    L      F    \n");
     printw("             T    LLLLL  F    \n");
-    printw
-	("\n\nThis program is copyright 2002, 2003, 2004 by Rein Couperus, PA0R\n\n");
-    printw
-	("It is free software; you can redistribute it and/or modify it under the terms\n");
-    printw
-	("of the GNU General Public License as published by the Free Software Foundation;\n");
-    printw
-	("either version 2 of the License, or (at your option) any later version.\n\n");
-    printw
-	("This program is distributed in the hope that it will be useful, but\n");
-    printw
-	("WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY\n");
-    printw
-	("or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License\n");
-    printw
-	("for more details.\n");
+    printw("\n\nThis program is copyright 2002, 2003, 2004 by Rein Couperus, PA0R\n\n");
+    printw("It is free software; you can redistribute it and/or modify it under the terms\n");
+    printw("of the GNU General Public License as published by the Free Software Foundation;\n");
+    printw("either version 2 of the License, or (at your option) any later version.\n\n");
+    printw("This program is distributed in the hope that it will be useful, but\n");
+    printw("WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY\n");
+    printw("or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License\n");
+    printw("for more details.\n");
 
     refreshp();
 }

--- a/src/printcall.c
+++ b/src/printcall.c
@@ -31,7 +31,7 @@
 void printcall(void) {
     extern char hiscall[];
     extern int miniterm;
-    extern int cqmode;
+    extern cqmode_t cqmode;
     extern int cwstart;
 
     int currentterm;
@@ -58,8 +58,8 @@ void printcall(void) {
  */
 void highlightCall(unsigned int n) {
     attr_t attrib = modify_attr(A_NORMAL);
-				/* use NORMAL here as normal display
-				   uses STANDOUT */
+    /* use NORMAL here as normal display
+       uses STANDOUT */
 
     mvchgat(12, 29, n, attrib, C_INPUT, NULL);
 }

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -202,9 +202,9 @@ void ExpandMacro(void) {
     }
 
 
-    strncpy(rst_out, his_rst, 4);
-    rst_out[1] = short_number(rst_out[1]);
-    rst_out[2] = short_number(rst_out[2]);
+    rst_out[0] = his_rst[0];
+    rst_out[1] = short_number(his_rst[1]);
+    rst_out[2] = short_number(his_rst[2]);
     rst_out[3] = '\0';
 
     replace_all(buffer, BUFSIZE, "[", rst_out);   /* his RST */

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -49,8 +49,12 @@
 
 #define SEARCHWINDOW 1  /* searchflg on */
 
-#define CQ 1			/* cqmode   on */
-#define S_P 0			/* S&P mode  on  */
+typedef enum {
+    CQ,         // Run
+    S_P,        // Search and Pounce
+    AUTO_CQ,    // temporary, used in autocq.c
+    KEYBOARD    // temporary, used in keyer.c
+} cqmode_t;
 
 #define SEND_DE 1		/* de_mode on */
 #define CONTEST 1		/* contest mode on */
@@ -126,8 +130,8 @@ enum {
 #define LOGLINELEN (88)		/* Length of logline in logfile
 				   (including linefeed) */
 #define MINITEST_DEFAULT_PERIOD 600
-				/* ignore dupe state when MINITEST is set
-				 * and last QSO was not in actual period */
+/* ignore dupe state when MINITEST is set
+ * and last QSO was not in actual period */
 
 /* special message numbers */
 enum {

--- a/src/write_keyer.h
+++ b/src/write_keyer.h
@@ -22,7 +22,8 @@
 #define WRITE_KEYER_H
 
 void keyer_append(const char *string);
+void keyer_append_char(const char c);
 void keyer_flush();
-int write_keyer(void);
+void write_keyer(void);
 
 #endif /* WRITE_KEYER_H */

--- a/test/data.c
+++ b/test/data.c
@@ -146,7 +146,7 @@ int cluster = NOCLUSTER;	/* 0 = OFF, 1 = FOLLOW, 2  = spots  3 = all */
 int clusterlog = 0;		/* clusterlog on/off */
 int searchflg = 0;		/* 1  = display search  window */
 int show_time = 0;
-int cqmode = CQ;		/* 1  = CQ  0 = S&P  */
+cqmode_t cqmode = CQ;
 int demode = 0;			/* 1 =  send DE  before s&p call  */
 int contest = 0;		/* 0 =  General,  1  = contest */
 int announcefilter = FILTER_ANN; /*  filter cluster  announcements */


### PR DESCRIPTION
It started as a quick fix for keyer clearing exchange field which could be quite annoying when one needs that info for e.g. asking confirmation.
Example:
![image](https://user-images.githubusercontent.com/15141948/69080175-bc7edb80-0a3b-11ea-92a2-30fac8485d3d.png)
after pressing Ctrl-K 123 is gone. At least it is restored once keyer window is closed.
![image](https://user-images.githubusercontent.com/15141948/69080198-c99bca80-0a3b-11ea-9b9b-f1b1bd22d39b.png)

The solution seemed to be simply removing `clear_display()` from `keyer.c`. But it caused further issues so at the end the update of the header row was separated into `update_header_line()`. This allowed getting rid of `mode` and its settings scattered all around the code. Introduced `cqmode_t` for mode values.

Bonus: search window doesn't overlap keyer widow after Fx keys or PgUp/PgDn/Backspace.

As already touched, `autocq.c` has been refactored.

Introduced `keyer_append_char()` to avoid locally fiddling with 2-byte char arrays.

A minor fix in `write_keyer()`: if called with an empty string and using `digikeyer == GMFSK` then an array access at index -1 would happen. (both conditions are quite unlikely...)   Added an early exit if there is nothing to send.

Changed come "cryptic" constants as in `case 125:` to characters and switched to `toupper()` instead of the unreadable `if`.

Astyle formatting changed some comments. Perhaps the comments should be also improved.
