### PR TITLE
Added variable space generation

### DIFF
--- a/src/addspot.c
+++ b/src/addspot.c
@@ -36,6 +36,7 @@
 #include "splitscreen.h"
 #include "tlf.h"
 #include "tlf_curses.h"
+#include "ui_utils.h"
 
 
 /** add call to list of spots
@@ -53,7 +54,7 @@ void add_to_spots(char *call, freq_t freq) {
     char spottime[6];
 
     sprintf(spotline, "DX de TLF-%c:     %9.3f  %s", thisnode, freq / 1000.0, call);
-    strcat(spotline, "                                           ");
+    strcat(spotline, spaces(43));
 
     get_time();
 
@@ -68,15 +69,16 @@ void add_to_spots(char *call, freq_t freq) {
 }
 
 
-int addspot(void) {
+void addspot(void) {
     extern freq_t freq;
     extern char hiscall[];
     extern int trx_control;
 
     char frequency[8];
 
-    if (strlen(hiscall) < 3)
-	return (0);
+    if (strlen(hiscall) < 3) {
+	return;
+    }
 
     if (trx_control == 0) {
 
@@ -93,5 +95,4 @@ int addspot(void) {
 
     hiscall[0] = '\0';
 
-    return (0);
 }

--- a/src/addspot.h
+++ b/src/addspot.h
@@ -24,6 +24,6 @@
 #include <hamlib/rig.h>
 
 void add_to_spots(char *call, freq_t freq);
-int addspot(void);
+void addspot(void);
 
 #endif /* ADDSPOT_H */

--- a/src/audio.c
+++ b/src/audio.c
@@ -47,8 +47,7 @@ void recordmenue(void) {
     attron(modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
 
     for (j = 0; j <= 24; j++)
-	mvprintw(j, 0,
-		 "                                                                                ");
+	mvprintw(j, 0, backgrnd_str);
 
     mvprintw(1, 20, "--- TLF SOUND RECORDER UTILITY ---");
     mvprintw(6, 20, "F1 ... F12, S, C: Record Messages");

--- a/src/autocq.c
+++ b/src/autocq.c
@@ -104,7 +104,7 @@ int auto_cq(void) {
 	    }
 	}
 
-	mvprintw(12, 29, "            ");
+	mvprintw(12, 29, spaces(13));
 	mvprintw(12, 29, "");
 	refreshp();
     }
