### PR TITLE
New effort to use symbolic names for keystrokes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,7 @@ noinst_HEADERS = \
 	get_time.h  getctydata.h getexchange.h getmessages.h getpx.h \
 	getsummary.h gettxinfo.h getwwv.h globalvars.h grabspot.h \
 	ignore_unused.h initial_exchange.h \
-	keyer.h \
+	keyer.h keystroke_names.h \
 	lancode.h last10.h listmessages.h \
 	log_to_disk.h logit.h logview.h locator2longlat.h \
 	makelogline.h messagechange.h muf.h \

--- a/src/audio.c
+++ b/src/audio.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 
 #include "ignore_unused.h"
+#include "keystroke_names.h"
 #include "tlf.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
@@ -78,7 +79,7 @@ void do_record(int message_nr) {
     IGNORE(system(commands));;
     //G4KNO: Loop until <esc> keypress
     while (1) {
-	if (key_get() == 27) {
+	if (key_get() == ESCAPE) {
 	    //kill process (SIGINT=Ctrl-C).
 	    IGNORE(system("pkill -SIGINT -n rec"));;
 	    break;
@@ -253,7 +254,7 @@ void record(void) {
 		IGNORE(system(commands));;
 		runnit = 0;
 		break;
-	    case 27:
+	    case ESCAPE:
 		runnit = 0;
 	}
     }

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include "getctydata.h"
+#include "keystroke_names.h"
 #include "searchlog.h"		// Includes glib.h
 #include "showinfo.h"
 #include "tlf.h"
@@ -71,19 +72,19 @@ void calledit(void) {
 	}
 
 	// <Tab>
-	if (i == 9)
+	if (i == TAB)
 	    block_part = 1;
 	else
 	    block_part = 0;
 
 	// Ctrl-A (^A) or <Home>, move to head of callsign field.
-	if (i == 1 || i == KEY_HOME) {
+	if (i == CTRL_A || i == KEY_HOME) {
 	    b = 0;
 	    x = 0;
 	}
 
 	// Ctrl-E (^E) or <End>, move to end of callsign field, exit edit mode.
-	if (i == 5 || i == KEY_END) {
+	if (i == CTRL_E || i == KEY_END) {
 	    break;		/* stop edit */
 	}
 
@@ -218,7 +219,7 @@ int insert_char(int curposition) {
 	ichr = key_get();
 
 	// Leave insert mode if <Tab>, <Enter>, or <Backspace> are received.
-	if ((ichr == 9) || (ichr == '\n') || (ichr == KEY_ENTER) || (ichr == 127))
+	if ((ichr == TAB) || (ichr == '\n') || (ichr == KEY_ENTER) || (ichr == 127))
 	    break;
 
 	// Promote lower case to upper case.

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -50,7 +50,7 @@ void calledit(void) {
     b = l - 1;
 
 
-    while ((i != 27) && (b <= strlen(hiscall))) {
+    while ((i != ESCAPE) && (b <= strlen(hiscall))) {
 
 	attroff(A_STANDOUT);
 	attron(COLOR_PAIR(C_HEADER));
@@ -67,7 +67,7 @@ void calledit(void) {
 	if ((i == KEY_DC) || (i == KEY_IC))
 	    cnt++;
 	else {
-	    if (i != 27)
+	    if (i != ESCAPE)
 		cnt = 0;
 	}
 
@@ -142,7 +142,7 @@ void calledit(void) {
 		insertflg = 0;
 
 	    // Any character left other than <Escape>.
-	} else if (i != 27) {
+	} else if (i != ESCAPE) {
 
 	    // Promote lower case to upper case.
 	    if ((i >= 97) && (i <= 122))
@@ -183,10 +183,10 @@ void calledit(void) {
 		searchlog(hiscall);
 
 	    } else if (x != 0)
-		i = 27;
+		i = ESCAPE;
 
 	} else
-	    i = 27;
+	    i = ESCAPE;
 
     }
 
@@ -214,12 +214,12 @@ int insert_char(int curposition) {
     call1[0] = '\0';
     call2[0] = '\0';
 
-    while (ichr != 27) {
+    while (ichr != ESCAPE) {
 
 	ichr = key_get();
 
-	// Leave insert mode if <Tab>, <Enter>, or <Backspace> are received.
-	if ((ichr == TAB) || (ichr == '\n') || (ichr == KEY_ENTER) || (ichr == 127))
+	// Leave insert mode if <Tab>, <Enter>, or <Delete> are received.
+	if ((ichr == TAB) || (ichr == '\n') || (ichr == KEY_ENTER) || (ichr == DELETE))
 	    break;
 
 	// Promote lower case to upper case.
@@ -262,7 +262,7 @@ int insert_char(int curposition) {
 	refreshp();
 
     }
-    ichr = 27;
+    ichr = ESCAPE;
 
     return (ichr);
 }

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -408,7 +408,7 @@ int callinput(void) {
 	    // Alt-v (M-v), change Morse speed in CW mode, else band down.
 	    case ALT_V: {
 		if (ctcomp == 1) {
-		    while (x != 27) {	//escape
+		    while (x != ESCAPE) {
 			nicebox(1, 1, 2, 12, "Cw");
 			attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 			mvprintw(2, 2, "Speed:   %2u ", GetCWSpeed());
@@ -429,7 +429,7 @@ int callinput(void) {
 			    mvprintw(0, 14, "%2u", GetCWSpeed());
 
 			} else
-			    x = 27;	// <Escape>
+			    x = ESCAPE;
 
 			clear_display();
 		    }
@@ -828,12 +828,12 @@ int callinput(void) {
 			exit(0);
 		    }
 		}
-		x = 27;		// <Escape>
+		x = ESCAPE;
 		break;
 	    }
 
 	    // <Escape>, clear call input or stop sending.
-	    case 27: {
+	    case ESCAPE: {
 		if (early_started == 0) {
 		    /* if CW not started early drop call and start anew */
 		    cleanup();
@@ -1071,8 +1071,8 @@ int callinput(void) {
 	    }
 	}
 
-	if ((x == '\n' || x == KEY_ENTER) || x == 32 || x == TAB || x == CTRL_K
-		|| x == 44 || x == BACKSLASH) {
+	if ((x == '\n' || x == KEY_ENTER) || x == SPACE || x == TAB
+		|| x == CTRL_K || x == 44 || x == BACKSLASH) {
 	    break;
 	}
 
@@ -1142,7 +1142,7 @@ int autosend() {
     timeout = (1.2 / GetCWSpeed()) * cw_message_length(hiscall);
 
     x = -1;
-    while ((x != 27) && (x != '\n' && x != KEY_ENTER)) {
+    while ((x != ESCAPE) && (x != '\n' && x != KEY_ENTER)) {
 	x = -1;
 	while ((x == -1) && (g_timer_elapsed(timer, NULL) < timeout)) {
 
@@ -1171,7 +1171,7 @@ int autosend() {
 	}
 
 	// <Escape>
-	if (x == 27) {
+	if (x == ESCAPE) {
 	    stoptx();
 	    *hiscall_sent = '\0';
 	    early_started = 0;

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -48,6 +48,7 @@
 #include "gettxinfo.h"
 #include "grabspot.h"
 #include "ignore_unused.h"
+#include "keystroke_names.h"
 #include "lancode.h"
 #include "muf.h"
 #include "netkeyer.h"
@@ -320,7 +321,7 @@ int callinput(void) {
 	    }
 
 	    // Ctrl-Q (^Q), open QTC window for receiving or sending QTCs.
-	    case 17: {
+	    case CTRL_Q: {
 		if (qtcdirection == 1 || qtcdirection == 3) {	// in case of QTC=RECV or QTC=BOTH
 		    qtc_main_panel(RECV);
 		}
@@ -332,7 +333,7 @@ int callinput(void) {
 	    }
 
 	    // Ctrl-S (^S), open QTC window for sending QTCs.
-	    case 19: {
+	    case CTRL_S: {
 		if (qtcdirection == 2 || qtcdirection == 3) {	// in case of QTC=SEND ot QTC=BOTH
 		    qtc_main_panel(SEND);
 		}
@@ -498,7 +499,8 @@ int callinput(void) {
 			break;
 		    }
 		    else {
-			x = 92; // '\' log without sending message
+			/* Log without sending message. */
+			x = BACKSLASH;
 			break;
 		    }
 		}
@@ -580,7 +582,7 @@ int callinput(void) {
 
 	    // Semicolon or Alt-n (M-n), insert note in log.
 	    case ';':
-	    case 238: {
+	    case ALT_N: {
 		include_note();
 		x = -1;
 		break;
@@ -675,7 +677,7 @@ int callinput(void) {
 
 	    // Alt-k (M-k), synonym for Ctrl-K (^K).
 	    case 235: {
-		x = 11;		// Ctrl-K
+		x = CTRL_K;		// Ctrl-K
 		break;
 	    }
 
@@ -871,7 +873,7 @@ int callinput(void) {
 	    }
 
 	    // Ctrl-L (^L), resets screen.
-	    case 12: {
+	    case CTRL_L: {
 		endwin();
 		set_term(mainscreen);
 		clear_display();
@@ -880,7 +882,7 @@ int callinput(void) {
 	    }
 
 	    // Ctrl-P (^P), show MUF display.
-	    case 16: {
+	    case CTRL_P: {
 		int currentterm = miniterm;
 		miniterm = 0;
 		muf();
@@ -891,7 +893,7 @@ int callinput(void) {
 	    }
 
 	    // Ctrl-A (^A), add a spot and share on LAN.
-	    case 1: {
+	    case CTRL_A: {
 		addspot();
 		HideSearchPanel();
 		showinfo(SHOWINFO_DUMMY);
@@ -902,7 +904,7 @@ int callinput(void) {
 	    }
 
 	    // Ctrl-B (^B), send spot to DX cluster.
-	    case 2: {
+	    case CTRL_B: {
 		announcefilter = 0;
 		cluster = CLUSTER;
 		send_cluster();
@@ -911,14 +913,14 @@ int callinput(void) {
 	    }
 
 	    // Ctrl-F (^F), change frequency dialog.
-	    case 6: {
+	    case CTRL_F: {
 		change_freq();
 
 		break;
 	    }
 
 	    // Ctrl-G (^G), grab next DX spot from bandmap.
-	    case 7: {
+	    case CTRL_G: {
 		freq_t f = grab_next();
 		if (f > 0.0) {
 		    grab.state = IN_PROGRESS;
@@ -952,7 +954,7 @@ int callinput(void) {
 	    }
 
 	    // Ctrl-R (^R), toogle trx1, trx2 via lp0 pin 14.
-	    case 18: {
+	    case CTRL_R: {
 		if (k_pin14 == 0) {
 		    k_pin14 = 1;
 		    netkeyer(K_SET14, "1");
@@ -964,7 +966,7 @@ int callinput(void) {
 	    }
 
 	    // Ctrl-T (^T) or Alt-i (M-i), show talk messages.
-	    case 20:
+	    case CTRL_T:
 	    case 233: {
 		if (lan_active != 0) {
 
@@ -1069,8 +1071,8 @@ int callinput(void) {
 	    }
 	}
 
-	if ((x == '\n' || x == KEY_ENTER) || x == 32 || x == 9 || x == 11
-		|| x == 44 || x == 92) {
+	if ((x == '\n' || x == KEY_ENTER) || x == 32 || x == TAB || x == CTRL_K
+		|| x == 44 || x == BACKSLASH) {
 	    break;
 	}
 

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -265,7 +265,7 @@ int callinput(void) {
 	    }
 
 	    // Up Arrow or Alt-e, edit last QSO
-	    if (x == KEY_UP || x == 229) {
+	    if (x == KEY_UP || x == ALT_E) {
 		edit_last();
 		break;
 	    }
@@ -368,7 +368,7 @@ int callinput(void) {
 	    }
 
 	    // Alt-w (M-w), set Morse weight.
-	    case 247: {
+	    case ALT_W: {
 		char weightbuf[5] = "";
 		char *end;
 
@@ -406,7 +406,7 @@ int callinput(void) {
 	    }
 
 	    // Alt-v (M-v), change Morse speed in CW mode, else band down.
-	    case 246: {
+	    case ALT_V: {
 		if (ctcomp == 1) {
 		    while (x != 27) {	//escape
 			nicebox(1, 1, 2, 12, "Cw");
@@ -664,8 +664,8 @@ int callinput(void) {
 	    }
 
 	    // Alt-r (M-r) or Alt-s (M-s), toggle score window.
-	    case 242:
-	    case 243: {
+	    case ALT_R:
+	    case ALT_S: {
 		if (showscore_flag == 0)
 		    showscore_flag = 1;
 		else {
@@ -676,13 +676,13 @@ int callinput(void) {
 	    }
 
 	    // Alt-k (M-k), synonym for Ctrl-K (^K).
-	    case 235: {
+	    case ALT_K: {
 		x = CTRL_K;		// Ctrl-K
 		break;
 	    }
 
 	    // Alt-a (M-a), cycle cluster window.
-	    case 225: {
+	    case ALT_A: {
 		if (cluster == NOCLUSTER) {
 		    cluster = CLUSTER;	// alt-A
 		    announcefilter = FILTER_ALL;
@@ -696,7 +696,7 @@ int callinput(void) {
 	    }
 
 	    // Alt-b (M-b), band-up for TR-Log mode.
-	    case 226: {
+	    case ALT_B: {
 		if (ctcomp == 0) {
 		    handle_bandswitch(BAND_UP);
 		}
@@ -704,7 +704,7 @@ int callinput(void) {
 	    }
 
 	    // Alt-j (M-j), show station frequencies.
-	    case 234: {
+	    case ALT_J: {
 		if (cluster != FREQWINDOW) {
 		    lastwindow = cluster;
 		    cluster = FREQWINDOW;
@@ -715,7 +715,7 @@ int callinput(void) {
 	    }
 
 	    // Alt-h (M-h), show help.
-	    case 232: {
+	    case ALT_H: {
 		show_help();
 		break;
 	    }
@@ -728,7 +728,7 @@ int callinput(void) {
 	    }
 
 	    // Alt-c (M-c), toggle check window.
-	    case 227: {
+	    case ALT_C: {
 		if (searchflg != SEARCHWINDOW)
 		    searchflg = SEARCHWINDOW;
 		else
@@ -737,14 +737,14 @@ int callinput(void) {
 	    }
 
 	    // Alt-m (M-m), show multipliers.
-	    case 237: {
+	    case ALT_M: {
 		show_mults();
 		refreshp();
 		break;
 	    }
 
 	    // Alt-p (M-p), toggle PTT via cwdaemon
-	    case 240: {
+	    case ALT_P: {
 		if (k_ptt == 0) {
 		    k_ptt = 1;
 		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
@@ -753,7 +753,7 @@ int callinput(void) {
 		    refreshp();
 		    netkeyer(K_PTT, "1");	// ptt on
 		    x = key_get();	// any character to stop tuning
-		    if (x == 240)	// Alt-P (M-p)
+		    if (x == ALT_P)	// Alt-P (M-p)
 			netkeyer(K_PTT, "0");	// ptt off
 		    k_ptt = 0;
 		    show_header_line();
@@ -765,7 +765,7 @@ int callinput(void) {
 	    }
 
 	    // Alt-t (M-t), tune xcvr via cwdaemon.
-	    case 244: {
+	    case ALT_T: {
 		int count;
 		gchar *buff;
 
@@ -796,7 +796,7 @@ int callinput(void) {
 	    }
 
 	    // Alt-z (M-z), show zones worked.
-	    case 250: {
+	    case ALT_Z: {
 		if (cqww == 1) {
 		    if (zonedisplay == 0)
 			zonedisplay = 1;
@@ -812,8 +812,8 @@ int callinput(void) {
 	    }
 
 	    // Alt-q (M-q) or Alt-x (M-x), Exit
-	    case 241:
-	    case 248: {
+	    case ALT_Q:
+	    case ALT_X: {
 		mvprintw(13, 29, "You want to leave tlf? (y/n): ");
 		while (x != 'n' && x != 'N') {
 
@@ -933,7 +933,7 @@ int callinput(void) {
 	    }
 
 	    // Alt-g (M-g), grab first spot matching call field chars.
-	    case 231: {
+	    case ALT_G: {
 		double f = grabspot();
 		if (f > 0.0) {
 		    grab.state = IN_PROGRESS;
@@ -967,7 +967,7 @@ int callinput(void) {
 
 	    // Ctrl-T (^T) or Alt-i (M-i), show talk messages.
 	    case CTRL_T:
-	    case 233: {
+	    case ALT_I: {
 		if (lan_active != 0) {
 
 		    for (t = 0; t <= 5; t++)

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -39,6 +39,7 @@
 #include "fldigixmlrpc.h"
 #include "gettxinfo.h"
 #include "ignore_unused.h"
+#include "keystroke_names.h"
 #include "lancode.h"
 #include "listmessages.h"
 #include "logview.h"
@@ -656,13 +657,13 @@ int changepars(void) {
 	    /* wait for correct input or ESC */
 	    while ((x != 0) && !((x >= 2) && (x <= 5)) && !(x == 'm' - '0')) {
 		x = key_get();
-		if (x == 27)
+		if (x == ESCAPE)
 		    break;
 		x = x - '0';
 	    }
 
 	    /* remember new setting */
-	    if (x != 27) {
+	    if (x != ESCAPE) {
 		if (x == 0 || (x >= 2 && x <= 5))
 		    cwstart = x;
 		else

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -31,6 +31,7 @@
 #include "background_process.h"
 #include "err_utils.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "keystroke_names.h"
 #include "logview.h"
 #include "scroll_log.h"
 #include "tlf_curses.h"
@@ -114,15 +115,15 @@ void edit_last(void) {
 	j = key_get();
 
 	// Ctrl-A (^A) or <Home>, beginning of line.
-	if (j == 1 || j == KEY_HOME) {
+	if (j == CTRL_A || j == KEY_HOME) {
 	    b = 1;
 
 	    // Ctrl-E (^E) or <End>, end of line.
-	} else if (j == 5 || j == KEY_END) {
+	} else if (j == CTRL_E || j == KEY_END) {
 	    b = 77;
 
 	    // <Tab>, next field.
-	} else if (j == 9) {
+	} else if (j == TAB) {
 	    if (b < 17)
 		b = 17;
 	    else if (b < 29)

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -109,7 +109,7 @@ void edit_last(void) {
     /* start with last QSO */
     get_qso(nr_qsos - (NR_LINES - editline), editbuffer);
 
-    while (j != 27 && j != '\n' && j != KEY_ENTER) {
+    while (j != ESCAPE && j != '\n' && j != KEY_ENTER) {
 	highlight_line(editline, editbuffer, b);
 
 	j = key_get();
@@ -146,7 +146,7 @@ void edit_last(void) {
 		get_qso(nr_qsos - (NR_LINES - editline), editbuffer);
 	    } else {
 		logview();
-		j = 27;
+		j = ESCAPE;
 	    }
 
 	    // Down arrow, move to next line.
@@ -158,7 +158,7 @@ void edit_last(void) {
 		editline++;
 		get_qso(nr_qsos - (NR_LINES - editline), editbuffer);
 	    } else
-		j = 27;		/* escape */
+		j = ESCAPE;
 
 	    // Left arrow, move cursor one position left.
 	} else if (j == KEY_LEFT) {
@@ -214,7 +214,7 @@ void edit_last(void) {
 	    for (k = b; k < 64; k++)
 		editbuffer[k] = editbuffer[k + 1];
 
-	} else if (j != 27) {
+	} else if (j != ESCAPE) {
 
 	    // Promote lower case to upper case.
 	    if ((j >= 97) && (j <= 122))

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -207,7 +207,7 @@ int getexchange(void) {
 		break;
 	    }
 
-	    case 27: {	// <Escape>
+	    case ESCAPE: {                // <Escape>
 		stoptx();			/* stop sending CW */
 		if (comment[0] != '\0') {	/* if comment not empty */
 		    /* drop exchange so far */
@@ -1124,7 +1124,7 @@ void exchange_edit(void) {
     l = strlen(comment);
     b = l - 1;
 
-    while ((i != 27) && (b <= strlen(comment))) {
+    while ((i != ESCAPE) && (b <= strlen(comment))) {
 	attroff(A_STANDOUT);
 	attron(COLOR_PAIR(C_HEADER));
 
@@ -1184,7 +1184,7 @@ void exchange_edit(void) {
 	    }
 
 	    // <Escape> not received.
-	} else if (i != 27) {
+	} else if (i != ESCAPE) {
 
 	    // Promote lower case to upper case.
 	    if ((i >= 'a') && (i <= 'z'))
@@ -1205,7 +1205,7 @@ void exchange_edit(void) {
 		}
 
 	    } else if (i != 0)
-		i = 27;
+		i = ESCAPE;
 	}
     }
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -32,6 +32,7 @@
 #include "addspot.h"
 #include "cw_utils.h"
 #include "keyer.h"
+#include "keystroke_names.h"
 #include "lancode.h"
 #include "locator2longlat.h"
 #include "logit.h"
@@ -174,7 +175,7 @@ int getexchange(void) {
 
 	switch (x) {
 
-	    case 17: {	// Ctl-q (^Q)--Open QTC panel for receiving or sending QTCs
+	    case CTRL_Q: {	// Ctl-q (^Q)--Open QTC panel for receiving or sending QTCs
 		if (qtcdirection == 1 || qtcdirection == 3) {	// in case of QTC=RECV or QTC=BOTH
 		    qtc_main_panel(RECV);
 		}
@@ -191,10 +192,10 @@ int getexchange(void) {
 		x = KEY_LEFT;
 		continue;
 	    }
-	    case 1: {	// Ctl-a (^A)
+	    case CTRL_A: {	// Ctrl-A (^A)
 		addspot();
 		*comment = '\0';
-		x = 9;	// <Tab>
+		x = TAB;	// <Tab>
 		break;
 	    }
 
@@ -214,7 +215,7 @@ int getexchange(void) {
 		    i = 0;
 		} else {
 		    /* back to callinput */
-		    x = 9;	// <Tab>
+		    x = TAB;	// <Tab>
 		}
 		break;
 	    }
@@ -244,8 +245,8 @@ int getexchange(void) {
 			/* F4 (TU macro) */
 			send_standard_message(3);
 
-			/* '\' log without additional message */
-			x = 92;
+			/* log without additional message */
+			x = BACKSLASH;
 		    }
 		}
 		break;
@@ -254,7 +255,7 @@ int getexchange(void) {
 	    /* <Insert>, send exchange in CT mode */
 	    case KEY_IC: {
 		if (ctcomp != 0) {
-                    /* F3 (RST macro) */
+		    /* F3 (RST macro) */
 		    send_standard_message(2);
 
 		}
@@ -333,7 +334,7 @@ int getexchange(void) {
 
 	    }
 	    case ',':		// Keyboard Morse
-	    case 11: {	// Ctrl-K
+	    case CTRL_K: {	// Ctrl-K
 		mvprintw(5, 0, "");
 		keyer();
 		x = 0;
@@ -349,7 +350,8 @@ int getexchange(void) {
 			x = -1;
 		    }
 		    else {
-			x = 92;	// '\'
+			/* Log without sending a message. */
+			x = BACKSLASH;
 		    }
 		}
 		break;
@@ -380,7 +382,8 @@ int getexchange(void) {
 	}
 
 	/* <Enter>, <Tab>, Ctl-K, '\' */
-	if (x == '\n' || x == KEY_ENTER || x == 9 || x == 11 || x == 92) {
+	if (x == '\n' || x == KEY_ENTER || x == TAB
+	    || x == CTRL_K || x == BACKSLASH) {
 
 	    if ((exchange_serial == 1 && comment[0] >= '0'
 		    && comment[0] <= '9')) {	/* align serial nr. */
@@ -457,12 +460,12 @@ int getexchange(void) {
 
 	    }
 
-	    if ((arrlss == 1) && (x != 9) && (strlen(section) < 2)) {
+	    if ((arrlss == 1) && (x != TAB) && (strlen(section) < 2)) {
 		mvprintw(13, 54, "section?");
 		mvprintw(12, 54, comment);
 		x = 0;
 	    } else if (((serial_section_mult == 1) || (sectn_mult == 1))
-		       && ((x != 9) && (strlen(section) < 1))) {
+		       && ((x != TAB) && (strlen(section) < 1))) {
 		if (serial_or_section == 0 || (serial_or_section == 1
 					       && country_found(hiscall) == 1)) {
 		    mvprintw(13, 54, "section?", section);
@@ -495,7 +498,7 @@ int getexchange(void) {
 		if (strlen(comment) < 5) {
 		    mvprintw(13, 54, "state/prov?");
 		    mvprintw(12, 54, comment);
-		    if (x == '\n' || x == KEY_ENTER || x == 92) {
+		    if (x == '\n' || x == KEY_ENTER || x == BACKSLASH) {
 			x = 0;
 		    } else {
 			refreshp();
@@ -1132,12 +1135,12 @@ void exchange_edit(void) {
 	i = key_get();
 
 	// Ctrl-A (^A) or <Home>, move to beginning of comment field.
-	if (i == 1 || i == KEY_HOME) {
+	if (i == CTRL_A || i == KEY_HOME) {
 
 	    b = 0;
 
 	    // Ctrl-E (^E) or <End>, move to end of comment field, exit edit mode.
-	} else if (i == 5 || i == KEY_END) {
+	} else if (i == CTRL_E || i == KEY_END) {
 
 	    b = strlen(comment);
 	    break;

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -126,7 +126,7 @@ void keyer(void) {
 	}
 
 	// <Escape>, Ctrl-K (^K), Alt-k (M-k)
-	if (x == 27 || x == CTRL_K || x == 235) {
+	if (x == 27 || x == CTRL_K || x == ALT_K) {
 	    if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {
 		/* switch back to rx */
 		keyer_append(rxcontrolstring);
@@ -210,7 +210,7 @@ void keyer(void) {
 		    break;
 		}
 
-		case 247: {	// Alt-w, set weight
+		case ALT_W: {	// Alt-w, set weight
 		    mvprintw(1, 0, "Weight=   ");
 		    mvprintw(1, 7, "");
 		    refreshp();

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -126,7 +126,7 @@ void keyer(void) {
 	}
 
 	// <Escape>, Ctrl-K (^K), Alt-k (M-k)
-	if (x == 27 || x == CTRL_K || x == ALT_K) {
+	if (x == ESCAPE || x == CTRL_K || x == ALT_K) {
 	    if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {
 		/* switch back to rx */
 		keyer_append(rxcontrolstring);

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -30,6 +30,7 @@
 #include <ctype.h>
 
 #include "clear_display.h"
+#include "keystroke_names.h"
 #include "netkeyer.h"
 #include "nicebox.h"		// Includes curses.h
 #include "sendbuf.h"
@@ -68,9 +69,9 @@ void keyer(void) {
     int keyerstringpos = 0;
     char weightbuf[15];
     const char txcontrolstring[2] = { 20, '\0' };	// ^t
-    const char rxcontrolstring[2] = { 18, '\0' };	// ^r
-    const char crcontrolstring[2] = { 13, '\0' };	// cr
-    const char ctl_c_controlstring[2] = { 92, '\0' };	// '\'
+    const char rxcontrolstring[2] = { CTRL_R, '\0' };	// ^r
+    const char crcontrolstring[2] = { RETURN, '\0' };	// cr
+    const char ctl_c_controlstring[2] = { BACKSLASH, '\0' };	// '\'
 
     if ((trxmode == CWMODE && cwkeyer == NO_KEYER) ||
 	    (trxmode == DIGIMODE && digikeyer == NO_KEYER)) {
@@ -125,7 +126,7 @@ void keyer(void) {
 	}
 
 	// <Escape>, Ctrl-K (^K), Alt-k (M-k)
-	if (x == 27 || x == 11 || x == 235) {
+	if (x == 27 || x == CTRL_K || x == 235) {
 	    if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {
 		/* switch back to rx */
 		keyer_append(rxcontrolstring);
@@ -155,7 +156,7 @@ void keyer(void) {
 
 	x = toupper(x);
 
-	if ((x >= ' ' && x <= 'Z') || x == 10) {    /* ~printable or LF */
+	if ((x >= ' ' && x <= 'Z') || x == LINEFEED) { /* ~printable or LF */
 	    if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {
 		mfj1278_control(x);
 	    } else if (cwkeyer == NET_KEYER) {
@@ -177,8 +178,8 @@ void keyer(void) {
 
 	    switch (x) {
 		case '|':
-		case '\n':		// Note that '\n', KEY_ENTER, and usually 13
-		case 13:		// Will never happen (converted to space above)
+		case '\n':		// Note that '\n', KEY_ENTER, and usually RETURN
+		case RETURN:		// Will never happen (converted to space above)
 		case KEY_ENTER: {
 		    if (cwkeyer == MFJ1278_KEYER ||
 			    digikeyer == MFJ1278_KEYER) {
@@ -311,8 +312,8 @@ void mfj1278_control(int x) {
     if (trxmode == CWMODE || trxmode == DIGIMODE) {
 
 	if (trxmode == DIGIMODE) {
-	    if (x == 10)
-		x = 13;		// tnc needs CR instead of LF
+	    if (x == LINEFEED)
+		x = RETURN;     // tnc needs CR instead of LF
 	}
 	keyer_append_char(x);
     }

--- a/src/keystroke_names.h
+++ b/src/keystroke_names.h
@@ -43,7 +43,10 @@
 #define CTRL_T    20
 
 /* Keyboard characters */
+#define ESCAPE    27
+#define SPACE     32
 #define BACKSLASH 92
+#define DELETE    127
 
 #define ALT_A     225
 #define ALT_B     226

--- a/src/keystroke_names.h
+++ b/src/keystroke_names.h
@@ -1,0 +1,50 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2019      Nate Bargmann <n0nb@n0nb.us>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+/* ------------------------------------------------------------
+ *        Keystroke magic numbers and names as symbolic
+ *        constants.  Values are decimal ordinals provided
+ *        by the ncurses library.  See doc/keynames.txt.
+ *
+ *--------------------------------------------------------------*/
+
+#define CTRL_A    1
+#define CTRL_B    2
+#define CTRL_E    5
+#define CTRL_F    6
+#define CTRL_G    7             /* Bell */
+#define CTRL_H    8             /* Backspace */
+#define CTRL_I    9             /* Tab */
+#define CTRL_J    10            /* Newline/Linefeed */
+#define CTRL_K    11
+#define CTRL_L    12
+#define CTRL_M    13            /* Return */
+#define CTRL_N    14
+#define CTRL_P    16
+#define CTRL_Q    17
+#define CTRL_R    18
+#define CTRL_S    19
+#define CTRL_T    20
+#define BACKSLASH 92
+#define ALT_N     238
+
+/* Common name macros. */
+#define TAB       CTRL_I
+#define LINEFEED  CTRL_J
+#define RETURN    CTRL_M

--- a/src/keystroke_names.h
+++ b/src/keystroke_names.h
@@ -41,8 +41,30 @@
 #define CTRL_R    18
 #define CTRL_S    19
 #define CTRL_T    20
+
+/* Keyboard characters */
 #define BACKSLASH 92
+
+#define ALT_A     225
+#define ALT_B     226
+#define ALT_C     227
+#define ALT_E     229
+#define ALT_G     231
+#define ALT_H     232
+#define ALT_I     233
+#define ALT_J     234
+#define ALT_K     235
+#define ALT_M     237
 #define ALT_N     238
+#define ALT_P     240
+#define ALT_Q     241
+#define ALT_R     242
+#define ALT_S     243
+#define ALT_T     244
+#define ALT_V     246
+#define ALT_W     247
+#define ALT_X     248
+#define ALT_Z     250
 
 /* Common name macros. */
 #define TAB       CTRL_I

--- a/src/logit.c
+++ b/src/logit.c
@@ -96,7 +96,7 @@ void logit(void) {
 		strcpy(comment, cqzone);
 	    }
 
-	    if ((callreturn == TAB || callreturn == 32)) {
+	    if ((callreturn == TAB || callreturn == SPACE)) {
 		callreturn = getexchange();
 	    }
 

--- a/src/logit.c
+++ b/src/logit.c
@@ -31,6 +31,7 @@
 #include "clear_display.h"
 #include "getexchange.h"
 #include "keyer.h"
+#include "keystroke_names.h"
 #include "log_to_disk.h"
 #include "printcall.h"
 #include "recall_exchange.h"
@@ -91,11 +92,11 @@ void logit(void) {
 
 	    if ((trxmode == CWMODE || trxmode == DIGIMODE)
 		    && (callreturn == '\n') && ctcomp == 1) {
-		callreturn = 92; 	/* '\' */
+		callreturn = BACKSLASH;
 		strcpy(comment, cqzone);
 	    }
 
-	    if ((callreturn == 9 || callreturn == 32)) {
+	    if ((callreturn == TAB || callreturn == 32)) {
 		callreturn = getexchange();
 	    }
 
@@ -193,7 +194,7 @@ void logit(void) {
 		}
 	    }
 
-	    if ((callreturn == 92) && (*hiscall != '\0')) {
+	    if ((callreturn == BACKSLASH) && (*hiscall != '\0')) {
 		defer_store = 0;
 
 		log_to_disk(false);
@@ -203,7 +204,7 @@ void logit(void) {
 		HideSearchPanel();
 	    }
 
-	    if (callreturn == 11 || callreturn == 44) {	/*  CTRL K  */
+	    if (callreturn == CTRL_K || callreturn == 44) {	/*  CTRL K  */
 		getyx(stdscr, cury, curx);
 		mvprintw(5, 0, "");
 		keyer();

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -33,6 +33,7 @@
 #include "get_time.h"
 #include "ignore_unused.h"
 #include "keyer.h"
+#include "keystroke_names.h"
 #include "lancode.h"
 #include "nicebox.h"		// Includes curses.h
 #include "qtc_log.h"
@@ -460,7 +461,7 @@ void qtc_main_panel(int direction) {
 	    //case 227:		// ALT-c
 
 	    // Ctrl-T (^T)
-	    case 20:
+	    case CTRL_T:
 		if (trxmode == DIGIMODE) {
 		    show_rtty_lines();
 		}
@@ -794,7 +795,7 @@ void qtc_main_panel(int direction) {
 		break;
 
 	    // Ctrl-S (^S), save QTC
-	    case 19:
+	    case CTRL_S:
 		if (qtccurrdirection == SEND && *qtccount > 0
 			&& qtclist.totalsent == *qtccount) {
 		    log_sent_qtc_to_disk(nr_qsos);
@@ -820,7 +821,7 @@ void qtc_main_panel(int direction) {
 		break;
 
 	    // Ctrl-E (^E), end capture
-	    case 5:
+	    case CTRL_E:
 		if (qtccurrdirection == RECV && trxmode == DIGIMODE) {
 		    qtc_ry_capture = 0;
 		    wattr_get(qtcwin, &attributes, &cpair, NULL);
@@ -1119,7 +1120,7 @@ void qtc_main_panel(int direction) {
 		break;
 
 	    // Ctrl-L (^L), mark callsign for late QTC
-	    case 12:
+	    case CTRL_L:
 		if (strlen(g_strstrip(qtccallsign)) > 3) {
 		    qtc_inc(g_strstrip(qtccallsign), QTC_LATER);
 		    sprintf(tempc, "%s;L\n", qtccallsign);
@@ -1128,7 +1129,7 @@ void qtc_main_panel(int direction) {
 		break;
 
 	    // Ctrl-N (^N), mark callsign for explicit NO QTC
-	    case 14:
+	    case CTRL_N:
 		if (strlen(g_strstrip(qtccallsign)) > 3) {
 		    qtc_inc(g_strstrip(qtccallsign), QTC_NO);
 		    sprintf(tempc, "%s;N\n", qtccallsign);
@@ -1137,7 +1138,7 @@ void qtc_main_panel(int direction) {
 		break;
 
 	    // Ctrl-F (^F), fill time fields with first 2 chars
-	    case 6:
+	    case CTRL_F:
 		if (activefield > 2) {
 		    fill_qtc_times(qtcreclist.qtclines[(activefield - 3) / 3].time);
 		    showfield(activefield);
@@ -1145,7 +1146,7 @@ void qtc_main_panel(int direction) {
 		break;
 
 	    // Ctrl-R (^R), start/stop recording
-	    case 18:
+	    case CTRL_R:
 		if (direction == RECV) {
 		    if (record_run < 0) {
 			start_qtc_recording();
@@ -1811,7 +1812,7 @@ void show_rtty_lines() {
 		break;
 
 	    // Ctrl-R (^R)
-	    case 18:
+	    case CTRL_R:
 		for (j = 0; j < 12; j++) {
 		    qtc_ry_lines[j].content[0] = '\0';
 		    qtc_ry_lines[j].attr = 0;
@@ -1824,19 +1825,19 @@ void show_rtty_lines() {
 		break;
 
 	    // Ctrl-S (^S), start capture
-	    case 19:
+	    case CTRL_S:
 		qtc_ry_capture = 1;
 		mvwprintw(qtcwin, 2, 11, "CAPTURE ON ");
 		break;
 
 	    // Ctrl-E (^E), end capture
-	    case 5:
+	    case CTRL_E:
 		qtc_ry_capture = 0;
 		mvwprintw(qtcwin, 2, 11, "CAPTURE OFF");
 		break;
 
 	    // <Enter>, add to qtc
-	    case 10:
+	    case LINEFEED:
 		if (qtc_ry_lines[actline - 1].attr == 0) {
 		    parse_ry_line(qtc_ry_lines[actline - 1].content);
 		    qtc_ry_lines[actline - 1].attr = 1;
@@ -1942,4 +1943,3 @@ void recalc_qtclist() {
     }
     g_strlcpy(prevqtccall, qtccallsign, sizeof(prevqtccall));
 }
-

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -458,8 +458,6 @@ void qtc_main_panel(int direction) {
 	}
 
 	switch (x) {
-	    //case 227:		// ALT-c
-
 	    // Ctrl-T (^T)
 	    case CTRL_T:
 		if (trxmode == DIGIMODE) {

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -444,7 +444,7 @@ void qtc_main_panel(int direction) {
 
     x = -1;
     /* main loop */
-    while (x != 27) {
+    while (x != ESCAPE) {
 
 	while (x < 1) {
 
@@ -675,7 +675,7 @@ void qtc_main_panel(int direction) {
 				    play_file(qtc_phrecv_message[9]);
 				}
 			    }
-			    x = 27;	// <Escape> close the window
+			    x = ESCAPE;	// <Escape> close the window
 			}
 		    }
 		    if (direction == SEND && trxmode != DIGIMODE) {
@@ -803,7 +803,7 @@ void qtc_main_panel(int direction) {
 		    qtccallsign[0] = '\0';
 		    refreshp();
 		    sleep(1);
-		    x = 27;	// <Escape> close the window
+		    x = ESCAPE;	// <Escape> close the window
 
 		}
 		if (qtccurrdirection == RECV && trxmode == DIGIMODE) {
@@ -931,7 +931,7 @@ void qtc_main_panel(int direction) {
 		break;
 
 	    // <Tab>
-	    case 9:
+	    case TAB:
 		if (direction == RECV) {
 		    if (trxmode == DIGIMODE) {
 			if (activefield == 32) {
@@ -1014,7 +1014,7 @@ void qtc_main_panel(int direction) {
 		break;
 
 	    // <Space>
-	    case ' ':
+	    case SPACE:
 		if (DIRCLAUSE) {
 		    if (direction == RECV) {
 			if (activefield > 2) {
@@ -1155,7 +1155,7 @@ void qtc_main_panel(int direction) {
 		}
 	}
 	refreshp();
-	if (x != 27) {
+	if (x != ESCAPE) {
 	    x = 0;
 	}
     }
@@ -1739,7 +1739,7 @@ void show_rtty_lines() {
     x = -1; j = 1;
     prevline = -1;
     curs_set(0);
-    while (x != 27) {
+    while (x != ESCAPE) {
 
 	while (x < 1) {
 
@@ -1846,7 +1846,7 @@ void show_rtty_lines() {
 		break;
 	}
 	refreshp();
-	if (x != 27) {
+	if (x != ESCAPE) {
 	    x = -1;
 	}
 	if (*qtccount > 0 && qtc_ry_copied == qtcreclist.count) {

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -33,6 +33,7 @@
 #include "callinput.h"
 #include "displayit.h"
 #include "globalvars.h"
+#include "keystroke_names.h"
 #include "lancode.h"
 #include "netkeyer.h"
 #include "tlf.h"
@@ -305,13 +306,13 @@ void sendbuf(void) {
 		int i = 0;
 		for (i = 0; i < strlen(buffer); i++)
 		    if (buffer[i] == '\n')
-			buffer[i] = 13;
+			buffer[i] = RETURN;
 		for (i = 0; i < strlen(buffer); i++)
 		    if (buffer[i] == 123)
 			buffer[i] = 20;	/* ctrl-t */
 		for (i = 0; i < strlen(buffer); i++)
 		    if (buffer[i] == 125)
-			buffer[i] = 18;	/* ctrl-r */
+			buffer[i] = CTRL_R;	/* ctrl-r */
 	    }
 	    keyer_append(buffer);
 	}
@@ -322,7 +323,7 @@ void sendbuf(void) {
 		int i = 0;
 		for (i = 0; i < strlen(buffer); i++)
 		    if (buffer[i] == '\n')
-			buffer[i] = 13;
+			buffer[i] = RETURN;
 	    }
 	    keyer_append(buffer);
 	}

--- a/src/showpxmap.c
+++ b/src/showpxmap.c
@@ -28,6 +28,7 @@
 #include "dxcc.h"
 #include "focm.h"
 #include "changepars.h"
+#include "keystroke_names.h"
 #include "tlf.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
@@ -64,7 +65,7 @@ void show_mults(void) {
 
 	while (ch != '\n' && ch != KEY_ENTER) {
 
-	    if (ch == 27)
+	    if (ch == ESCAPE)
 		break;
 
 	    zonecmp[0] = '\0';

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -25,6 +25,7 @@
 
 #include "clear_display.h"
 #include "clusterinfo.h"
+#include "keystroke_names.h"
 #include "stoptx.h"
 #include "tlf_panel.h"
 #include "startmsg.h"
@@ -167,7 +168,7 @@ static int onechar(void) {
     x = getch();
 
     /* Replace Ctl-H and Backspace with KEY_BACKSPACE */
-    if (x == 8 || x == 127)
+    if (x == CTRL_H || x == 127)
 	x = KEY_BACKSPACE;
 
     if (x == 27) {

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -167,11 +167,11 @@ static int onechar(void) {
 
     x = getch();
 
-    /* Replace Ctl-H and Backspace with KEY_BACKSPACE */
-    if (x == CTRL_H || x == 127)
+    /* Replace Ctl-H (Backspace) and Delete with KEY_BACKSPACE */
+    if (x == CTRL_H || x == DELETE)
 	x = KEY_BACKSPACE;
 
-    if (x == 27) {
+    if (x == ESCAPE) {
 	nodelay(stdscr, TRUE);
 
 	x = getch();
@@ -180,7 +180,7 @@ static int onechar(void) {
 	if (x == ERR) {
 	    stoptx();
 
-	    return x = 27;
+	    return x = ESCAPE;
 
 	} else if (x != 91) {
 

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -926,9 +926,9 @@ Toggle PTT (via cwdaemon).
 Exit @PACKAGE_NAME@ (synonym to
 .BR :EXI "t ,"
 .BR :QUI "t ,"
-.BR Ctl-C ,
+.BR Ctrl-C ,
 and
-.BR Ctl-D ")."
+.BR Ctrl-D ")."
 .
 .TP
 .B Alt-R


### PR DESCRIPTION
Many "magic numbers" exist for various keystrokes handled in the code,
mostly callinput.c and getexchange.c but elsewhere.  Even though these
are often commented, symbolic names are more readable.