### PR TITLE
Xresources

### DIFF
--- a/doc/Xresources
+++ b/doc/Xresources
@@ -1,51 +1,115 @@
-! Sample Xresources for Xterm.
-! Copy to your home directory as $HOME/.Xresources and
-! run xrdb -merge ~/.Xresources to make these settings visible
-! to a running X instance
+! Sample Xresources for Xterm and URxvt.
 
-!Xcursor*theme: DMZ-White
+! Copy this file to your home directory as $HOME/.Xresources and run
+! 'xrdb -merge ~/.Xresources' to make these settings visible to a running X
+! instance.
+!
+! These themes for Xterm and URxvt consist of colors as used in the Gnome
+! Terminal's Linux Console color palette.  You can also use this file as the
+! starting point for your own custom Xterm or URxvt theme.  Have fun!
 
-!xterm*font:     *-fixed-*-*-*-20-*
-!xterm*font:     10x20
+! A custom cursor color is provided for Xterm and URxvt.
 
-! Adjust the size parameter to your preference
-xterm*faceName: DejaVu Sans Mono:size=18:antialias=false
-XTerm*allowBoldFonts: true
 
-! terminal colors ------------------------------------------------------------
+! ---------------------------------------------------------------------
+! Xterm settings.
 
-! Linux terminal scheme
-xterm*background: #000000
-xterm*foreground: #c0c0c0
+! A mouse cursor theme may be set.  In this case the dmz-cursor-theme package
+! can be installed on Debian and derivatives (Ubuntu, Mint, etc.)
+!Xcursor*theme:          DMZ-White
 
-! Black + DarkGrey
-xterm*color0:  #000000
-xterm*color8:  #808080
+! Traditional ways to set a font or font size for Xterm.
+!xterm*font:             *-fixed-*-*-*-20-*
+!xterm*font:             10x20
 
-! DarkRed + Red
-xterm*color1:  #800000
-xterm*color9:  #ff0000
+! Fonts are a matter of personal taste.  A good terminal/monospace font will
+! show a definite difference between O and 0 or l and 1.  Later Xterm and
+! URxvt versions support anti-aliasing so try it each way and see which looks
+! better to you.
 
-! DarkGreen + Green
-xterm*color2:  #008000
-xterm*color10: #00ff00
+! TrueType fonts with a slashed zero can be found at:
+! http://www.g0hwc.com/ham_radio_fonts.html
+! https://github.com/AlbertoDorado/droid-sans-mono-zeromod
+! install using your desktop's/distributions's font installer.
 
-! Brown + Yellow
-xterm*color3:  #808000
-xterm*color11: #ffff00
+! Adjust the size parameter to your preference.
+xterm*faceName:         DejaVu Sans Mono:size=18:antialias=true
+!xterm*faceName:         Droid Sans Mono Slashed:size=18:antialias=true
 
-! DarkBlue + Blue
-xterm*color4:  #000080
-xterm*color12: #0000ff
+! Tlf uses bold fonts, so enable them.
+XTerm*allowBoldFonts:   true
 
-! DarkMagenta + Magenta
-xterm*color5:  #800080
-xterm*color13: #ff00ff
+! ---------------------------------------------------------------------
+! Linux terminal scheme from Gnome Terminal Linux Console color palette
+! Black & Gray
+xterm*background:       #000000
+xterm*foreground:       #aaaaaa
+! Black & DarkGray
+xterm*color0:           #000000
+xterm*color8:           #555555
+! DarkRed & Red
+xterm*color1:           #aa0000
+xterm*color9:           #ff5555
+! DarkGreen & Green
+xterm*color2:           #00aa00
+xterm*color10:          #55ff55
+! DarkYellow & Yellow
+xterm*color3:           #aa5500
+xterm*color11:          #ffff55
+! DarkBlue & Blue
+xterm*color4:           #0000aa
+xterm*color12:          #5555ff
+! DarkMagenta & Magenta
+xterm*color5:           #aa00aa
+xterm*color13:          #ff55ff
+!DarkCyan & Cyan
+xterm*color6:           #00aaaa
+xterm*color14:          #55ffff
+! LightGray & White
+xterm*color7:           #aaaaaa
+xterm*color15:          #ffffff
 
-!DarkCyan + Cyan
-xterm*color6:  #008080
-xterm*color14: #00ffff
+! ---------------------------------------------------------------------
+! Custom cursor color.  Change to suit taste.
+! Orange
+xterm*cursorColor:      #ffa530
 
-! LightGrey + White
-xterm*color7:  #c0c0c0
-xterm*color15: #ffffff
+
+! ---------------------------------------------------------------------
+! URxvt settings.
+
+URxvt.geometry:         80x25
+URxvt.font:             xft:Droid Sans Mono Slashed:size=16:antialias=true
+!URxvt.font:             xft:DejaVu Sans Mono:size=18:antialias=true
+
+! Orange
+URxvt.cursorColor:      #ffa530
+
+! URxvt VGA colors
+! Black & Gray
+URxvt.background:       #000000
+URxvt.foreground:       #aaaaaa
+! Black & DarkGray
+URxvt.color0:           #000000
+URxvt.color8:           #555555
+! DarkRed & Red
+URxvt.color1:           #AA0000
+URxvt.color9:           #FF5555
+! DarkGreen & Green
+URxvt.color2:           #00AA00
+URxvt.color10:          #55FF55
+! DarkYellow & Yellow
+URxvt.color3:           #AA5500
+URxvt.color11:          #FFFF55
+! DarkBlue & Blue
+URxvt.color4:           #0000AA
+URxvt.color12:          #5555FF
+! DarkMagenta & Magenta
+URxvt.color5:           #AA00AA
+URxvt.color13:          #FF55FF
+!DarkCyan & Cyan
+URxvt.color6:           #00AAAA
+URxvt.color14:          #55FFFF
+! LightGray & White
+URxvt.color7:           #AAAAAA
+URxvt.color15:          #FFFFFF

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -494,11 +494,11 @@ for @PACKAGE_NAME@ use.
 Some desktop terminal emulators are capable of being configured to allow the
 application running in them to get all of the keys the desktop environment
 does not consume.  In testing good choices seem to be Gnome Terminal, Rox
