### PR TITLE
Fix ARRLDX scoring for W/VE stations

### DIFF
--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -411,7 +411,7 @@ int readcalls(void) {
 	    int ci = 0;
 	    int countrynr_tocheck = countrynr;
 	    while (strlen(countrylist[ci]) != 0) {
-		if (getctydata(countrylist[ci]) == countrynr_tocheck) {
+		if (getctynr(countrylist[ci]) == countrynr_tocheck) {
 		    excl_add_veto = 1;
 		    break;
 		}
@@ -514,22 +514,24 @@ int readcalls(void) {
 	}
     }				// end dx_arrlsections
 
-    if ((arrldx_usa == 1) && (countrynr != w_cty) && (countrynr != ve_cty)) {
+    if (arrldx_usa == 1) {
 
 	int cntr;
 	for (cntr = 1; cntr < MAX_DATALINES; cntr++) {
-	    if ((countries[cntr] & BAND160) != 0)
-		countryscore[BANDINDEX_160]++;
-	    if ((countries[cntr] & BAND80) != 0)
-		countryscore[BANDINDEX_80]++;
-	    if ((countries[cntr] & BAND40) != 0)
-		countryscore[BANDINDEX_40]++;
-	    if ((countries[cntr] & BAND20) != 0)
-		countryscore[BANDINDEX_20]++;
-	    if ((countries[cntr] & BAND15) != 0)
-		countryscore[BANDINDEX_15]++;
-	    if ((countries[cntr] & BAND10) != 0)
-		countryscore[BANDINDEX_10]++;
+	    if (cntr != w_cty && cntr != ve_cty) {	// W and VE don't count here...
+		if ((countries[cntr] & BAND160) != 0)
+		    countryscore[BANDINDEX_160]++;
+		if ((countries[cntr] & BAND80) != 0)
+		    countryscore[BANDINDEX_80]++;
+		if ((countries[cntr] & BAND40) != 0)
+		    countryscore[BANDINDEX_40]++;
+		if ((countries[cntr] & BAND20) != 0)
+		    countryscore[BANDINDEX_20]++;
+		if ((countries[cntr] & BAND15) != 0)
+		    countryscore[BANDINDEX_15]++;
+		if ((countries[cntr] & BAND10) != 0)
+		    countryscore[BANDINDEX_10]++;
+	    }
 	}
 
     }

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -31,7 +31,7 @@
 #include "tlf.h"
 
 
-int setcontest(void) {
+void setcontest(void) {
 
     extern int focm;
     extern int wpx;
@@ -103,6 +103,9 @@ int setcontest(void) {
     sectn_mult = 0;
     noleadingzeros = 0;
 
+    w_cty = getctynr(wcall);
+    ve_cty = getctynr(vecall);
+
     if (strcmp(whichcontest, "wpx") == 0) {
 	wpx = 1;
 	contest = 1;
@@ -116,8 +119,6 @@ int setcontest(void) {
 	contest = 1;
 	showscore_flag = 1;
 	searchflg = 1;
-	w_cty = getctynr(wcall);
-	ve_cty = getctynr(vecall);
     }
 
     if (strcmp(whichcontest, "dxped") == 0) {
@@ -184,8 +185,6 @@ int setcontest(void) {
 	showscore_flag = 1;
 	searchflg = 1;
 
-	ve_cty = getctynr(vecall);
-	w_cty = getctynr(wcall);
 	zl_cty = getctynr(zlcall);
 	ja_cty = getctynr(jacall);
 	py_cty = getctynr(pycall);
@@ -228,8 +227,6 @@ int setcontest(void) {
 //      universal = 1;
 	showscore_flag = 1;
 	searchflg = 1;
-	w_cty = getctynr(wcall);
-	ve_cty = getctynr(vecall);
     }
 
     if (strcmp(whichcontest, "qso") == 0) {
@@ -241,6 +238,4 @@ int setcontest(void) {
 	showscore_flag = 1;
 	universal = 1;
     }
-
-    return (0);
 }

--- a/src/setcontest.h
+++ b/src/setcontest.h
@@ -21,6 +21,6 @@
 #ifndef SETCONTEST_H
 #define SETCONTEST_H
 
-int setcontest(void);
+void setcontest(void);
 
 #endif /* SETCONTEST_H */


### PR DESCRIPTION
QSOs between W/VE stations should not count as multi and also give no
points.

Add missing initialization of w_cty and ve_cty variables and fixes logic to count worked countries.

Fix also evaluation of COUNTRYLIST if EXCLUDE_MULTILIST is in use. Old code changed the 'countrynr' variable which was used later.