### PR TITLE
Fix warnings and improve

### DIFF
--- a/src/addcall.c
+++ b/src/addcall.c
@@ -26,7 +26,9 @@
 #define _GNU_SOURCE
 #endif
 
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE
+#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -113,7 +113,7 @@ void calledit(void) {
 	    showinfo(getctydata_pfx(hiscall));
 
 	    if (cnt > 1)
-		searchlog(hiscall);
+		searchlog();
 
 	    // <Backspace>
 	} else if (i == KEY_BACKSPACE) {
@@ -131,7 +131,7 @@ void calledit(void) {
 		showinfo(getctydata_pfx(hiscall));
 
 		if (cnt > 1)
-		    searchlog(hiscall);
+		    searchlog();
 	    }
 
 	    // <Insert>
@@ -180,7 +180,7 @@ void calledit(void) {
 
 		showinfo(getctydata_pfx(hiscall));
 
-		searchlog(hiscall);
+		searchlog();
 
 	    } else if (x != 0)
 		i = ESCAPE;
@@ -198,7 +198,7 @@ void calledit(void) {
     refreshp();
 
     attron(A_STANDOUT);
-    searchlog(hiscall);
+    searchlog();
 }
 
 int insert_char(int curposition) {

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -168,7 +168,7 @@ int callinput(void) {
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
     printcall();	/* print call input field */
-    searchlog(hiscall);
+    searchlog();
 
     while (strlen(hiscall) <= 13) {
 
@@ -219,7 +219,7 @@ int callinput(void) {
 
 		    showinfo(getctydata_pfx(hiscall));
 		    printcall();
-		    searchlog(hiscall);
+		    searchlog();
 		    freqstore = 0;
 		}
 	    }
@@ -307,8 +307,7 @@ int callinput(void) {
 
 			if (*comment == '\0') {
 			    x = -1;
-			}
-			else {
+			} else {
 			    /* F4 (TU macro) */
 			    send_standard_message(3);
 
@@ -496,8 +495,7 @@ int callinput(void) {
 		    if (comment[0] == '\0') {
 			x = -1;
 			break;
-		    }
-		    else {
+		    } else {
 			/* Log without sending message. */
 			x = BACKSLASH;
 			break;
@@ -510,7 +508,7 @@ int callinput(void) {
 		/* check b4 QSO if call is long enough and 'nob4' off */
 		isdupe = 0;	// LZ3NY  auto-b4 patch
 
-		searchlog(hiscall);
+		searchlog();
 
 		if (isdupe != 0) {
 		    // XXX: Before digi_message, SSB mode sent CW here. - W8BSD
@@ -524,12 +522,12 @@ int callinput(void) {
 	    /* <Insert>, send exchange in CT mode */
 	    case KEY_IC: {
 		if (ctcomp != 0) {
-	            /* F3 (RST macro) */
+		    /* F3 (RST macro) */
 		    send_standard_message(2);
-	            /* Set to space to move cursor to exchange field
-	             * which will trigger autofill if available.
-	             */
-	            x = ' ';
+		    /* Set to space to move cursor to exchange field
+		     * which will trigger autofill if available.
+		     */
+		    x = ' ';
 		}
 		break;
 	    }
@@ -652,7 +650,7 @@ int callinput(void) {
 
 		    if (atoi(hiscall) < 1800) {	/*  no frequency */
 			showinfo(getctydata_pfx(hiscall));
-			searchlog(hiscall);
+			searchlog();
 			refreshp();
 		    }
 
@@ -1050,7 +1048,7 @@ int callinput(void) {
 	    if (atoi(hiscall) < 1800) {	/*  no frequency */
 
 		showinfo(getctydata_pfx(hiscall));
-		searchlog(hiscall);
+		searchlog();
 	    }
 
 	    refreshp();

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -209,7 +209,7 @@ int changepars(void) {
 	    break;
 	}
 	case 6: {		/* MESSAGE  */
-	    message_change(i);
+	    message_change();
 	    break;
 	}
 

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -80,7 +80,6 @@ void clear_display(void) {
     extern int cqww;
     extern int arrldx_usa;
     extern char comment[];
-    extern char hiscall[];
     extern int searchflg;
     extern int m;
     extern struct tm *time_ptr;
@@ -164,7 +163,7 @@ void clear_display(void) {
     }
 
     if (searchflg == SEARCHWINDOW)
-	searchlog(hiscall);
+	searchlog();
 
     printcall();
 

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -610,7 +610,7 @@ int fldigi_get_log_call() {
 			strcpy(thiscall, hiscall);
 			printcall();
 			getctydata_pfx(hiscall);
-			searchlog(hiscall);
+			searchlog();
 			fldigi_set_callfield = 1;
 		    }
 		}

--- a/src/getwwv.c
+++ b/src/getwwv.c
@@ -27,8 +27,6 @@
 #include "tlf.h"
 #include "tlf_curses.h"
 
-extern int ymax;
-
 #define LINELENGTH 80
 
 int getwwv(void) {

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -101,7 +101,7 @@ static freq_t execute_grab(spot *data) {
     strcpy(hiscall, data->call);
 
     showinfo(getctydata_pfx(hiscall));
-    searchlog(hiscall);
+    searchlog();
 
     /* if in CQ mode switch to S&P and remember QRG */
     if (cqmode == CQ) {

--- a/src/messagechange.c
+++ b/src/messagechange.c
@@ -56,18 +56,17 @@ static void enter_message(int bufnr) {
     noecho();
 
     if (printbuf[0] == ESCAPE) {
-        return; // user didn't wish to change the message
+	return; // user didn't wish to change the message
     }
 
     for (char *p = printbuf; *p; p++) {
-        *p = toupper(*p);
+	*p = toupper(*p);
     }
 
     if (trxmode == DIGIMODE) {
 	free(digi_message[bufnr]);
 	digi_message[bufnr] = strdup(printbuf);
-    }
-    else
+    } else
 	strcpy(message[bufnr], printbuf);
 }
 
@@ -80,7 +79,7 @@ void message_change() {
 
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     for (int y = 13; y < LINES - 1; y++) {
-        mvprintw(y, 0, backgrnd_str);
+	mvprintw(y, 0, backgrnd_str);
     }
 
     nicebox(14, 3, 2, 60, "Enter message (F1-12, C, S)");
@@ -94,8 +93,8 @@ void message_change() {
 	if (bufnr >= KEY_F(1) && bufnr <= KEY_F(12))
 	    break;
 
-        if (bufnr == ESCAPE)
-            break;
+	if (bufnr == ESCAPE)
+	    break;
     }
 
     if (bufnr == 'S') {
@@ -109,7 +108,7 @@ void message_change() {
     }
 
     if (bufnr >= 0) {
-        enter_message(bufnr);
+	enter_message(bufnr);
     }
 
     mvprintw(12, 29, "");

--- a/src/messagechange.c
+++ b/src/messagechange.c
@@ -17,8 +17,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 /* ------------------------------------------------------------
- *         Change CW messages
- *         last change: 25.2.02 11:50
+ *         Change CW/DIGI messages
  *--------------------------------------------------------------*/
 
 
@@ -32,28 +31,59 @@
 #include "tlf.h"
 #include "ui_utils.h"
 #include "writeparas.h"
+#include "keystroke_names.h"
 
+static void enter_message(int bufnr) {
 
-int message_change(int x) {
-    extern char message[][80];
-
-    int j;
-    int count;
-    int mes_length;
-    int bufnr = 0;
     char printbuf[80];
     char *msg;
 
-    clear_display();
-    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
+    if (trxmode == DIGIMODE)
+	msg = digi_message[bufnr];
+    else
+	msg = message[bufnr];
 
-    for (j = 13; j <= 23; j++) {
-	mvprintw(j, 0, backgrnd_str);
+    g_strlcpy(printbuf, msg, sizeof(printbuf));
+    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+    mvaddstr(15, 4, printbuf);
+    refreshp();
+
+    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
+    mvprintw(16, 4, "");
+
+    echo();
+    getnstr(printbuf, 60);
+    noecho();
+
+    if (printbuf[0] == ESCAPE) {
+        return; // user didn't wish to change the message
+    }
+
+    for (char *p = printbuf; *p; p++) {
+        *p = toupper(*p);
+    }
+
+    if (trxmode == DIGIMODE) {
+	free(digi_message[bufnr]);
+	digi_message[bufnr] = strdup(printbuf);
+    }
+    else
+	strcpy(message[bufnr], printbuf);
+}
+
+
+void message_change() {
+
+    int bufnr;
+
+    clear_display();
+
+    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
+    for (int y = 13; y < LINES - 1; y++) {
+        mvprintw(y, 0, backgrnd_str);
     }
 
     nicebox(14, 3, 2, 60, "Enter message (F1-12, C, S)");
-
-    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
     while (1) {
 	bufnr = toupper(key_get());
@@ -63,81 +93,30 @@ int message_change(int x) {
 
 	if (bufnr >= KEY_F(1) && bufnr <= KEY_F(12))
 	    break;
+
+        if (bufnr == ESCAPE)
+            break;
     }
 
     if (bufnr == 'S') {
 	bufnr = 12;
     } else if (bufnr == 'C') {
 	bufnr = 13;
+    } else if (bufnr == ESCAPE) {
+	bufnr = -1;
     } else {
 	bufnr = bufnr - KEY_F(1);
     }
 
-    if (trxmode == DIGIMODE)
-	msg = digi_message[bufnr];
-    else
-	msg = message[bufnr];
-
-    g_strlcpy(printbuf, msg, sizeof(printbuf));
-    mvprintw(15, 4, "%s", printbuf);
-    refreshp();
-
-    mvprintw(16, 4, "");
-    msg[0] = '\0';
-
-    echo();
-    getnstr(printbuf, 60);
-    noecho();
-
-    if (trxmode == DIGIMODE)
-	strcat(printbuf, " ");
-    else
-	strcat(printbuf, "\n");
-    mes_length = strlen(printbuf);
-
-    if (mes_length < 2) {
-	clear_display();
-	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-
-	for (j = 13; j <= 23; j++) {
-	    mvprintw(j, 0, backgrnd_str);
-	}
-
-	if (trxmode == DIGIMODE) {
-	    strcat(printbuf, " ");
-	    free(digi_message[bufnr]);
-	    digi_message[bufnr] = strdup(printbuf);
-        }
-	else
-	    strcpy(message[bufnr], printbuf);
-
-	return (1);
+    if (bufnr >= 0) {
+        enter_message(bufnr);
     }
-
-    for (count = 0; count <= mes_length; count++) {
-	if ((printbuf[count] > 96)
-		&& (printbuf[count] < 123))
-	    printbuf[count] = printbuf[count] - 32;
-    }
-
-    if (trxmode == DIGIMODE) {
-	strcat(printbuf, " ");
-	free(digi_message[bufnr]);
-	digi_message[bufnr] = strdup(printbuf);
-    }
-    else
-	strcpy(message[bufnr], printbuf);
 
     mvprintw(12, 29, "");
     refreshp();
     clear_display();
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
-    for (j = 13; j <= 23; j++) {
-	mvprintw(j, 0, backgrnd_str);
-    }
-
     writeparas();
 
-    return (0);
 }

--- a/src/messagechange.h
+++ b/src/messagechange.h
@@ -21,6 +21,6 @@
 #ifndef MESSAGECHANGE_H
 #define MESSAGECHANGE_H
 
-int message_change(int x);
+void message_change(void);
 
 #endif /* MESSAGECHANGE_H */

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -22,7 +22,9 @@
  *
  *--------------------------------------------------------------*/
 
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -44,6 +46,7 @@
 #include "readqtccalls.h"
 #include "startmsg.h"
 #include "tlf_curses.h"
+#include "ui_utils.h"
 #include "zone_nr.h"
 
 
@@ -62,7 +65,6 @@ int readcalls(void) {
     char zonebuf[3];
     char checkcall[20];
     int i = 0, l = 0, n = 0, r = 0, s = 0;
-    unsigned int k;
     int m = 0;
     int t;
     int z = 0;
@@ -154,8 +156,7 @@ int readcalls(void) {
 	    refreshp();
 	}
 
-	strcat(inputbuffer,
-	       "                                                  ");	/* repair the logfile */
+	strcat(inputbuffer, spaces(50)); /* repair the logfile */
 	inputbuffer[LOGLINELEN - 1] = '\0';
 
 	for (t = 0; t <= strlen(inputbuffer); t++) {
@@ -310,7 +311,7 @@ int readcalls(void) {
 
 	}
 	/*  once  per call !  */
-	for (k = 0; k < i; k++) {	// changed k=< i
+	for (int k = 0; k < i; k++) {
 	    m = strcmp(worked[k].call, presentcall);
 
 	    if (m == 0) {

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -710,7 +710,7 @@ void displayWorkedZonesCountries(int z) {
 }
 
 
-void searchlog(char *searchstring) {
+void searchlog() {
 
     extern int isdupe;		// LZ3NY auto-b4 patch
     extern int searchflg;

--- a/src/searchlog.h
+++ b/src/searchlog.h
@@ -33,7 +33,8 @@ extern char *callmaster_filename;
 
 int load_callmaster(void);
 
-void searchlog(char *searchstring);
+/* search 'hiscall' in the log */
+void searchlog(void);
 
 void InitSearchPanel(void);
 void ShowSearchPanel(void);

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -545,10 +545,9 @@ void sanitize(char *s) {
 	if (*s == '\007')
 	    beep();
 	else if (*s == '\015');
-	else if (*s < 0)
-	    *t++ = *s - 128;
-	else
-	    *t++ = *s;
+	else {
+	    *t++ = *s & 0x7f;
+        }
     }
     *t = '\0';
 }


### PR DESCRIPTION
Fixed some warning produced by a compilation using `-Wextra`. Some parts of the the were improved (message_change) when already at it.

`_XOPEN_SOURCE` is guraded agains redefinition.

> clear_display.c: In function clear_display:
clear_display.c:83:17: warning: unused variable hiscall [-Wunused-variable]
     extern char hiscall[];

> messagechange.c: In function message_change:
messagechange.c:37:24: warning: unused parameter x [-Wunused-parameter]
 int message_change(int x) {

Here the code has been revisited. The two internal branches were doing essentially the same. Added option to escape without changes, both at message selection and later at message entry (`Esc` then `Enter`).  Dropped adding trailing space or NL: this should be done in the respective message sender (if needed at all). We should also remove trailing NL when reading messages from logcfg, but that's a longer story.

> searchlog.c:713:22: warning: unused parameter searchstring [-Wunused-parameter]
 void searchlog(char *searchstring) {

Again an example of function using global vars instead of argument. I agree that the real fix is to rewrite the function to do what was meant originally, but for the time being it's less effort to correct the signature.

> splitscreen.c: In function sanitize:
splitscreen.c:548:14: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  else if (*s < 0)

`char` can be unsigned (e.g. on ARM), the check was fixed.

One thing that was *not* fixed: 

> score.c: In function country_found:
score.c:42:24: warning: unused parameter prefix [-Wunused-parameter]
 int country_found(char prefix[]) {

This guy gets called with various arguments from `exist_in_country_list`. As it doesn't actually use its arg I suspect here a functional issue. The code is somewhat complex, I couldn't come up with a test case for this.
