### PR TITLE
Extended memory functions (was: Grab switch back)

### DIFF
--- a/share/logcfg.dat
+++ b/share/logcfg.dat
@@ -129,8 +129,6 @@ CWTONE=800
 #
 #RIT_CLEAR
 #
-#SHOW_FREQUENCY
-#
 #################################
 #                               #
 #  INFORMATION WINDOWS          #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,6 +30,7 @@ tlf_SOURCES = \
 	setparameters.c show_help.c showinfo.c showpxmap.c \
 	showscore.c showzones.c sockserv.c speedupndown.c   \
 	stoptx.c store_qso.c sunup.c splitscreen.c startmsg.c\
+	trx_memory.c \
 	rtty.c time_update.c ui_utils.c \
 	write_keyer.c writecabrillo.c writeparas.c \
 	zone_nr.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,12 +62,13 @@ noinst_HEADERS = \
 	paccdx.h parse_logcfg.h prevqso.h printcall.h \
 	qrb.h qsonr_to_str.h qtc_log.h qtcvars.h qtcwin.h qtcutil.h \
 	readcalls.h readqtccalls.h readctydata.h recall_exchange.h \
-	rules.h readcabrillo.h \
+	rules.h readcabrillo.h rtty.h \
 	score.h scroll_log.h searchcallarray.h searchlog.h sendbuf.h \
 	sendqrg.h sendspcall.h set_tone.h setcontest.h \
 	setparameters.h show_help.h showinfo.h showpxmap.h showscore.h \
 	showzones.h sockserv.h speedupndown.h  \
 	splitscreen.h startmsg.h stoptx.h store_qso.h sunup.h \
-	rtty.h time_update.h tlf.h tlf_curses.h tlf_panel.h ui_utils.h \
+	time_update.h tlf.h tlf_curses.h tlf_panel.h trx_memory.c \
+	ui_utils.h \
 	write_keyer.h writecabrillo.h writeparas.h \
 	zone_nr.h

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -57,6 +57,8 @@ void show_header_line() {
 	case KEYBOARD:
 	    mode = "Keyboard";
 	    break;
+	default:
+	    ;   // should not happen
     }
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -97,6 +97,7 @@ extern int highqsonr;
 
 extern int trxmode;
 extern rmode_t rigmode;
+extern freq_t freq;
 extern char lastqsonr[];
 extern int cqwwm2;
 extern char thisnode;

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -25,11 +25,13 @@
 #include "bandmap.h"
 #include "fldigixmlrpc.h"
 #include "getctydata.h"
+#include "gettxinfo.h"
+#include "globalvars.h"
 #include "searchlog.h"		// Includes glib.h
 #include "showinfo.h"
 #include "tlf.h"
 #include "tlf_curses.h"
-#include "gettxinfo.h"
+#include "trx_memory.h"
 
 void send_bandswitch(freq_t outfreq);
 