@@ -116,7 +116,7 @@ int auto_cq(void) {
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
-    mvprintw(12, 29, "             ");
+    mvprintw(12, 29, spaces(13));
     printcall();
 
     return toupper(key);

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -112,7 +112,6 @@ int callinput(void) {
     extern char lastcall[];
     extern int cqdelay;
     extern char his_rst[];
-    extern const char backgrnd_str[];
     extern int cluster;
     extern int announcefilter;
     extern char ph_message[14][80];

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -1054,7 +1054,6 @@ int debug_tty(void) {
 
 void wipe_display() {
     int j;
-    extern const char backgrnd_str[];
 
     attron(modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
 

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -71,7 +71,6 @@ void clear_display(void) {
     extern char terminal2[];
     extern char terminal3[];
     extern char terminal4[];
-    extern const char backgrnd_str[];
     extern char band[NBANDS][4];
     extern int bandinx;
     extern int trxmode;

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -56,7 +56,6 @@ int getclusterinfo(void);
 void clusterinfo(void) {
 
     extern int cluster;
-    extern const char backgrnd_str[];
     extern freq_t freq;
     extern char band[NBANDS][4];
     extern int bandinx;

--- a/src/displayit.c
+++ b/src/displayit.c
@@ -28,6 +28,7 @@
 
 #include <glib.h>
 
+#include "tlf.h"
 #include "clear_display.h"
 #include "tlf_curses.h"
 
@@ -35,7 +36,6 @@
 void displayit(void) {
 
     extern char termbuf[];
-    extern const char backgrnd_str[];
     extern char terminal1[];
     extern char terminal2[];
     extern char terminal3[];

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -72,7 +72,6 @@ void edit(char *filename) {
 void logedit(void) {
 
     extern char logfile[];
-    extern const char backgrnd_str[];
 
     int j;
 

--- a/src/err_utils.c
+++ b/src/err_utils.c
@@ -17,14 +17,13 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 #include "err_utils.h"
+#include "tlf.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
 #include <glib.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <unistd.h>
-
-extern const char backgrnd_str[];
 
 void handle_logging(enum log_lvl lvl, ...) {
     char *fmt;

--- a/src/freq_display.c
+++ b/src/freq_display.c
@@ -270,7 +270,7 @@ void clear_freq_display(int y, int x) {
     attron(modify_attr(COLOR_PAIR(C_LOG)));
 
     for (int i = 0; i < 5; ++i) {
-	mvprintw(y + i, x, "                                   ");
+	mvprintw(y + i, x, spaces(35));
     }
 
 }

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -1128,7 +1128,7 @@ void exchange_edit(void) {
 	attroff(A_STANDOUT);
 	attron(COLOR_PAIR(C_HEADER));
 
-	mvprintw(12, 54, "                          ");
+	mvprintw(12, 54, spaces(80 - 54));
 	mvprintw(12, 54, comment);
 	mvprintw(12, 54 + b, "");
 

--- a/src/getmessages.c
+++ b/src/getmessages.c
@@ -37,16 +37,16 @@
 #include "ignore_unused.h"
 #include "tlf_curses.h"
 
+extern char call[];
+extern int mycountrynr;
+extern char mycqzone[];
+extern char mycontinent[];
+extern double QTH_Lat;
+extern double QTH_Long;
+
 
 /* get countrynumber, QTH, CQ zone and continent for myself */
 void getstationinfo() {
-    extern char call[];
-    extern int mycountrynr;
-    extern char mycqzone[];
-    extern char mycontinent[];
-    extern double QTH_Lat;
-    extern double QTH_Long;
-
     dxcc_data *mydx;
 
     mycountrynr = getctydata(call);	/* whoami? */
@@ -61,23 +61,10 @@ void getstationinfo() {
 
 void getmessages(void) {
 
-    extern char call[];
-    extern char mycqzone[];
-    extern char mycontinent[];
-    extern char logfile[];
-    extern int qsonum;
-    extern char qsonrstr[];
-    extern const char backgrnd_str[];
-
-    FILE *fp;
-
-    int i, ii;
-    char logline[5][82];
+    getstationinfo();
 
     printw("\n     Call = ");
     printw(call);
-
-    getstationinfo();
 
     printw("     My Zone = ");
     printw(mycqzone);
@@ -87,67 +74,4 @@ void getmessages(void) {
 
     printw("\n\n");
     refreshp();
-
-    if ((fp = fopen(logfile, "r")) == NULL) {
-	printw("\nError opening logfile.\nExiting...\n");
-	refreshp();
-	sleep(5);
-	endwin();
-	exit(1);
-    }
-
-    for (i = 5; i >= 1; i--) {
-
-	ii = 5 - i;
-
-	if (fseek(fp, -1L * i * LOGLINELEN, SEEK_END) == 0) {
-	    IGNORE(fgets(logline[ii], 85, fp));;
-	} else {
-	    strncpy(logline[ii], backgrnd_str, 81);
-	}
-
-	logline[ii][80] = '\0';
-	logline[ii][78] = 32;
-	logline[ii][79] = 32;
-    }
-
-    fclose(fp);
-
-
-    strncpy(qsonrstr, logline[4] + 23, 4);
-    qsonrstr[4] = '\0';
-
-    qsonum = atoi(qsonrstr) + 1;
-
-    if (qsonum == 1) {
-	strncpy(qsonrstr, logline[3] + 23, 4);
-	qsonrstr[4] = '\0';
-	qsonum = atoi(qsonrstr) + 1;
-	qsonr_to_str();
-    }
-
-    if (strlen(logline[0]) >= 75)
-	strncpy(logline0, logline[0], 80);
-    else
-	strcpy(logline0, backgrnd_str);
-
-    if (strlen(logline[1]) >= 75)
-	strncpy(logline1, logline[1], 80);
-    else
-	strcpy(logline1, backgrnd_str);
-
-    if (strlen(logline[2]) >= 75)
-	strncpy(logline2, logline[2], 80);
-    else
-	strcpy(logline2, backgrnd_str);
-
-    if (strlen(logline[3]) >= 75)
-	strncpy(logline3, logline[3], 80);
-    else
-	strcpy(logline3, backgrnd_str);
-
-    if (strlen(logline[4]) >= 75)
-	strncpy(logline4, logline[4], 80);
-    else
-	strcpy(logline4, backgrnd_str);
 }

--- a/src/getwwv.c
+++ b/src/getwwv.c
@@ -34,7 +34,6 @@ extern int ymax;
 int getwwv(void) {
 
     extern char lastwwv[];
-    extern const char backgrnd_str[];
     extern double r;
     extern int mycountrynr;
     extern int timeoffset;

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -88,8 +88,6 @@ int time_master;
 char thisnode = 'A'; 		/*  start with 'A' if not defined in
 				    logcfg.dat */
 
-extern const char backgrnd_str[];
-
 //---------------------end lan globals --------------
 
 int resolveService(const char *service) {

--- a/src/listmessages.c
+++ b/src/listmessages.c
@@ -37,12 +37,10 @@
 #define LIST_UPPER  7
 #define LIST_LEFT   0
 
-
 char  printbuffer[160];
 
 char *formatMessage(int i) {
     extern char message[][80];
-    extern const char backgrnd_str[];
 
     /* copy the message string WITHOUT trailing newline/space */
     if (trxmode == DIGIMODE)
@@ -57,7 +55,6 @@ char *formatMessage(int i) {
 }
 
 void listmessages(void) {
-    extern const char backgrnd_str[];
 
     int i;
 

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -51,7 +51,7 @@ pthread_mutex_t disk_mutex = PTHREAD_MUTEX_INITIALIZER;
  *
  * \param from_lan true - Log lanmessage, false - normal message
  */
-int log_to_disk(int from_lan) {
+void log_to_disk(int from_lan) {
     extern char my_rst[];
     extern char his_rst[];
     extern char last_rst[4];
@@ -90,8 +90,7 @@ int log_to_disk(int from_lan) {
     } else {			// qso from lan
 
 	strncpy(lan_logline, lan_message + 2, 87);
-	strcat(lan_logline,
-	       "                                                                              ");
+	strcat(lan_logline, spaces(78));
 
 	if (cqwwm2 == 1) {
 	    if (lan_logline[0] != thisnode)
@@ -120,7 +119,7 @@ int log_to_disk(int from_lan) {
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));	/* erase comment  field */
 
     if (!from_lan)
-	mvprintw(12, 54, "                          ");
+	mvprintw(12, 54, spaces(80 - 54));
 
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     if (!from_lan) {
@@ -154,5 +153,4 @@ int log_to_disk(int from_lan) {
 
     pthread_mutex_unlock(&disk_mutex);
 
-    return (0);
 }

--- a/src/log_to_disk.h
+++ b/src/log_to_disk.h
@@ -21,6 +21,6 @@
 #ifndef LOG_TO_DISK_H
 #define LOG_TO_DISK_H
 
-int log_to_disk(int from_lan);
+void log_to_disk(int from_lan);
 
 #endif /*  LOG_TO_DISK_H */

--- a/src/logit.c
+++ b/src/logit.c
@@ -224,7 +224,7 @@ void refresh_comment(void) {
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
-    mvprintw(12, 54, "                          ");
+    mvprintw(12, 54, spaces(80 - 54));
     mvprintw(12, 54, comment);
 }
 

--- a/src/logview.c
+++ b/src/logview.c
@@ -33,7 +33,6 @@
 
 int logview(void) {
     extern char logfile[];
-    extern const char backgrnd_str[];
 
     char comstr[40]  = "";
     int j;

--- a/src/main.c
+++ b/src/main.c
@@ -421,8 +421,7 @@ freq_t bandfrequency[NBANDS] = {
 
 const char headerline[] =
     "   1=CQ  2=DE  3=RST 4=73  5=HIS  6=MY  7=B4   8=AGN  9=?  ";
-const char backgrnd_str[81] =
-    "                                                                                ";
+const char *backgrnd_str;
 
 char logline_edit[5][LOGLINELEN + 1];
 
@@ -896,11 +895,13 @@ void tlf_cleanup() {
 /* ------------------------------------------------------------------------*/
 /*     Main loop of the program			                           */
 /* ------------------------------------------------------------------------*/
-
 int main(int argc, char *argv[]) {
     int j;
     int ret;
     char welcome[80];
+
+    backgrnd_str = spaces(80);
+
     sprintf(welcome, "        Welcome to %s by PA0R!!", argp_program_version);
 
     argp_parse(&argp, argc, argv, 0, 0, NULL);  // parse options

--- a/src/messagechange.c
+++ b/src/messagechange.c
@@ -35,7 +35,6 @@
 
 
 int message_change(int x) {
-    extern const char backgrnd_str[];
     extern char message[][80];
 
     int j;

--- a/src/muf.c
+++ b/src/muf.c
@@ -154,7 +154,6 @@ int muf(void) {
     extern int mycountrynr;
     extern int countrynr;
     extern char lastwwv[];
-    extern const char backgrnd_str[];
 
     dxcc_data *dx;
     int row;

--- a/src/note.c
+++ b/src/note.c
@@ -33,7 +33,6 @@
 
 int include_note(void) {
 
-    extern const char backgrnd_str[];
     extern char logfile[];
     extern char qsonrstr[];
     extern char thisnode;

--- a/src/rtty.c
+++ b/src/rtty.c
@@ -174,27 +174,28 @@ void ry_addchar(char c) {
 
 /* ----------------------  display rtty ---------------------------------- */
 
-int show_rtty(void) {
+void show_rtty(void) {
 
     extern int miniterm;
     extern int commentfield;
     extern char comment[];
 
-    if (miniterm == 0)
-	return (-1);
+    if (!miniterm) {
+	return;
+    }
 
     attroff(A_STANDOUT);
     attron(modify_attr(COLOR_PAIR(C_HEADER)));
 
-    mvprintw(1, 0, "                                        ");
+    mvprintw(1, 0, spaces(40));
     mvprintw(1, 0, "%s", ry_term[0]);
-    mvprintw(2, 0, "                                        ");
+    mvprintw(2, 0, spaces(40));
     mvprintw(2, 0, "%s", ry_term[1]);
-    mvprintw(3, 0, "                                        ");
+    mvprintw(3, 0, spaces(40));
     mvprintw(3, 0, "%s", ry_term[2]);
-    mvprintw(4, 0, "                                        ");
+    mvprintw(4, 0, spaces(40));
     mvprintw(4, 0, "%s", ry_term[3]);
-    mvprintw(5, 0, "                                        ");
+    mvprintw(5, 0, spaces(40));
     mvprintw(5, 0, "%s", ry_term[4]);
     if (commentfield == 0) {
 	printcall();
@@ -204,7 +205,6 @@ int show_rtty(void) {
     refreshp();
     attron(A_STANDOUT);
 
-    return (0);
 }
 
 /* ---------------------  receive rtty ----------------------------------- */

--- a/src/rtty.h
+++ b/src/rtty.h
@@ -29,7 +29,7 @@
 int init_controller() ;
 void deinit_controller();
 int rx_rtty() ;
-int show_rtty(void);
+void show_rtty(void);
 
 #endif /* end of include guard: RTTY_H */
 

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include "err_utils.h"
+#include "ui_utils.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "log_utils.h"
 #include "ignore_unused.h"
@@ -108,8 +109,7 @@ void scroll_log(void) {
 	if (fseek(fp, -1L * i * LOGLINELEN, SEEK_END) == 0)
 	    IGNORE(fgets(inputbuffer, 90, fp));
 	else
-	    strcpy(inputbuffer,
-		   "                                                                                ");
+	    strcpy(inputbuffer, spaces(80));
 
 	if (strlen(inputbuffer) <= 10)	/* log repair */
 	    IGNORE(fgets(inputbuffer, 90, fp));;

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -112,8 +112,7 @@ void drawSearchWin(void) {
 
     wattrset(search_win, COLOR_PAIR(C_LOG) | A_STANDOUT);
     for (i = 0; i < nr_bands; i++)
-	mvwprintw(search_win, i + 1, 1,
-		  "                                     ");
+	mvwprintw(search_win, i + 1, 1, spaces(37));
 
     mvwprintw(search_win, 1, 1, " 10");
     mvwprintw(search_win, 2, 1, " 15");
@@ -871,7 +870,7 @@ void show_needed_sections(void) {
 	wattron(search_win, modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
 
 	for (j = 1; j < 7; j++)
-	    mvwprintw(search_win, j, 1, "                                     ");
+	    mvwprintw(search_win, j, 1, spaces(37));
 
 	for (vert = 1; vert < 7; vert++) {
 	    if (cnt >= get_mult_count())

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -248,7 +248,6 @@ void sendbuf(void) {
     extern int trxmode;
     extern int searchflg;
     extern char termbuf[];
-    extern const char backgrnd_str[];
     extern int cwkeyer;
     extern int digikeyer;
     extern int simulator;

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -56,7 +56,6 @@ void showinfo(int x) {
     extern long timecorr;
     extern char itustr[];
     extern int mycountrynr;
-    extern const char backgrnd_str[];
 
     int cury, curx;
     char pxstr[16];
@@ -131,9 +130,7 @@ void showinfo(int x) {
     if (contstr[0] != '-') {
 	mvprintw(LINES - 1, 0, " %s  %s", pxstr, countrystr);
 
-	mvprintw(LINES - 1, 26,
-		 " %s %s",
-		 contstr, zonestr);
+	mvprintw(LINES - 1, 26, " %s %s", contstr, zonestr);
 
 	if (x != 0 && x != mycountrynr && 0 == get_qrb(&range, &bearing)) {
 	    mvprintw(LINES - 1, 35, "%.0f km/%.0f deg ", range, bearing);

--- a/src/showpxmap.c
+++ b/src/showpxmap.c
@@ -87,8 +87,7 @@ void show_mults(void) {
 	    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
 	    for (l = 1; l < 6; l++)
-		mvprintw(l, 0,
-			 "                                                                                ");
+		mvprintw(l, 0, backgrnd_str);
 
 	    i = 0;
 
@@ -139,8 +138,7 @@ void show_mults(void) {
 
 	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 	for (l = 1; l < 6; l++)
-	    mvprintw(l, 0,
-		     "                                                                                ");
+	    mvprintw(l, 0, backgrnd_str);
     } else
 
 	multiplierinfo();

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -33,6 +33,7 @@
 #include "nicebox.h"		// Includes curses.h
 #include "printcall.h"
 #include "bands.h"
+#include "ui_utils.h"
 
 #define START_COL 45	/* start display in these column */
 
@@ -65,7 +66,7 @@ void stewperry_show_summary(int points, float fixedmult);
 void stewperry_show_summary(int points, float fixedmult) {
     float mult;
 
-    mvprintw(5, START_COL, "                                   ");
+    mvprintw(5, START_COL, spaces(80 - START_COL));
     /* TODO: respect field boundaries for large numbers */
     mult = (fixedmult == 0.0) ? 1.0 : fixedmult;
 
@@ -76,7 +77,7 @@ void stewperry_show_summary(int points, float fixedmult) {
 
 /* show summary line */
 void show_summary(int points, int multi) {
-    mvprintw(5, START_COL, "                                   ");
+    mvprintw(5, START_COL, spaces(80 - START_COL));
     /* TODO: respect field boundaries for large numbers */
     mvprintw(5, START_COL, "Pts: %d  Mul: %d Score: %d",
 	     points, multi, points * multi);
@@ -112,9 +113,9 @@ void display_header(int *bi) {
 	printfield(2, band_cols[i], band_score[bi[i]]);
     }
 
-    mvprintw(3, START_COL, "                                   ");
-    mvprintw(4, START_COL, "                                   ");
-    mvprintw(5, START_COL, "                                   ");
+    mvprintw(3, START_COL, spaces(80 - START_COL));
+    mvprintw(4, START_COL, spaces(80 - START_COL));
+    mvprintw(5, START_COL, spaces(80 - START_COL));
 
 }
 
@@ -229,7 +230,7 @@ int get_total_score() {
  *
  * display scoring results of contest if activated by 'showscore_flag'
  */
-int showscore(void) {
+void showscore(void) {
 
     extern int showscore_flag;
     extern int cqww;
@@ -256,135 +257,135 @@ int showscore(void) {
     int i, l10;
     float p;
 
-    if (showscore_flag == 1) {
-
-	/* show header with active band and number of QSOs */
-	if (!IsWarcIndex(bandinx)) {
-
-	    display_header(bi_normal);
-
-	} else {
-
-	    display_header(bi_warc);
-	}
-
-	/* show score per band */
-	if ((wysiwyg_multi == 1)
-		|| (serial_section_mult == 1)
-		|| (serial_grid4_mult == 1)
-		|| (sectn_mult == 1)) {
-
-	    mvprintw(3, START_COL, "Mult ");
-	    for (i = 0; i < 6; i++) {
-		printfield(3, band_cols[i], multscore[bi_normal[i]]);
-	    }
-	}
-
-	if ((itumult == 1) || (wazmult == 1)) {
-
-	    mvprintw(3, START_COL, "Mult ");
-	    for (i = 0; i < 6; i++) {
-		printfield(3, band_cols[i], zonescore[bi_normal[i]]);
-	    }
-	}
-
-	if (pfxmultab == 1) {
-	    mvprintw(3, START_COL, "Mult ");
-	    for (i = 0; i < 6; i++) {
-		printfield(3, band_cols[i], GetNrOfPfx_OnBand(bi_normal[i]));
-	    }
-	}
-
-	if (dx_arrlsections == 1) {
-
-	    mvprintw(3, START_COL, "Cty  ");
-	    for (i = 0; i < 6; i++) {
-		printfield(3, band_cols[i], countryscore[bi_normal[i]]);
-	    }
-
-	    mvprintw(4, START_COL, "Sect");
-	    for (i = 0; i < 6; i++) {
-		printfield(4, band_cols[i], multscore[bi_normal[i]]);
-	    }
-	}
-
-	if (cqww == 1) {
-
-	    mvprintw(3, START_COL, "Cty  ");
-	    for (i = 0; i < 6; i++) {
-		printfield(3, band_cols[i], countryscore[bi_normal[i]]);
-	    }
-
-	    mvprintw(4, START_COL, "Zone ");
-	    for (i = 0; i < 6; i++) {
-		printfield(4, band_cols[i], zonescore[bi_normal[i]]);
-	    }
-	}
-
-	if (arrldx_usa == 1) {
-
-	    mvprintw(3, START_COL, "Cty  ");
-	    for (i = 0; i < 6; i++) {
-		printfield(3, band_cols[i], countryscore[bi_normal[i]]);
-	    }
-	}
-
-	if (universal == 1 && country_mult == 1) {
-
-	    mvprintw(3, START_COL, "Cty  ");
-	    for (i = 0; i < 6; i++) {
-		printfield(3, band_cols[i], countryscore[bi_normal[i]]);
-	    }
-	}
-
-	if (pacc_pa_flg == 1) {
-
-	    mvprintw(3, START_COL, "Cty  ");
-	    for (i = 0; i < 6; i++) {
-		printfield(3, band_cols[i], countryscore[bi_normal[i]]);
-	    }
-	}
-
-	/* show score summary */
-	if (sprint == 1) {
-
-	    mvprintw(5, START_COL, "Score: %d", get_nr_of_points());
-	} else if (focm == 1) {
-	    foc_show_scoring(START_COL);
-	} else if (stewperry_flg == 1) {
-	    /* no normal multis, but may have POWERMULT set (fixedmult != 0.) */
-	    stewperry_show_summary(get_nr_of_points(), fixedmult);
-	} else {
-	    show_summary(get_nr_of_points(), get_nr_of_mults());
-	}
-
-
-	/* show statistics */
-	attron(COLOR_PAIR(C_HEADER));
-	mvprintw(6, 55, "                   ");
-
-	if ((cqww == 1) || (wpx == 1) || (arrldx_usa == 1) || (pacc_pa_flg == 1)
-		|| (wysiwyg_once == 1) || (universal == 1)) {	/* cqww or wpx */
-
-	    totalmults = get_nr_of_mults();
-	    totalmults = totalmults ? totalmults : 1;	/* at least one */
-	    p = ((qsonum - 1) / (float)totalmults);
-
-	    if ((l10 = last10()) >= 1)
-		mvprintw(6, 55, "Q/M %.1f  Rate %d ", p, (60 * 10) / l10);
-	    else
-		mvprintw(6, 55, "Q/M %.1f ", p);
-	}
-
-	if (wpx == 1) {
-	    if (minute_timer > 0)
-		mvprintw(6, 75, "%d", minute_timer);
-	}
-
-	printcall();
-
+    if (!showscore_flag) {
+        return;
     }
-    return (0);
+
+    /* show header with active band and number of QSOs */
+    if (!IsWarcIndex(bandinx)) {
+
+        display_header(bi_normal);
+
+    } else {
+
+        display_header(bi_warc);
+    }
+
+    /* show score per band */
+    if ((wysiwyg_multi == 1)
+            || (serial_section_mult == 1)
+            || (serial_grid4_mult == 1)
+            || (sectn_mult == 1)) {
+
+        mvprintw(3, START_COL, "Mult ");
+        for (i = 0; i < 6; i++) {
+            printfield(3, band_cols[i], multscore[bi_normal[i]]);
+        }
+    }
+
+    if ((itumult == 1) || (wazmult == 1)) {
+
+        mvprintw(3, START_COL, "Mult ");
+        for (i = 0; i < 6; i++) {
+            printfield(3, band_cols[i], zonescore[bi_normal[i]]);
+        }
+    }
+
+    if (pfxmultab == 1) {
+        mvprintw(3, START_COL, "Mult ");
+        for (i = 0; i < 6; i++) {
+            printfield(3, band_cols[i], GetNrOfPfx_OnBand(bi_normal[i]));
+        }
+    }
+
+    if (dx_arrlsections == 1) {
+
+        mvprintw(3, START_COL, "Cty  ");
+        for (i = 0; i < 6; i++) {
+            printfield(3, band_cols[i], countryscore[bi_normal[i]]);
+        }
+
+        mvprintw(4, START_COL, "Sect");
+        for (i = 0; i < 6; i++) {
+            printfield(4, band_cols[i], multscore[bi_normal[i]]);
+        }
+    }
+
+    if (cqww == 1) {
+
+        mvprintw(3, START_COL, "Cty  ");
+        for (i = 0; i < 6; i++) {
+            printfield(3, band_cols[i], countryscore[bi_normal[i]]);
+        }
+
+        mvprintw(4, START_COL, "Zone ");
+        for (i = 0; i < 6; i++) {
+            printfield(4, band_cols[i], zonescore[bi_normal[i]]);
+        }
+    }
+
+    if (arrldx_usa == 1) {
+
+        mvprintw(3, START_COL, "Cty  ");
+        for (i = 0; i < 6; i++) {
+            printfield(3, band_cols[i], countryscore[bi_normal[i]]);
+        }
+    }
+
+    if (universal == 1 && country_mult == 1) {
+
+        mvprintw(3, START_COL, "Cty  ");
+        for (i = 0; i < 6; i++) {
+            printfield(3, band_cols[i], countryscore[bi_normal[i]]);
+        }
+    }
+
+    if (pacc_pa_flg == 1) {
+
+        mvprintw(3, START_COL, "Cty  ");
+        for (i = 0; i < 6; i++) {
+            printfield(3, band_cols[i], countryscore[bi_normal[i]]);
+        }
+    }
+
+    /* show score summary */
+    if (sprint == 1) {
+
+        mvprintw(5, START_COL, "Score: %d", get_nr_of_points());
+    } else if (focm == 1) {
+        foc_show_scoring(START_COL);
+    } else if (stewperry_flg == 1) {
+        /* no normal multis, but may have POWERMULT set (fixedmult != 0.) */
+        stewperry_show_summary(get_nr_of_points(), fixedmult);
+    } else {
+        show_summary(get_nr_of_points(), get_nr_of_mults());
+    }
+
+
+    /* show statistics */
+    attron(COLOR_PAIR(C_HEADER));
+    mvprintw(6, 55, spaces(19));
+
+    if ((cqww == 1) || (wpx == 1) || (arrldx_usa == 1) || (pacc_pa_flg == 1)
+            || (wysiwyg_once == 1) || (universal == 1)) {	/* cqww or wpx */
+
+        totalmults = get_nr_of_mults();
+        totalmults = totalmults ? totalmults : 1;	/* at least one */
+        p = ((qsonum - 1) / (float)totalmults);
+
+        if ((l10 = last10()) >= 1)
+            mvprintw(6, 55, "Q/M %.1f  Rate %d ", p, (60 * 10) / l10);
+        else
+            mvprintw(6, 55, "Q/M %.1f ", p);
+    }
+
+    if (wpx == 1) {
+        if (minute_timer > 0)
+            mvprintw(6, 75, "%d", minute_timer);
+    }
+
+    printcall();
+
 }
 
 /** formated print of integer number 0..9999 */

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -50,8 +50,6 @@
 #include "ui_utils.h"
 #include "err_utils.h"
 
-extern const char backgrnd_str[];
-
 struct tln_logline {
     struct tln_logline *next;
     struct tln_logline *prev;
@@ -692,10 +690,8 @@ void addtext(char *s) {
 			spotline[m] -= 32;
 		}
 
-		strcat(spotline,
-		       "                                           ");
+		strcat(spotline, spaces(43));
 		get_time();
-//                                              strftime(spottime, 80, "%H%MZ", time_ptr);      ### bug fix
 		strftime(spottime, sizeof(spottime), "%H%MZ", time_ptr);
 		strcpy(spotline + 70, spottime);
 		spotline[75] = '\0';

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -106,7 +106,7 @@ void show_freq(void) {
 	if (mem > 0.0)
 	    mvprintw(14, 67, " MEM: %7.1f", mem / 1000.0);
 	else
-	    mvprintw(14, 67, "             ");
+	    mvprintw(14, 67, spaces(80 - 67));
 
 	if ((showfreq == 1) && (showscore_flag == 0)) {
 
@@ -114,8 +114,8 @@ void show_freq(void) {
 	}
     }
     else {
-	mvprintw(13, 67, "             ");
-	mvprintw(14, 67, "             ");
+	mvprintw(13, 67, spaces(80 - 67));
+	mvprintw(14, 67, spaces(80 - 67));
     }
 }
 
@@ -190,8 +190,7 @@ void time_update(void) {
 	    mvprintw(9, 0, logline2);
 	    mvprintw(10, 0, logline3);
 	    mvprintw(11, 0, logline4);
-	    mvprintw(13, 0,
-		     "                                                                    ");
+	    mvprintw(13, 0, spaces(67));
 	    attron(COLOR_PAIR(C_WINDOW));
 	    mvprintw(12, 23, qsonrstr);
 	    printcall();

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -165,5 +165,7 @@ typedef struct {
 
 void refreshp();
 
+extern const char *backgrnd_str;
+
 #endif /* TLF_H */
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -22,6 +22,7 @@
 
 #include <pthread.h>
 #include <unistd.h>
+#include <glib.h>
 
 #include "clear_display.h"
 #include "clusterinfo.h"
@@ -338,4 +339,23 @@ void resize_layout(void) {
     clear_display();
     clusterinfo();
     refresh_splitlayout();
+}
+
+#define MAX_SPACES  1000
+
+static char *spaces_buffer = NULL;
+
+const char *spaces(int n) {
+
+    if (spaces_buffer == NULL) {
+	spaces_buffer = g_strnfill(MAX_SPACES, ' ');
+    }
+
+    if (n < 0) {
+	n = 0;
+    } else if (n > MAX_SPACES) {
+	n = MAX_SPACES;
+    }
+
+    return spaces_buffer + (MAX_SPACES - n);
 }

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -38,5 +38,6 @@ int key_get();
 int key_poll();
 void resize_layout();
 
+const char *spaces(int);
 
 #endif /* UI_UTILS_H */

--- a/test/data.c
+++ b/test/data.c
@@ -374,7 +374,7 @@ freq_t bandfrequency[9] = {
 
 char headerline[81] =
     "   1=CQ  2=DE  3=RST 4=73  5=HIS  6=MY  7=B4   8=AGN  9=?  \n";
-char backgrnd_str[81] =
+const char *backgrnd_str =
     "                                                                                ";
 
 char logline_edit[5][LOGLINELEN + 1];

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -16,6 +16,7 @@
 // OBJECT ../src/qtcutil.o
 // OBJECT ../src/printcall.o
 // OBJECT ../src/err_utils.o
+// OBJECT ../src/ui_utils.o
 
 extern WINDOW *search_win;
 extern PANEL *search_panel;
@@ -45,9 +46,16 @@ int stoptx() {
     return 0;
 }
 
-// ui_utils.c
-int modify_attr(int attr) {
-    return attr;
+// clear_display.c
+void clear_display() {
+}
+
+// clusterinfo.c
+void clusterinfo() {
+}
+
+// splitscreen.c
+void refresh_splitlayout() {
 }
 
 // get_time.c


### PR DESCRIPTION
While preparing the switch back feature I ran across a bunch of hard coded strings of spaces.
Added a `spaces(int)` function in order to get them more under control and to facilitate eventual horizontal resizing.

The spaces are served from a pre-allocated string of 1000 spaces. The returned value must be used for reading only.

Also voidified some functions (`addspot`, `log_to_disk`, `show_rtty`, `showscore`). Latter got an early exit to reduce somewhat its complexity.

`getmessages`: removed yet another log reading. This function has nothing to do neither with messages nor with `.paras` file as some comments suggest. That file is in fact write-only and used solely for first run recognition. getmessages deserves a renaming in the near future.

Found some functions that don't use their arguments (e.g. `int country_found(char prefix[])`), they'll be checked in separately.