### PR TITLE
Fix warnings

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -26,6 +26,7 @@
 
 #include <dirent.h>
 #include <errno.h>
+#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -214,7 +215,7 @@ void record(void) {
 				i = 10;
 				j++;
 			    }
-			    strncpy(printname, soundfilename->d_name, 6);
+			    g_strlcpy(printname, soundfilename->d_name, 7);
 			    mvprintw(j, i, "%s", printname);
 			    refreshp();
 

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -189,10 +189,10 @@ int loadbandmap(void) {
     char spotcall[20];
     char spottime[6];
     char spotline[38];
-    char callcopy[81];
+    char callcopy[20];
     FILE *fp;
     char marker_out[60];
-    char color[20];
+    char color[sizeof("Magenta")];
     int lon;
     int lat;
     int zz;

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -225,7 +225,7 @@ int loadbandmap(void) {
 
     for (j = 0; j < nr_of_spots; j++) {
 
-	strncpy(thisline, spot_ptr[j], 82);
+	g_strlcpy(thisline, spot_ptr[j], sizeof(thisline));
 	if (strncmp(thisline, "DX de ", 6) == 0) {
 
 	    g_strlcpy(spotcall, thisline + 26, 6);

--- a/src/dxcc.h
+++ b/src/dxcc.h
@@ -25,8 +25,8 @@
 
 typedef struct {
     char *pfx;
-    short cq;
-    short itu;
+    unsigned short cq;
+    unsigned short itu;
     short dxcc_index;
     float lat;
     float lon;
@@ -37,8 +37,8 @@ typedef struct {
 
 typedef struct {
     char *countryname;
-    short cq;
-    short itu;
+    unsigned short cq;
+    unsigned short itu;
     char *continent;
     float lat;
     float lon;

--- a/src/genqtclist.c
+++ b/src/genqtclist.c
@@ -52,7 +52,7 @@ int genqtclist(char *callsign, int nrofqtc) {
     qtclist.marked = 0;
     qtclist.totalsent = 0;
     qtclist.count = 0;
-    strncpy(qtclist.callsign, callsign, strlen(callsign));
+    g_strlcpy(qtclist.callsign, callsign, sizeof(qtclist.callsign));
     for (s = 0; s < qtclistlen; s++) {
 	qtclist.qtclines[s].qtc[0] = '\0';
 	qtclist.qtclines[s].flag = 0;

--- a/src/genqtclist.c
+++ b/src/genqtclist.c
@@ -118,17 +118,21 @@ void genqtcline(char *qtc, char *qsoline) {
     }
 
     /* add finally 3 or 4 digit exchange */
-    strncpy(tstring, qsoline + 54, 4);
+    g_strlcpy(tstring, qsoline + 54, sizeof(tstring));
     nr = atoi(tstring);
     // 3 digit
-    if (nr < 1000) {
+    if ((nr >= 0) && (nr < 1000)) {
 	sprintf(tstring, "%03d ", nr);
     }
     // 4 digit
-    else {
+    else if ((nr >= 0) && (nr < 10000)) {
 	sprintf(tstring, "%d", nr);
+    } else {
+    // ignore all other exchange values
+	strcpy(tstring, "    ");
     }
-    strncpy(qtc + qpos, tstring, strlen(tstring));
+
+    strcpy(qtc + qpos, tstring);
     qpos += 4;
     qtc[qpos] = '\0';
 }

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -126,7 +126,7 @@ int getpfxindex(char *checkcallptr, char **normalized_call) {
     int w = 0, abnormal_call = 0;
     size_t loc;
 
-    g_strlcpy(strippedcall, checkcallptr, 17);
+    g_strlcpy(strippedcall, checkcallptr, sizeof(strippedcall));
 
     if (strstr(strippedcall, "/QRP") ==
 	    (strippedcall + strlen(strippedcall) - 4))
@@ -137,7 +137,7 @@ int getpfxindex(char *checkcallptr, char **normalized_call) {
     if (location_unknown(strippedcall))
 	strippedcall[0] = '\0';
 
-    strncpy(checkcall, strippedcall, 16);
+    g_strlcpy(checkcall, strippedcall, sizeof(checkcall));
 
     loc = strcspn(checkcall, "/");
 

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -152,7 +152,9 @@ int getpfxindex(char *checkcallptr, char **normalized_call) {
 
 	if (strlen(call2) < strlen(call1)
 		&& strlen(call2) > 1) {
-	    sprintf(checkcall, "%s/%s", call2, call1);
+	    strcpy(checkcall, call2);
+	    g_strlcat(checkcall, "/", sizeof(checkcall));
+	    g_strlcat(checkcall, call1, sizeof(checkcall));
 	    abnormal_call = 1;
 	    loc = strcspn(checkcall, "/");
 	}
@@ -171,9 +173,6 @@ int getpfxindex(char *checkcallptr, char **normalized_call) {
 
 	    if (loc < 5)
 		checkcall[loc] = '\0';	/*  "PA/DJ0LN/P   */
-	    else {		/*  DJ0LN/P       */
-		strncpy(checkcall, checkcall, loc + 1);
-	    }
 	}
 
 	/* ------------------------------------------------------------ */

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -151,7 +151,7 @@ void prepare_fixed_part(void) {
 	    ((strcmp(whichcontest, "qso") == 0) ||
 	     (strcmp(whichcontest, "dxped") == 0))) {
         char khz[5];
-	sprintf(khz, " %3d", ((int)(freq / 1000.0)) % 1000);	// show freq.
+	sprintf(khz, " %3d", ((unsigned int)(freq / 1000.0)) % 1000);	// show freq.
 	strcat(logline4, khz);
 
     } else {
@@ -168,8 +168,9 @@ void prepare_fixed_part(void) {
 	strcat(logline4, " ");
     } else
 	strcat(logline4, "  ");
+    /* goes till 29 */
 
-    strncat(logline4, hiscall, 15);	/*  29 */
+    g_strlcat(logline4, hiscall, 44 + 1);
 
     fillto(44);
 

--- a/src/messagechange.c
+++ b/src/messagechange.c
@@ -79,8 +79,7 @@ int message_change(int x) {
     else
 	msg = message[bufnr];
 
-    printbuf[0] = '\0';
-    strncat(printbuf, msg, strlen(msg) - 1);
+    g_strlcpy(printbuf, msg, sizeof(printbuf));
     mvprintw(15, 4, "%s", printbuf);
     refreshp();
 

--- a/src/note.c
+++ b/src/note.c
@@ -55,8 +55,6 @@ int include_note(void) {
     getnstr(buffer, 78);
     noecho();
 
-    buffer2[0] = '\0';
-
     if (lan_active == 1) {
 	sprintf(buffer2, "; Node %c, %d : ", thisnode, atoi(qsonrstr) - 1);
     } else
@@ -78,11 +76,11 @@ int include_note(void) {
 
 	fclose(fp);
 
-	strncpy(qsos[nr_qsos], buffer2, LOGLINELEN - 1);
+	g_strlcpy(qsos[nr_qsos], buffer2, LOGLINELEN);
 	nr_qsos++;
 
 	scroll_log();
-	strncpy(logline4, buffer2, 80);  /* max. 80 columns */
+	g_strlcpy(logline4, buffer2, 81);  /* max. 80 columns */
 	clear_display();
 
     }

--- a/src/qsonr_to_str.c
+++ b/src/qsonr_to_str.c
@@ -22,18 +22,19 @@
  *--------------------------------------------------------------*/
 
 
+#include <glib.h>
 #include <string.h>
 
 
-int qsonr_to_str(void) {
+void qsonr_to_str(void) {
     extern int qsonum;
     extern char qsonrstr[5];
 
-    static int x;
-    static int thousands;
-    static int hundreds;
-    static int tens;
-    static char buffer[5];
+    int x;
+    int thousands;
+    int hundreds;
+    int tens;
+    char buffer[5];
 
     x = qsonum;
     thousands = (x / 1000);
@@ -48,7 +49,5 @@ int qsonr_to_str(void) {
     buffer[2] = tens + 48;
     buffer[3] = x + 48;
     buffer[4] = '\0';
-    strncpy(qsonrstr, buffer, 4);
-
-    return (0);
+    g_strlcpy(qsonrstr, buffer, sizeof(qsonrstr));
 }

--- a/src/qsonr_to_str.c
+++ b/src/qsonr_to_str.c
@@ -24,30 +24,16 @@
 
 #include <glib.h>
 #include <string.h>
+#include <stdio.h>
 
 
 void qsonr_to_str(void) {
     extern int qsonum;
     extern char qsonrstr[5];
 
-    int x;
-    int thousands;
-    int hundreds;
-    int tens;
-    char buffer[5];
-
-    x = qsonum;
-    thousands = (x / 1000);
-    x = x - (thousands * 1000);
-    hundreds = (x / 100);
-    x = x - (hundreds * 100);
-    tens = (x / 10);
-    x = x - (tens * 10);
-
-    buffer[0] = thousands + 48;
-    buffer[1] = hundreds + 48;
-    buffer[2] = tens + 48;
-    buffer[3] = x + 48;
-    buffer[4] = '\0';
-    g_strlcpy(qsonrstr, buffer, sizeof(qsonrstr));
+    if (qsonum < 0 || qsonum > 9999) { // should in fact never happen ...
+	strcpy(qsonrstr, "????");
+	return;
+    }
+    sprintf(qsonrstr, "%04d", qsonum);
 }

--- a/src/qsonr_to_str.h
+++ b/src/qsonr_to_str.h
@@ -21,6 +21,6 @@
 #ifndef QSONR_TO_STR_H
 #define QSONR_TO_STR_H
 
-int qsonr_to_str(void);
+void qsonr_to_str(void);
 
 #endif /* QSONR_TO_STR_H */

--- a/src/qtcvars.h
+++ b/src/qtcvars.h
@@ -36,6 +36,8 @@
 #define QTC_LATER 8	// QTC LATER
 #define QTC_NO 16	// NO QTC for/from this station
 
+#define QTC_CALL_SIZE 15
+
 typedef struct {
     int qsoline;	// qsos[INDEX]
     int flag;	// flag to mark for send
@@ -50,14 +52,14 @@ typedef struct {
     int count;	// nr of qtc line in block
     int marked;	// nr of marked to send
     int totalsent; // nr of sent qtc's
-    char callsign[15];  // current callsign; helps to detect if QSO has dropped
+    char callsign[QTC_CALL_SIZE];  // current callsign; helps to detect if QSO has dropped
     t_qtcline qtclines[QTC_LINES];
 } t_qtclist;
 
 typedef struct {
     int status;	// received, failed, nothing
     char time[5];	// time of qso
-    char callsign[15]; // callsign
+    char callsign[QTC_CALL_SIZE]; // callsign
     char serial[5]; // qso serial
     int confirmed; // qtc had confirmed
     char receivedtime[16]; // received time: YY-Mon-dd HH:MM\0
@@ -68,7 +70,7 @@ typedef struct {
     int count;
     int confirmed;
     int sentcfmall;
-    char callsign[15];
+    char callsign[QTC_CALL_SIZE];
     t_qtcrecline qtclines[QTC_LINES];
 } t_qtcreclist;
 

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -369,8 +369,7 @@ void prepare_for_recv() {
     }
 
     /* save the previous qtc callsign */
-    strncpy(prevqtccall, qtcreclist.callsign, strlen(qtcreclist.callsign));
-    prevqtccall[strlen(qtcreclist.callsign)] = '\0';
+    g_strlcpy(prevqtccall, qtcreclist.callsign, sizeof(prevqtccall));
     qtccallsign = qtcreclist.callsign;
 
     /* save the address of the counter of receive QTC block */
@@ -396,8 +395,7 @@ void prepare_for_send() {
     }
 
     /* save the current callsign to previous call variable */
-    strncpy(prevqtccall, qtclist.callsign, strlen(qtclist.callsign));
-    prevqtccall[strlen(qtclist.callsign)] = '\0';
+    g_strlcpy(prevqtccall, qtclist.callsign, sizeof(prevqtccall));
     qtccallsign = qtclist.callsign;
 
     /* save the address of the counter of SEND qtc structure */
@@ -1590,7 +1588,7 @@ int parse_ry_line(char *line) {
 	nr_parsed_line = 1;
     }
 
-    strncpy(lline, line, strlen(line));
+    g_strlcpy(lline, line, sizeof(lline));
     tactivefield = activefield;
     if (nr_parsed_line == 0) {		// 1st line: SERIAL/NR
 	wtoken = strtok_r(lline, " ", &saveptr1);
@@ -1949,7 +1947,6 @@ void recalc_qtclist() {
 	    put_qtc();
 	}
     }
-    strncpy(prevqtccall, qtccallsign, strlen(qtccallsign));
-    prevqtccall[strlen(qtccallsign)] = '\0';
+    g_strlcpy(prevqtccall, qtccallsign, sizeof(prevqtccall));
 }
 

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -618,8 +618,7 @@ void qtc_main_panel(int direction) {
 			    get_time();
 			    tempc[0] = '\0';
 			    strftime(tempc, 40, "%d-%b-%y %H:%M", time_ptr);
-			    strncpy(qtcreclist.qtclines[currqtc].receivedtime, tempc, 15);
-			    qtcreclist.qtclines[currqtc].receivedtime[15] = '\0';
+			    g_strlcpy(qtcreclist.qtclines[currqtc].receivedtime, tempc, 16);
 			    qtcreclist.qtclines[currqtc].status = 2;
 			    show_status(currqtc);
 			    if (currqtc < *qtccount) {
@@ -686,7 +685,7 @@ void qtc_main_panel(int direction) {
 			    get_time();
 			    tempc[0] = '\0';
 			    strftime(tempc, 40, "%d-%b-%y %H:%M", time_ptr);
-			    strncpy(qtclist.qtclines[activefield - 3].senttime, tempc, 15);
+			    g_strlcpy(qtclist.qtclines[activefield - 3].senttime, tempc, 16);
 			    qtclist.qtclines[activefield - 3].senttime[15] = '\0';
 			    qtclist.totalsent++;
 			}
@@ -745,10 +744,9 @@ void qtc_main_panel(int direction) {
 			int ql;
 			tmess[0] = '\0';
 			if (tlen > 0 && strncmp(qtc_send_msgs[1] + tlen, "sr/nr", 5) == 0) {
-			    tempc[0] = '\0';
-			    strncpy(tempc, qtc_send_msgs[1], tlen - 1);
-			    tempc[tlen - 1] = '\0';
-			    sprintf(tmess, "%s %d/%d %s %d/%d\n", tempc, qtclist.serial, *qtccount, tempc,
+			    g_strlcpy(tempc, qtc_send_msgs[1], tlen);
+			    sprintf(tmess, "%s %d/%d %s %d/%d\n",
+				    tempc, qtclist.serial, *qtccount, tempc,
 				    qtclist.serial, *qtccount);
 			}
 			timec[0] = '\0';
@@ -757,8 +755,7 @@ void qtc_main_panel(int direction) {
 
 			for (ql = 0; ql < *qtccount; ql++) {
 			    qtclist.qtclines[ql].sent = 1;
-			    strncpy(qtclist.qtclines[ql].senttime, timec, 15);
-			    qtclist.qtclines[ql].senttime[15] = '\0';
+			    g_strlcpy(qtclist.qtclines[ql].senttime, timec, 16);
 			    qtclist.totalsent++;
 
 			    tempc[0] = '\0';
@@ -871,12 +868,10 @@ void qtc_main_panel(int direction) {
 			    qtc_send_msgs[x - KEY_F(1)][strlen(qtc_send_msgs[x - KEY_F(1)]) - 1] = 0;
 			}
 			tlen = strlen(qtc_send_msgs[x - KEY_F(1)]) - 5; // len("sr/nr") = 5
-			char tmess[40];
+			char tmess[60];
 			tmess[0] = '\0';
 			if (tlen > 0 && strncmp(qtc_send_msgs[x - KEY_F(1)] + tlen, "sr/nr", 5) == 0) {
-			    tempc[0] = '\0';
-			    strncpy(tempc, qtc_send_msgs[x - KEY_F(1)], tlen - 1);
-			    tempc[tlen - 1] = '\0';
+			    g_strlcpy(tempc, qtc_send_msgs[x - KEY_F(1)], tlen);
 			    sprintf(tmess, "%s %d/%d ", tempc, qtclist.serial, *qtccount);
 			    sendmessage(tmess);
 			} else if ((activefield - 3) >= 0) {
@@ -1353,7 +1348,7 @@ void delete_from_field(int dir) {
 	if (strlen(qtccallsign) > 0) {
 	    sprintf(fieldval, "%s", qtccallsign);
 	    shift_left(fieldval, dir);
-	    strncpy(qtccallsign, fieldval, strlen(fieldval));
+	    g_strlcpy(qtccallsign, fieldval, QTC_CALL_SIZE);
 	    qtccallsign[strlen(fieldval)] = '\0';
 	    recalc_qtclist();
 	    showfield(0);
@@ -1545,8 +1540,7 @@ void show_help_msg(int msgidx) {
     for (i = 0; i < 12 && j < 12; i++) {
 	if (qtccurrdirection == RECV) {
 	    if (strlen(qtc_recv_msgs[i]) > 0) {
-		strncpy(buff, qtc_recv_msgs[i], strlen(qtc_recv_msgs[i]) - 1);
-		buff[strlen(qtc_recv_msgs[i]) - 1] = '\0';
+		g_strlcpy(buff, qtc_recv_msgs[i], sizeof(buff));
 		mvwprintw(qtcwin, ++j, 36, "F%-2d: %s", (i + 1), buff);
 	    }
 	    if (i == 1) {
@@ -1558,8 +1552,7 @@ void show_help_msg(int msgidx) {
 	}
 	if (qtccurrdirection == SEND) {
 	    if (strlen(qtc_send_msgs[i]) > 0) {
-		strncpy(buff, qtc_send_msgs[i], strlen(qtc_send_msgs[i]) - 1);
-		buff[strlen(qtc_send_msgs[i]) - 1] = '\0';
+		g_strlcpy(buff, qtc_send_msgs[i], sizeof(buff));
 		mvwprintw(qtcwin, ++j, 36, "F%-2d: %s", (i + 1), buff);
 	    }
 	}

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -389,10 +389,10 @@ int readcabrillo(int mode) {
 
     char *cab_dfltfile;
     struct cabrillo_desc *cabdesc;
-    char input_logfile[80];
+    char input_logfile[24];
     char output_logfile[80], temp_logfile[80];
     char logline[MAX_CABRILLO_LEN];
-    char tempstr[80];
+    char *tempstrp;
 
     char t_qsonrstr[5];
     int t_qsonum;
@@ -426,10 +426,13 @@ int readcabrillo(int mode) {
 	do_cabrillo = 0;
 	return (2);
     } else {
-	sprintf(tempstr, "CABRILLO format: %s", cabrillo);
-	show_readcab_msg(mode, tempstr);
+	tempstrp = g_strdup_printf("CABRILLO format: %s", cabrillo);
+	show_readcab_msg(mode, tempstrp);
+	g_free (tempstrp);
 	sleep(1);
     }
+
+    strcpy(temp_logfile, logfile);
 
     strcpy(input_logfile, call);
     g_strchomp(input_logfile); /* drop \n */
@@ -437,12 +440,13 @@ int readcabrillo(int mode) {
 
     strcpy(output_logfile, "IMPORT_");
     strcat(output_logfile, logfile);
-    strcpy(temp_logfile, logfile);
     strcpy(logfile, output_logfile);
 
     if ((fp2 = fopen(output_logfile, "w")) == NULL) {
-	sprintf(tempstr, "Can't open output logfile: %s.", output_logfile);
-	show_readcab_msg(mode, tempstr);
+	tempstrp = g_strdup_printf("Can't open output logfile: %s.",
+							output_logfile);
+	show_readcab_msg(mode, tempstrp);
+	g_free (tempstrp);
 	sleep(2);
 	do_cabrillo = 0;
 	free_cabfmt(cabdesc);
@@ -451,8 +455,10 @@ int readcabrillo(int mode) {
     fclose(fp2);
 
     if ((fp1 = fopen(input_logfile, "r")) == NULL) {
-	sprintf(tempstr, "Can't open input logfile: %s.", input_logfile);
-	show_readcab_msg(mode, tempstr);
+	tempstrp = g_strdup_printf("Can't open input logfile: %s.",
+							input_logfile);
+	show_readcab_msg(mode, tempstrp);
+	g_free (tempstrp);
 	sleep(2);
 	do_cabrillo = 0;
 	free_cabfmt(cabdesc);

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -68,31 +68,26 @@ void scroll_log(void) {
 
 	switch (kk) {
 	    case 0: {
-		strncpy(logline0, inputbuffer, 80);
-		logline0[80] = '\0';
+		strcpy(logline0, inputbuffer);
 		break;
 	    }
 	    case 1: {
-		strncpy(logline1, inputbuffer, 80);
-		logline1[80] = '\0';
+		strcpy(logline1, inputbuffer);
 		break;
 	    }
 
 	    case 2: {
-		strncpy(logline2, inputbuffer, 80);
-		logline2[80] = '\0';
+		strcpy(logline2, inputbuffer);
 		break;
 
 	    }
 	    case 3: {
-		strncpy(logline3, inputbuffer, 80);
-		logline3[80] = '\0';
+		strcpy(logline3, inputbuffer);
 		break;
 
 	    }
 	    case 4: {
-		strncpy(logline4, inputbuffer, 80);
-		logline4[80] = '\0';
+		strcpy(logline4, inputbuffer);
 		break;
 	    }
 	}

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -272,10 +272,7 @@ void sendbuf(void) {
 //              }
 	}
 
-	if (simulator == 0)
-	    strncat(printlinebuffer, termbuf, strlen(termbuf));
-	else
-	    strncat(printlinebuffer, termbuf, strlen(termbuf));
+	g_strlcpy(printlinebuffer, termbuf, sizeof(printlinebuffer));
 
 	if (searchflg == 0 && simulator == 0)
 	    strncat(printlinebuffer, backgrnd_str,

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -100,7 +100,7 @@ int init_tlf_rig(void) {
 
     rigportname[strlen(rigportname) - 1] = '\0';	// remove '\n'
     strncpy(my_rig->state.rigport.pathname, rigportname,
-	    FILPATHLEN);
+	    FILPATHLEN - 1);
 
     caps = my_rig->caps;
 

--- a/src/setparameters.c
+++ b/src/setparameters.c
@@ -23,6 +23,7 @@
  *--------------------------------------------------------------*/
 
 
+#include <glib.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -55,7 +56,7 @@ int setparameters(void) {
     extern char whichcontest[];
 
     int i = '9';
-    char callcpy[12] = "";
+    char callcpy[15] = "";
     char logbuffer[20];
 
     stop_background_process();	/* to prevent race condition */
@@ -99,7 +100,8 @@ int setparameters(void) {
 
 	mvprintw(20, 2, "7: Logfile: %s", logfile);
 
-	strncpy(callcpy, call, strlen(call) - 1);
+	g_strlcpy(callcpy, call, sizeof(callcpy));
+	g_strchomp(callcpy);
 	mvprintw(21, 2, "8: Call:    %s", callcpy);
 	mvprintw(22, 2, "9: Contest: %s", whichcontest);
 

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -31,6 +31,7 @@
  */
 
 
+#include <assert.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
@@ -83,7 +84,8 @@ void showinfo(int x) {
     strcpy(countrystr, dx->countryname);	/* country */
 
     if (strlen(cqzone) < 2) {
-	sprintf(zonestr, "%02d", dx->cq); 	/* cqzone */
+	if (dx->cq > MAX_ZONES) dx->cq = MAX_ZONES;
+	snprintf(zonestr, sizeof(zonestr), "%02d", dx->cq); 	/* cqzone */
 	strcpy(cqzone, zonestr);
     } else {
 	strncpy(zonestr, cqzone, 2);

--- a/src/showpxmap.c
+++ b/src/showpxmap.c
@@ -22,6 +22,7 @@
  *--------------------------------------------------------------*/
 
 
+#include <glib.h>
 #include <string.h>
 
 #include "dxcc.h"
@@ -105,10 +106,8 @@ void show_mults(void) {
 		    bandmask = inxes[bandinx];
 
 		    if ((countries[i] & bandmask) == 0) {
-			prefix[0] = '\0';
-			strncat(prefix, dxcc_by_index(i)->pfx, 3);
-
-			strncat(prefix, "     ", 4 - strlen(prefix));
+			strncpy(prefix, dxcc_by_index(i)->pfx, 3);
+			g_strlcat(prefix, "     ", sizeof(prefix));
 
 			attron(modify_attr(COLOR_PAIR(C_INPUT)));
 

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -615,7 +615,7 @@ int write_cabrillo(void) {
     /* ask for exchange and header information */
     ask(buffer,
 	"Your exchange (e.g. State, province, age etc... (# if serial number)): ");
-    strncpy(exchange, buffer, 10);
+    g_strlcpy(exchange, buffer, 11);
     getsummary(fp2);
 
     info("Writing cabrillo file");
@@ -741,7 +741,7 @@ int write_adif(void) {
     if ((strlen(standardexchange) == 0) && (exchange_serial != 1)) {
 	ask(buffer,
 	    "Your exchange (e.g. State, province, age etc... (# if serial number)): ");
-	strncpy(standardexchange, buffer, 10);
+	g_strlcpy(standardexchange, buffer, 11);
     }
 
     info("Writing ADIF file");


### PR DESCRIPTION
Quell warnings due to stricter check with GCC-8 or GCC-9 compiler.

Most problems were related to buffers to small or size of operands not correctly specified.
Most are easy ones but some are a little bit tricky.

@airween please test the  changes in the WAE related code (genqtclist and qtwin). It is quite complex and I am not sure if I did not break something. So please test the expected behavior especially for the places I did change.