### PR TITLE
Rescore after delete of QSO 

### DIFF
--- a/ToDo
+++ b/ToDo
@@ -20,7 +20,7 @@ Planned for later versions
 [ ] Refactor write_adif function. Use an add_adif_field() helper and also 
     already existing get_next_record() function.
 [x] Fix arrlsections, paccmults and spdxmults (drop '-end-' marker)
-[ ] Do a complete rescore after delete of QSO automatically
+[x] Do a complete rescore after delete of QSO automatically
 [x] document use of CT9.91 CTY.DAT files in FAQ
 [ ] Have a template for cabrillo file header  (Joop PG4I)
 [ ] Add a keyword to startup TLF in S&P mode (should be an easy one)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,7 @@ tlf_SOURCES = \
 	getsummary.c gettxinfo.c getwwv.c grabspot.c \
 	initial_exchange.c \
 	keyer.c \
-	lancode.c last10.c listmessages.c log_to_disk.c \
+	lancode.c last10.c listmessages.c log_to_disk.c log_utils.c \
 	logit.c logview.c locator2longlat.c \
 	main.c makelogline.c messagechange.c muf.c \
 	nicebox.c note.c netkeyer.c\
@@ -54,7 +54,7 @@ noinst_HEADERS = \
 	getsummary.h gettxinfo.h getwwv.h globalvars.h grabspot.h \
 	ignore_unused.h initial_exchange.h \
 	keyer.h \
-	lancode.h last10.h listmessages.h \
+	lancode.h last10.h listmessages.h log_utils.h \
 	log_to_disk.h logit.h logview.h locator2longlat.h \
 	makelogline.h messagechange.h muf.h \
 	nicebox.h note.h netkeyer.h\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,7 @@ noinst_HEADERS = \
 	get_time.h  getctydata.h getexchange.h getmessages.h getpx.h \
 	getsummary.h gettxinfo.h getwwv.h globalvars.h grabspot.h \
 	ignore_unused.h initial_exchange.h \
