### PR TITLE
Fix handling of loglines coming fom other node for CQWW_M2

### DIFF
--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -93,7 +93,7 @@ void log_to_disk(int from_lan) {
 	strcat(lan_logline, spaces(78));
 
 	if (cqwwm2 == 1) {
-	    if (lan_logline[0] != thisnode)
+	    if (lan_message[0] != thisnode)
 		lan_logline[79] = '*';
 	}
 

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -49,7 +49,7 @@ void fillto(int n);
  * The structure of a logline entry is as follows:
  * - each logline contains exactly 87 characters followed by a newline.
  * - it consists of 3 parts
- *   | fixed part (54 chars) | contest dependent part (26 chars) | frequ (8 chars)
+ *   fixed part (54 chars) | contest dependent part (26 chars) | freq (7 chars)
  *
  *   See function definitions below
  */


### PR DESCRIPTION
QSOs from other node needs to be marked in the logfile for CQWW M/2
mode. The sending node is represented in first character of received LAN packet,
not in first character of logline.