@@ -60,7 +62,6 @@ freq_t grabspot(void) {
 
 freq_t grab_next(void) {
     extern int trx_control;
-    extern freq_t freq;
 
     static int dir = 1;		/* start scanning up */
 
@@ -91,8 +92,6 @@ freq_t grab_next(void) {
 static freq_t execute_grab(spot *data) {
     extern char hiscall[];
     extern cqmode_t cqmode;
-    extern freq_t mem;
-    extern freq_t freq;
 
     freq_t f = data->freq - fldigi_get_carrier();
     set_outfreq(f);
@@ -105,9 +104,8 @@ static freq_t execute_grab(spot *data) {
 
     /* if in CQ mode switch to S&P and remember QRG */
     if (cqmode == CQ) {
+	memory_store();
 	cqmode = S_P;
-	mem = freq;
-	mvprintw(14, 67, " MEM: %7.1f", mem / 1000.);
     }
 
     refreshp();

--- a/src/keystroke_names.h
+++ b/src/keystroke_names.h
@@ -73,3 +73,5 @@
 #define TAB       CTRL_I
 #define LINEFEED  CTRL_J
 #define RETURN    CTRL_M
+
+#define SHIFT_F(n)  (KEY_F(n) + 12)

--- a/src/main.c
+++ b/src/main.c
@@ -409,7 +409,6 @@ pid_t pid;
 struct tm *time_ptr, time_ptr_cabrillo;
 
 freq_t freq;
-freq_t mem;
 int logfrequency = 0;
 int rit;
 int trx_control = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -412,7 +412,6 @@ freq_t freq;
 int logfrequency = 0;
 int rit;
 int trx_control = 0;
-int showfreq = 0;
 freq_t bandfrequency[NBANDS] = {
     1830000, 3525000, 7010000, 10105000, 14025000, 18070000, 21025000, 24900000,
     28025000, 0.

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -215,7 +215,6 @@ int parse_logcfg(char *inputbuffer) {
     extern int weight;
     extern int txdelay;
     extern char tonestr[];
-    extern int showfreq;
     extern char *editor_cmd;
     extern int partials;
     extern int use_part;
@@ -370,7 +369,7 @@ int parse_logcfg(char *inputbuffer) {
 	"TXDELAY",
 	"SUNSPOTS",
 	"SFI",
-	"SHOW_FREQUENCY",
+	"SHOW_FREQUENCY",                       /* deprecated */
 	"EDITOR",		/* 45 */
 	"PARTIALS",
 	"USEPARTIALS",
@@ -910,10 +909,6 @@ int parse_logcfg(char *inputbuffer) {
 	    outputbuff[0] = '\0';
 	    sprintf(outputbuff, "WWV SFI=%d\n", atoi(buff));
 	    strcpy(lastwwv, outputbuff);
-	    break;
-	}
-	case 44: {
-	    showfreq = 1;
 	    break;
 	}
 	case 45: {

--- a/src/time_update.h
+++ b/src/time_update.h
@@ -21,6 +21,10 @@
 #ifndef TIME_UPDATE_H
 #define TIME_UPDATE_H
 
+#include <stdbool.h>
+
+extern bool force_show_freq;
+
 void time_update(void);
 
 #endif /* TIME_UPDATE_H */

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -53,7 +53,8 @@ typedef enum {
     CQ,         // Run
     S_P,        // Search and Pounce
     AUTO_CQ,    // temporary, used in autocq.c
-    KEYBOARD    // temporary, used in keyer.c
+    KEYBOARD,   // temporary, used in keyer.c
+    NONE        // used in trx_memory to signal empty memory
 } cqmode_t;
 
 #define SEND_DE 1		/* de_mode on */

--- a/src/trx_memory.c
+++ b/src/trx_memory.c
@@ -1,0 +1,104 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2020 Zoltan Csahok <ha5cqz@freemail.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdbool.h>
+
+#include "callinput.h"
+#include "gettxinfo.h"
+#include "globalvars.h"
+#include "time_update.h"
+#include "tlf.h"
+
+extern cqmode_t cqmode;
+
+typedef struct {
+    freq_t freq;
+    cqmode_t cqmode;
+    char hiscall[20];
+} mem_t;
+
+static mem_t trxmem = {.freq = 0, .cqmode = NONE};
+
+
+void memory_store() {
+    trxmem.freq = freq;
+    trxmem.cqmode = cqmode;
+    strcpy(trxmem.hiscall, hiscall);
+
+    force_show_freq = true;
+}
+
+void memory_recall() {
+    if (trxmem.freq <= 0) {
+	return;
+    }
+
+    set_outfreq(trxmem.freq);
+    send_bandswitch(trxmem.freq);
+    cqmode = trxmem.cqmode;
+    strcpy(hiscall, trxmem.hiscall);
+
+    force_show_freq = true;
+}
+
+void memory_pop() {
+    if (trxmem.freq <= 0) {
+	return;
+    }
+
+    memory_recall();
+
+    trxmem.freq = 0;
+    trxmem.cqmode = NONE;
+}
+
+void memory_store_or_pop() {
+    if (trxmem.freq <= 0) {
+	memory_store();
+    } else {
+	memory_pop();
+    }
+}
+
+void memory_swap() {
+    if (trxmem.freq <= 0) {
+	return;
+    }
+
+    freq_t tmp_freq = freq;
+    cqmode_t tmp_cqmode = cqmode;
+    char tmp_hiscall[sizeof(trxmem.hiscall)];
+    strcpy(tmp_hiscall, hiscall);
+
+    memory_recall();
+
+    trxmem.freq = tmp_freq;
+    trxmem.cqmode = tmp_cqmode;
+    strcpy(trxmem.hiscall, tmp_hiscall);
+}
+
+
+freq_t memory_get_freq() {
+    return trxmem.freq;
+}
+
+cqmode_t memory_get_cqmode() {
+    return trxmem.cqmode;
+}
+

--- a/src/trx_memory.h
+++ b/src/trx_memory.h
@@ -1,0 +1,35 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2020 Zoltan Csahok <ha5cqz@freemail.hu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef TRX_MEMORY_H
+#define TRX_MEMORY_H
+
+#include "time_update.h"
+#include "tlf.h"
+
+extern freq_t memory_get_freq();        // returns 0 if memory is empty
+extern cqmode_t memory_get_cqmode();    // returns NONE if memory is empty
+
+extern void memory_store_or_pop();
+extern void memory_store();
+extern void memory_pop();
+extern void memory_swap();
+
+#endif
+


### PR DESCRIPTION
Based on the discussions in PR #126 I added the following improved memory functionality to make it actually usable:
- in addition to the frequency memory now holds the mode (CQ/SP) and the entered call (if any)
- `%` swaps TRX and MEM (swap)
- `$` moves MEM to TRX (pop)
- in SP mode `Shift-F1` makes a swap if memory holds a previous CQ frequency and then executes `F1` (calls CQ).

These operations (and also the existing `#`) wait until the frequency is actually updated. Normally this happens quite fast with no noticeable delay.
Mode and entered call are also restored.

After the "switch back" using `Shift-F1` the previous frequency and entered call are not lost, pressing `%` restores the state, so one can continue SP and also move around or grab new stations.

Non-functional changes:
- memory handling moved to a separate file. The functions do no UI actions.
- refactored frequency/memory display in `time_update`. MEM displays scattered in the code were removed, now all is handled by `time_update`. For this a forced update mode was added: this avoids the up to one second delay before the update. Immediate update now happens also when the frequency is changed on the rig. This way also the band map gets more responsive. Band map aging is not affected by this change.

Minor stuff:
- `fabsf` replaced with `fabs`, we are not using floats any more.
- restructured `time_update` 
- added `freq` to `globalvars.h`: IMO we shall add all such variables (mostly defined in `main.c`) to this header file to get rid of ad-hoc `extern` definitions. (i.e. externs should be used only in headers)