-Terminal, or the classic Xterm (although its color representation differs from
-the Linux console and other terminal emulators).  Xfce Terminal is known to
-consume F11 and Ctrl-PageUp and Ctrl-PageDown.  The @PACKAGE_NAME@ developers
-have implemented Alt-PageUp and Alt-PageDown as a work-around for the Ctrl
-counterparts.  Reports of success with other terminals are welcome.
+Terminal, or the classic Xterm or URxvt which seem to consume the fewest
+keystrokes for their own use.  Xfce Terminal is known to consume F11 and
+Ctrl-PageUp and Ctrl-PageDown.  The @PACKAGE_NAME@ developers have implemented
+Alt-PageUp and Alt-PageDown as a work-around for the Ctrl counterparts.
+Reports of success with other terminals are welcome.
 .
 .SS Call Input and Exchange Fields
 .
@@ -1064,9 +1064,9 @@ for a default one.  Make sure you edit the
 .I logcfg.dat
 file at least to hold your call and your preferred system configuration.
 .
-.SH LOGCFG.DAT STATEMENTS
+.SS logcfg.dat STATEMENTS
 .
-Configuration parameters set in
+Configuration parameters are set in
 .I logcfg.dat
 located in the working directory (where @PACKAGE_NAME@ is started).
 .
@@ -1092,7 +1092,7 @@ switch between CQ and S&P modes, in which \(oqEnter\(cq is the sole key used
 to call the other station, send the exchange, and log the QSO.
 .
 .TP
-\fBTLFCOLOR\fIn\fR=\fIFG\fR/\fIBG\fR
+\fBTLFCOLOR\fIn\fR=\fIBF\fR
 Defaults:
 .RS 14
 \fBTLFCOLOR1\fR=\fI23\fR (Header and footer)
@@ -1109,8 +1109,36 @@ Defaults:
 .RE
 .
 .IP
-The numbers are given in octal, FG/BG or BG/FG (some experimentation likely
-required).
+The numbers are given in octal with each digit standing for
+.IR B ackground
+and
+.IR F oreground.
+No space is given between the values.
+.
+.IP
+The color values are:
+.RS 14
+Black           0
+.br
+Red             1
+.br
+Green           2
+.br
+Yellow          3
+.br
+Blue            4
+.br
+Magenta         5
+.br
+Cyan            6
+.br
+White           7
+.RE
+.
+.IP
+Some sections of the screen are coded to show the bright version of these
+colors so some combinations may be unreadable!  Some experimentation is
+required.
 .
 .IP
 You should only specify these if you wish to modify the standard colours of
@@ -1118,7 +1146,17 @@ You should only specify these if you wish to modify the standard colours of
 @PACKAGE_NAME@ with your own colours.  Another way is to define the colours
 via the
 .I $HOME/.Xresources
-file.
+file for
+.BR xterm (1)
+or
+.BR urxvt (1).
+.
+.IP
+A sample
+.B Xresources
+file with color values matching the Linux console is provided in
+.IR @prefix@/share/doc/@PACKAGE@/Xresources .
+Comments in the file provide instructions for its use.
 .
 .TP
 \fBEDITOR\fR=\fInano\fR | \fIvi\fR[\fIm\fR] | \fI<your_favorite_editor>\fR
@@ -2074,6 +2112,15 @@ It will take precedence over the system installed
 .IR callmaster .
 .
 .P
+.I @prefix@/share/doc/@PACKAGE@/Xresources
+contains a set of font and color settings for
+.BR xterm (1)
+and
+.BR urxvt (1)
+that are very close to the colors of the Linux console.  These terminals may
+be preferred as they consume the fewest key combinations for their own use.
+.
+.P
 \fISection files\fR contain a flat ASCII database of multpliers like states,
 sections, provinces, districts, names, ages, etc.  They are invoked by
 including \fBMULT_LIST\fR=\fIsection_file_name\fR in the rules file.
@@ -2081,13 +2128,13 @@ including \fBMULT_LIST\fR=\fIsection_file_name\fR in the rules file.
 .SH DOCUMENTATION
 .
 An operation manual (a little bit outdated) is available in HTML format at
-.UR http://sharon.esrac.ele.tue.nl/pub/linux/ham/tlf/
-the old @PACKAGE_NAME@ project page
+.UR https://tlf.github.io/tlfdoc.old/tlfdoc.html
+the @PACKAGE_NAME@ project page
 .UE .
 .
 .P
 An FAQ and other useful tips are installed in the system doc directory under
-\fI@PACKAGE_TARNAME@\fR.
+.IR @prefix@/share/doc/@PACKAGE@/ .
 .
 .SH BUGS
 Please send bug reports to


### PR DESCRIPTION
Hi Tom.

I've updated the doc/Xresources file to provide color palettes for xterm and urxvt that closely match the Linux console.  I've also updated the manual page to better reflect the available color settings.

Next I plan to work on a single set of default colors for the above terminals and the console.  I think doing so will give us a more consistent UI when a Linux console palette is in use.