-	keyer.h \
+	keyer.h keystroke_names.h \
 	lancode.h last10.h listmessages.h log_utils.h \
 	log_to_disk.h logit.h logview.h locator2longlat.h \
 	makelogline.h messagechange.h muf.h \

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -87,7 +87,6 @@ int changepars(void) {
     extern int ctcomp;
     extern char *config_file;
     extern int miniterm;
-    extern int total;
     extern int simulator;
     extern int cwkeyer;
     extern char synclogfile[];

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -560,21 +560,13 @@ int changepars(void) {
 		synclog(synclogfile);
 	    scroll_log();
 	    /** \todo register return value */
-	    total = 0;
-	    readcalls();
-	    if (qtcdirection > 0) {
-		readqtccalls();
-	    }
+	    log_read_n_score();
 	    clear_display();
 	    break;
 	}
 	case 42: {		/* RESCORE */
 	    /** \todo register return value */
-	    total = 0;
-	    readcalls();
-	    if (qtcdirection > 0) {
-		readqtccalls();
-	    }
+	    log_read_n_score();
 	    clear_display();
 	    break;
 	}

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -24,6 +24,7 @@
  *--------------------------------------------------------------*/
 
 
+#include <ctype.h>
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
@@ -132,16 +133,14 @@ void delete_last_qtcs(char *call, char *bandmode) {
 
 void delete_qso(void) {
 
-    int x;
     struct stat statbuf;
     int lfile;
     char logline[100];
     char call[15], bandmode[6];
 
     mvprintw(13, 29, "OK to delete last qso (y/n)?");
-    x = key_get();
 
-    if ((x == 'y') || (x == 'Y')) {
+    if (toupper(key_get()) == 'Y') {
 
 	if ((lfile = open(logfile, O_RDWR)) < 0) {
 

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -170,11 +170,7 @@ void delete_qso(void) {
 	    fsync(lfile);
 	    close(lfile);
 
-	    total = 0;
-	    nr_qsos = readcalls();
-	    if (qtcdirection > 0) {
-		readqtccalls();
-	    }
+	    nr_qsos = log_read_n_score();
 	}
 	scroll_log();
     }

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
+#include "addcall.h"
 #include "clear_display.h"
 #include "deleteqso.h"
 #include "err_utils.h"
@@ -38,10 +39,11 @@
 #include "qtcutil.h"
 #include "qtcvars.h"		// Includes globalvars.h
 #include "qsonr_to_str.h"
-#include "tlf_curses.h"
+#include "readcalls.h"
+#include "readqtccalls.h"
 #include "scroll_log.h"
+#include "tlf_curses.h"
 #include "ui_utils.h"
-#include "addcall.h"
 
 #define QTCRECVCALLPOS 30
 #define QTCSENTCALLPOS 35
@@ -168,25 +170,17 @@ void delete_qso(void) {
 	    fsync(lfile);
 	    close(lfile);
 
-	    if (qsos[nr_qsos-1][0] != ';') {
-		int band = get_band(qsos[nr_qsos-1]);
-		band_score[band]--;
-		qsonum--;
-		qsonr_to_str();
+	    total = 0;
+	    nr_qsos = readcalls();
+	    if (qtcdirection > 0) {
+		readqtccalls();
 	    }
-
-	    nr_qsos--;
-	    qsos[nr_qsos][0] = '\0';
 	}
-
 	scroll_log();
-
     }
 
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     mvprintw(13, 29, "                            ");
-
-    printcall();
 
     clear_display();
 }

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -69,12 +69,10 @@ void edit(char *filename) {
 }
 
 
-int logedit(void) {
+void logedit(void) {
 
-    extern int total;
     extern char logfile[];
     extern const char backgrnd_str[];
-    extern int qtcdirection;
 
     int j;
 
@@ -82,11 +80,7 @@ int logedit(void) {
     edit(logfile);
     checklogfile();
 
-    total = 0;
-    readcalls();
-    if (qtcdirection > 0) {
-        readqtccalls();
-    }
+    log_read_n_score();
 
     start_background_process();
 
@@ -101,6 +95,4 @@ int logedit(void) {
 	mvprintw(j, 0, backgrnd_str);
     }
     refreshp();
-
-    return (0);
 }

--- a/src/editlog.h
+++ b/src/editlog.h
@@ -22,6 +22,6 @@
 #define EDITLOG_H
 
 void edit(char *filename);
-int logedit(void);
+void logedit(void);
 
 #endif /* EDITLOG_H */

--- a/src/keystroke_names.h
+++ b/src/keystroke_names.h
@@ -1,0 +1,75 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2019      Nate Bargmann <n0nb@n0nb.us>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+/* ------------------------------------------------------------
+ *        Keystroke magic numbers and names as symbolic
+ *        constants.  Values are decimal ordinals provided
+ *        by the ncurses library.  See doc/keynames.txt.
+ *
+ *--------------------------------------------------------------*/
+
+#define CTRL_A    1
+#define CTRL_B    2
+#define CTRL_E    5
+#define CTRL_F    6
+#define CTRL_G    7             /* Bell */
+#define CTRL_H    8             /* Backspace */
+#define CTRL_I    9             /* Tab */
+#define CTRL_J    10            /* Newline/Linefeed */
+#define CTRL_K    11
+#define CTRL_L    12
+#define CTRL_M    13            /* Return */
+#define CTRL_N    14
+#define CTRL_P    16
+#define CTRL_Q    17
+#define CTRL_R    18
+#define CTRL_S    19
+#define CTRL_T    20
+
+/* Keyboard characters */
+#define ESCAPE    27
+#define SPACE     32
+#define BACKSLASH 92
+#define DELETE    127
+
+#define ALT_A     225
+#define ALT_B     226
+#define ALT_C     227
+#define ALT_E     229
+#define ALT_G     231
+#define ALT_H     232
+#define ALT_I     233
+#define ALT_J     234
+#define ALT_K     235
+#define ALT_M     237
+#define ALT_N     238
+#define ALT_P     240
+#define ALT_Q     241
+#define ALT_R     242
+#define ALT_S     243
+#define ALT_T     244
+#define ALT_V     246
+#define ALT_W     247
+#define ALT_X     248
+#define ALT_Z     250
+
+/* Common name macros. */
+#define TAB       CTRL_I
+#define LINEFEED  CTRL_J
+#define RETURN    CTRL_M

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -1,0 +1,35 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2019 Thomas Beierlein <dl1jbe@darc.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+/* ------------------------------------------------------------------------
+*    util functions to work with lines from log
+*
+---------------------------------------------------------------------------*/
+#include <string.h>
+#include <stdbool.h>
+
+/** check if logline is only a comment */
+bool log_is_comment(char *buffer) {
+
+    if (buffer[0] != ';' && strlen(buffer) > 60) /** \todo better check */
+	return 0;
+    else
+	return 1;
+}
+
+

--- a/src/log_utils.h
+++ b/src/log_utils.h
@@ -1,0 +1,30 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2019 Thomas Beierlein <dl1jbe@darc.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+/* ------------------------------------------------------------------------
+*    util functions to work with lines from log
+*
+---------------------------------------------------------------------------*/
+#ifndef LOG_UTILS_H
+#define LOG_UTILS_H
+
+#include <stdbool.h>
+
+bool log_is_comment(char *buffer);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -969,7 +969,7 @@ int main(int argc, char *argv[]) {
     lan_init();
     keyer_init();
 
-    scroll_log();		/* read the last 5  log lines and set the qso number */
+    scroll_log();		/* read the last 5  log lines and set the next serial number */
     nr_qsos = readcalls();	/* read the logfile for score and dupe */
 
     checkparameters();		/* check .paras file */

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -37,6 +37,7 @@
 #include "getpx.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "ignore_unused.h"
+#include "log_utils.h"
 #include "paccdx.h"
 #include "startmsg.h"
 #include "tlf_curses.h"
@@ -161,8 +162,8 @@ int readcalls(void) {
 	strncpy(qsos[s], inputbuffer, LOGLINELEN);
 	s++;
 
-	if (inputbuffer[0] == ';')
-	    continue;		/*  note in  log  */
+	if (log_is_comment(inputbuffer))
+	    continue;		/* skip note in  log  */
 
 	strncpy(presentcall, inputbuffer + 29, 13);
 	presentcall[13] = '\0';
@@ -609,21 +610,6 @@ int readcalls(void) {
 		    countryscore[BANDINDEX_10]++;
 	    }
 	}
-    }
-
-    if (qsonum == 1) {
-	InitPfx();
-
-	total = 0;
-	for (i = 0; i < NBANDS; i++)
-	    band_score[i] = 0;
-
-	for (i = 0; i < NBANDS; i++)
-	    countryscore[i] = 0;
-
-	for (i = 0; i < NBANDS; i++)
-	    multscore[i] = 0;
-
     }
 
     return (s);			// nr of lines in log

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -32,6 +32,8 @@
 
 #include "addmult.h"
 #include "addpfx.h"
+#include "bands.h"
+#include "cabrillo_utils.h"
 #include "get_time.h"
 #include "getctydata.h"
 #include "getpx.h"
@@ -39,10 +41,10 @@
 #include "ignore_unused.h"
 #include "log_utils.h"
 #include "paccdx.h"
+#include "readqtccalls.h"
 #include "startmsg.h"
 #include "tlf_curses.h"
 #include "zone_nr.h"
-#include "bands.h"
 
 
 int readcalls(void) {
@@ -613,6 +615,17 @@ int readcalls(void) {
     }
 
     return (s);			// nr of lines in log
+}
+
+int log_read_n_score() {
+    int nr_qsolines;
+
+    total = 0;
+    nr_qsolines = readcalls();
+    if (qtcdirection > 0) {
+	readqtccalls();
+    }
+    return nr_qsolines;
 }
 
 //------------------------------------------------------------------------

--- a/src/readcalls.h
+++ b/src/readcalls.h
@@ -23,6 +23,7 @@
 #define READCALLS_H
 
 int readcalls(void);
+int log_read_n_score();
 int synclog(char *synclogfile);
 
 #endif /* READCALLS_H */

--- a/src/setparameters.c
+++ b/src/setparameters.c
@@ -147,8 +147,8 @@ int setparameters(void) {
 	    getwwv();		/* get the latest wwv info from packet */
 
 	    scroll_log();	/* read the last 5  log lines and set the qso number */
-
-	    readcalls();	/* read the logfile for score and dupe */
+				/* read the logfile for score and dupe */
+	    log_read_n_score();
 
 	    clear_display();	/* tidy up the display */
 

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -34,6 +34,7 @@
 #include <unistd.h>
 
 #include "getsummary.h"
+#include "log_utils.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
 #include "cabrillo_utils.h"
@@ -43,19 +44,9 @@ extern char call[];
 /* conversion table between tag name in format file and internal tag */
 extern struct tag_conv tag_tbl[];
 
-int is_comment(char *buffer);
 struct qso_t *get_next_record(FILE *fp);
 struct qso_t *get_next_qtc_record(FILE *fp, int qtcdirection);
 void free_qso(struct qso_t *ptr);
-
-/** check if logline is only a comment */
-int is_comment(char *buffer) {
-
-    if (buffer[0] != ';' && strlen(buffer) > 60) /** \todo better check */
-	return 0;
-    else
-	return 1;
-}
 
 /** get next qso record from log
  *
@@ -75,7 +66,7 @@ struct qso_t *get_next_record(FILE *fp) {
 
     while ((fgets(buffer, sizeof(buffer), fp)) != NULL) {
 
-	if (!is_comment(buffer)) {
+	if (!log_is_comment(buffer)) {
 
 	    ptr = g_malloc0(sizeof(struct qso_t));
 


### PR DESCRIPTION
Until now after deleting a QSO we try to correct the counters for qso numbers and multipliers. That works only partially. Not all changes can be undone that way.

The proposed patch does always a complete rescore of the log file after delete. So all counters are correct.

There are some further changes to simplify the code and sort out weird sequences (especially the handling of an empty log at the end of readcalls()). 

Additionally a new file with helper functions for decoding parts of log lines got added.