### PR TITLE
improve WWV handling

### DIFF
--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -23,40 +23,31 @@
  *--------------------------------------------------------------*/
 
 
-#include "tlf.h"
+#include "globalvars.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
 #include "write_keyer.h"
 
 void cleanup_qso(void) {
-    extern char hiscall[];
-    extern char comment[];
-    extern char my_rst[];
-    extern char his_rst[];
-
     hiscall[0] = '\0';	    /* reset hiscall and comment */
     comment[0] = '\0';
     his_rst[1] = '9';	    /* reset to 599 */
     my_rst[1] = '9';
+    countrynr = 0;
 }
 
-int cleanup(void) {
+void cleanup(void) {
     extern int defer_store;
 
-    int k = 0;
-
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
-
-    mvprintw(12, 29, "            ");
-    mvprintw(12, 29, "");
+    mvaddstr(12, 29, spaces(12));
 
     attron(COLOR_PAIR(C_WINDOW));
-    mvprintw(12, 54, "                        ");
+    mvaddstr(12, 54, spaces(24));
 
     attron(COLOR_PAIR(C_LOG | A_STANDOUT));
-
-    for (k = 1; k <= 5; k++) {
-	mvprintw(k, 0, "%s", "                                        ");
+    for (int k = 1; k <= 5; k++) {
+	mvaddstr(k, 0, spaces(40));
     }
 
     refreshp();
@@ -64,5 +55,4 @@ int cleanup(void) {
     defer_store = 0;
     keyer_flush();
 
-    return (0);
 }

--- a/src/cleanup.h
+++ b/src/cleanup.h
@@ -22,6 +22,6 @@
 #define CLEANUP_H
 
 void cleanup_qso(void);
-int cleanup(void);
+void cleanup(void);
 
 #endif /* CLEANUP_H */

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -29,7 +29,9 @@
 
 #include "cw_utils.h"
 #include "get_time.h"
+#include "getwwv.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "muf.h"
 #include "printcall.h"
 #include "qsonr_to_str.h"
 #include "searchlog.h"		// Includes glib.h
@@ -62,9 +64,9 @@ void show_header_line() {
     }
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-    mvprintw(0, 0, "                             ");
+    mvaddstr(0, 0, spaces(29));
     mvprintw(0, 0, "  %-8s  S=%2i D=%i ", mode, GetCWSpeed(), cqdelay);
-    mvprintw(0, 21, headerline);
+    mvaddstr(0, 21, headerline);
 }
 
 
@@ -83,7 +85,6 @@ void clear_display(void) {
     extern int arrldx_usa;
     extern char comment[];
     extern int searchflg;
-    extern int m;
     extern struct tm *time_ptr;
     extern char whichcontest[];
     extern int no_rst;
@@ -129,21 +130,19 @@ void clear_display(void) {
     else
 	strftime(time_buf, 60, "DIG %d-%b-%y %H:%M ", time_ptr);
 
-    m = time_ptr->tm_mon;	/* month for muf calc */
+    month = time_ptr->tm_mon;	/* month for muf calc */
 
-    mvprintw(12, 3, time_buf);
+    mvaddstr(12, 3, time_buf);
 
     qsonr_to_str();
     mvaddstr(12, 23, qsonrstr);
 
     if (trxmode != SSBMODE) {
-
 	my_rst[2] = '9';
 	his_rst[2] = '9';
     } else {
 	my_rst[2] = ' ';
 	his_rst[2] = ' ';
-
     }
 
     if (no_rst) {
@@ -170,9 +169,10 @@ void clear_display(void) {
     printcall();
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-    mvprintw(LINES - 1, 0, backgrnd_str);
+    mvaddstr(LINES - 1, 0, backgrnd_str);
+    wwv_show_footer();
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
-    mvprintw(cury, curx, "");
+    move(cury, curx);
     refreshp();
 }

--- a/src/getwwv.h
+++ b/src/getwwv.h
@@ -21,6 +21,16 @@
 #ifndef GETWWV_H
 #define GETWWV_H
 
-int getwwv(void);
+#include <time.h>
+
+extern double ssn_r;        // sunspot number for MUF calculation
+extern char lastwwv[];      // processed WWV message
+extern char lastwwv_raw[];  // raw WWV message
+extern time_t lastwwv_time;
+
+void wwv_add(char *s);
+void wwv_set_r(double r);
+void wwv_set_sfi(double sfi);
+void wwv_show_footer();
 
 #endif /* GETWWV_H */

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -1,10 +1,8 @@
-#ifndef TLF_H
-# include "tlf.h"
-#endif
 
 #include <glib.h>
-
 #include <hamlib/rig.h>
+
+#include "tlf.h"
 
 extern char qsos[MAX_QSOS][LOGLINELEN + 1];
 					// array of log lines of QSOs so far;

--- a/src/logit.c
+++ b/src/logit.c
@@ -73,6 +73,7 @@ void logit(void) {
     int cury, curx;
     int qrg_out = 0;
 
+    cleanup();
     clear_display();
     defer_store = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -333,7 +333,6 @@ int commentfield = 0;		/* 1 if we are in comment/excahnge input */
 /*-------------------------------------packet-------------------------------*/
 char spot_ptr[MAX_SPOTS][82];		/* Array of cluster spot lines */
 int nr_of_spots;			/* Anzahl Lines in spot_ptr array */
-char lastwwv[120] = "";
 int packetinterface = 0;
 int fdSertnc = 0;
 int tncport = 1;
@@ -435,8 +434,6 @@ double QTH_Long = -7.;
 double DEST_Lat = 51.;
 double DEST_Long = 1.;
 
-double r = 50;
-int m = 1;
 char hiscountry[40];
 
 int this_second;
@@ -985,7 +982,6 @@ int main(int argc, char *argv[]) {
     }
     refreshp();
 
-    getwwv();			/* get the latest wwv info from packet */
     bm_init();			/* initialize bandmap */
 
     atexit(tlf_cleanup); 	/* register cleanup function */

--- a/src/muf.c
+++ b/src/muf.c
@@ -18,23 +18,172 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-
+#include <glib.h>
 #include <math.h>
 #include <string.h>
 #include <time.h>
 
 #include "dxcc.h"
 #include "get_time.h"
+#include "globalvars.h"
+#include "getwwv.h"
 #include "sunup.h"
-#include "tlf.h"
+#include "qrb.h"
 #include "tlf_panel.h"
 #include "ui_utils.h"
 
-#define RADIAN		(180.0 / M_PI)
+
+// message splitters:
+// line[0] - original line, content can be modified in-place
+// line[1],line[2] - pointers to subsequent lines within line[0], initially NULL
+
+static void split_condx(const int len, char **line) {
+    if (len < 40) {
+	return;
+    }
+    char *p = line[0] + 39;
+    while (*p != ' ' && p > line[0]) {    // find a space before index 39
+	--p;
+    }
+    if (p > line[0]) {
+	*p = 0;
+	line[1] = p + 1;
+    } else {    // no space found, truncate (should not happen)
+	line[0][40] = 0;
+    }
+}
 
 
-extern double r;
-extern int m;
+/*
+WCY de DK0WCY-1 <12> : K=2 expK=0 A=19 R=11 SFI=74 SA=qui GMF=qui Au=no
+                      ^                           ^
+
+WCY de DK0WCY-1 <12> :
+K=2 expK=0 A=19 R=11 SFI=74
+SA=qui GMF=qui Au=no
+*/
+static void split_wcy(const int len, char **line) {
+
+    char *p = strchr(line[0], ':'); // first colon
+    if (p != NULL && p + 2 < line[0] + len)  {
+	p[1] = 0;
+	line[1] = p + 2;
+	p = strstr(line[1], "SFI");
+	if (p != NULL) {
+	    p = strchr(p, ' ');     // the space after SFI
+	}
+	if (p != NULL) {
+	    p[0] = 0;
+	    line[2] = p + 1;
+	}
+    }
+}
+
+/*
+WWV de VE7CC <21>:   SFI=74, A=9, K=1, No Storms -> No Storms
+                    ^                 ^
+
+WWV de VE7CC <21>:
+SFI=74, A=9, K=1,
+No Storms -> No Storms
+*/
+static void split_wwv(const int len, char **line) {
+    char *p = strstr(line[0], "SFI");
+    if (p != NULL && p - 1 >= line[0])  {
+	p[-1] = 0;  // the space before SFI
+	line[1] = p;
+	p = strstr(line[1], "K=");
+	if (p != NULL) {
+	    p = strchr(p, ' '); // the space after K
+	}
+	if (p != NULL) {
+	    p[0] = 0;
+	    line[2] = p + 1;
+	}
+    }
+}
+
+static void show_condx(WINDOW *win) {
+    if (lastwwv[0] == 0) {
+	mvwaddstr(win, 10, 40, "Condx: n/a");  // no data
+	return;
+    }
+
+    static GRegex *squash_regex = NULL;
+    if (squash_regex == NULL) {
+	squash_regex = g_regex_new(" {2,}", 0, 0, NULL);
+    }
+
+    // squash spaces and show condx
+    gchar *condx = g_regex_replace_literal(squash_regex, lastwwv, -1, 0, "  ", 0,
+					   NULL);
+    char *line[3] = {condx, NULL, NULL};
+    split_condx(strlen(condx), line);
+
+    mvwaddstr(win, 10, 40, line[0]);
+    if (line[1] != NULL) {
+	mvwaddstr(win, 11, 40, line[1]);
+    }
+
+    g_free(condx);
+
+    // show original WWV message, split into up to 3 lines if needed
+    line[0] = g_strdup(lastwwv_raw);
+    line[1] = line[2] = NULL;
+    const int len = strlen(lastwwv_raw);
+    if (strncmp(lastwwv_raw, "WCY", 3) == 0) {
+	split_wcy(len, line);
+    } else {
+	split_wwv(len, line);
+    }
+
+    for (int i = 0; i < 3; ++i) {
+	if (line[i] != NULL) {
+	    mvwaddstr(win, 14 + i, 40, line[i]);
+	}
+    }
+
+    g_free(line[0]);
+}
+
+/*********************************************************************
+ Code below is based on MICROMUF.PAS
+
+http://www.classiccmp.org/cpmarchives/cpm/Software/WalnutCD/cpm/hamradio/micromuf.pas
+
+ Original attribution:
+---------------------------------------------------------------------
+  This program uses 'MINI-F2' devised by R. Fricker (BBC external
+  services) for FO-F calculations and L.M. Muggleton's formula for
+  FO-E calculations.
+
+
+  For the L.U.F. a minimum useable fieldstrength of 30 DBUV at the
+  receiver and 250 KW of transmitter power (aerial gain: 18 DBI) are
+  assumed.  The L.U.F. is derived from absorption calculations based
+  on the work of Piggot, George, Samuel, and Bradley.  In spite of the
+  program's simplicity it gives a good impression of the ionosphere's
+  behaviour and can be used for propagation predictions.
+
+            Hans Bakhuizen
+            Propagation Unit; Frequency Bureau
+            Radio Netherlands
+            P.O. Box 222
+            1200 JG Hilversum Holland
+
+(C) Copyright Media Network June 1984
+
+Translation from Basic into TURBO Pascal by Jonathan D Ogden on
+September 26, 1986.
+
+       Jonathan D Ogden
+       402 e Daniel
+       Champaign, Il 61820 USA
+---------------------------------------------------------------------
+*********************************************************************/
+
+int month;
+
 extern struct tm *time_ptr;
 
 double yt;
@@ -42,10 +191,10 @@ double xt;
 double yr;
 double xr;
 
-int t = 21;
+int t;
 
-double xn, xs, ls, h, ff, x, yn_, q, k, lm, u, a;
-//FIXME: q should be local variable
+double xn, xs, ls, h, ff, x, yn_, k, lm, u, a;
+
 
 static double power(man, ex)
 double man, ex;
@@ -54,7 +203,7 @@ double man, ex;
 }
 
 static void interlat() {
-    double yi;
+    double yi, q;
     /* Intermediate Latitude & Longitude calculations */
     q = cos(u / RADIAN) * cos(xt / RADIAN) * sin(k * lm / RADIAN);
     x = q + sin(xt / RADIAN) * cos(k * lm / RADIAN);
@@ -87,7 +236,7 @@ static void mini_f2() {
     if (tl < 0.0)
 	tl += 24.0;
 
-    mh = m;
+    mh = month;
     if (z <= 0.0) {
 	z = -z;
 	mh += 6;
@@ -102,12 +251,12 @@ static void mini_f2() {
     ty = tl;
     if (ty < 5.0)
 	ty = tl + 24.0;
-    yf = (ty - 14.0 - sx * 2.0 + wx * 2.0 - r / 175.0) *
-	 (7.0 - sx * 3.0 + wx * 4.0 - r / (150.0 - wx * 75.0));
+    yf = (ty - 14.0 - sx * 2.0 + wx * 2.0 - ssn_r / 175.0) *
+	 (7.0 - sx * 3.0 + wx * 4.0 - ssn_r / (150.0 - wx * 75.0));
 
     if (fabs(yf) > 60.0)
 	yf = 60.0;
-    x = 1 + r / (175.0 + sx * 175.0);
+    x = 1 + ssn_r / (175.0 + sx * 175.0);
     fo = 6.5 * x * cos(yf / RADIAN) *
 	 sqrt(cos((z - sx * 5.0 + wx * 5.0) / RADIAN));
     ex = -0.5;
@@ -119,7 +268,7 @@ static void mini_f2() {
 }
 
 static void e_layer() {
-    double temp, fe, se, ex, xz;
+    double temp, fe, se, ex, xz, q;
 
     q = sin(xn / RADIAN) * sin(xs / RADIAN);
     x = q +
@@ -128,10 +277,10 @@ static void e_layer() {
 
     if (xz <= 85.0) {
 	ex = 1.0 / 3.0;
-	fe = 3.4 * (1.0 + 0.0016 * r) * power(cos(xz / RADIAN), ex);
+	fe = 3.4 * (1.0 + 0.0016 * ssn_r) * power(cos(xz / RADIAN), ex);
     } else {
 	ex = -0.5;
-	fe = 3.4 * (1.0 + 0.0016 * r) * power(xz - 80.0, ex);
+	fe = 3.4 * (1.0 + 0.0016 * ssn_r) * power(xz - 80.0, ex);
     }
 
     temp = cos(a / RADIAN);
@@ -143,7 +292,7 @@ static void e_layer() {
 
 }
 
-int muf(void) {
+void muf(void) {
     extern double QTH_Lat;
     extern double QTH_Long;
     extern double DEST_Lat;
@@ -151,15 +300,9 @@ int muf(void) {
     double sunrise;
     double sundown;
 
-    extern int mycountrynr;
-    extern int countrynr;
-    extern char lastwwv[];
-
-    dxcc_data *dx;
     int row;
-    static double la, l, mf, lh;
-    static long ve, ho;
-    char mycountry[40];
+    double la, l, mf, lh;
+    dxcc_data *dx;
     char country[40];
     int i;
     char time_buf[25];
@@ -167,12 +310,7 @@ int muf(void) {
     double ab;
     double n;
     double td;
-
-    PANEL *pan;
-    WINDOW *win;
-
-    win = newwin(LINES, 80, 0, 0);
-    pan = new_panel(win);
+    double q;
 
     n = 0.0;
 
@@ -181,21 +319,24 @@ int muf(void) {
     xr = DEST_Lat;
     yr = DEST_Long;
 
+    dx = dxcc_by_index(countrynr);
+    strncpy(country, dx->countryname, 25);
+
+
     get_time();
-//strftime(time_buf, 60, "    %d-%b-%Y %H:%M ",  time_ptr);     ### bug fix
     strftime(time_buf, sizeof(time_buf), "    %d-%b-%Y %H:%M ", time_ptr);
 
     q = sin(xt / RADIAN) * sin(xr / RADIAN);
     x = q + cos(xt / RADIAN) * cos(xr / RADIAN) * cos(yt / RADIAN - yr / RADIAN);
     la = (M_PI_2 - atan(x / sqrt(1 - x * x + 1e-12))) * RADIAN;
-    l = 111.1 * la;
+    l = ARC_IN_KM * la;
     q = sin(xr / RADIAN) - sin(xt / RADIAN) * cos(la / RADIAN);
     x = q / cos(xt / RADIAN) / sin(la / RADIAN);
     u = (M_PI_2 - atan(x / sqrt(1 - x * x + 1e-12))) * RADIAN;
     if (yt - yr <= 0)
 	u = 360 - u;
-    h = 275 + r / 2;
-    xs = 23.4 * cos(30 * (m - 6.25) / RADIAN);
+    h = 275 + ssn_r / 2;
+    xs = 23.4 * cos(30 * (month - 6.25) / RADIAN);
     n++;
     lh = l / n;
     while (lh > 4000.0) {
@@ -219,11 +360,8 @@ int muf(void) {
 		  6367.0 / (h + 6367.0)) / sin(0.5 * lm / RADIAN)) * RADIAN;
     }
 
-    dx = dxcc_by_index(mycountrynr);
-    strncpy(mycountry, dx->countryname, 25);
-
-    dx = dxcc_by_index(countrynr);
-    strncpy(country, dx->countryname, 25);
+    WINDOW *win = newwin(LINES, 80, 0, 0);
+    PANEL *pan = new_panel(win);
 
     wclear(win);
     wattron(win, modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
@@ -231,45 +369,46 @@ int muf(void) {
     for (i = 0; i < LINES; i++)
 	mvwprintw(win, i, 0, backgrnd_str);
 
-    mvwprintw(win, 1, 40, "%s", country);
-    mvwprintw(win, 1, 0, "        SSN: %3.0f ", r);
-    mvwprintw(win, 3, 40, "Dist  : %5ld KM", (long) floor(l + 0.5));
+    mvwprintw(win, 1, 0, "        SSN: %3.0f ", ssn_r);
 
-    mvwprintw(win, 4, 40, "Azim  :   %3ld degrees.", (long) floor(u + 0.5));
-    mvwprintw(win, 5, 40, "F-hops:    %2.0f", n);
+    if (countrynr != 0) {
+	mvwprintw(win, 1, 40, "%s", country);
+	mvwprintw(win, 3, 40, "Dist  : %5.0f km", l);
+	mvwprintw(win, 4, 40, "Azim  :   %3.0f degrees", u);
+	mvwprintw(win, 5, 40, "F-hops:    %2.0f", n);
 
-    sunup(xr, &sunrise, &sundown);	/* calculate local sunup and down
-    					   at destination lattitude */
+	sunup(xr, &sunrise, &sundown);	/* calculate local sunup and down
+                                               at destination lattitude */
+	/* transform to UTC based on longitude from country description */
+	td = (yr * 4) / 60 ; 	/* 4 degree/min */
+	sunrise += td;
+	sundown += td;
 
-    /* transform to UTC based on longitude from country description */
-    td = (yr * 4) / 60 ; 	/* 4 degree/min */
-    sunrise += td;
-    sundown += td;
+	if (sunrise >= 24.0)
+	    sunrise -= 24.0;
+	else if (sunrise <= 0.0)
+	    sunrise += 24.0;
 
-    if (sunrise >= 24.0)
-	sunrise -= 24.0;
-    else if (sunrise <= 0.0)
-	sunrise += 24.0;
+	if (sundown >= 24.0)
+	    sundown -= 24.0;
+	else if (sundown <= 0.0)
+	    sundown += 24.0;
 
-    if (sundown >= 24.0)
-	sundown -= 24.0;
-    else if (sundown <= 0.0)
-	sundown += 24.0;
+	su = (int)(sunrise);
+	sd = (int)(sundown);
 
-    su = (int)(sunrise);
-    sd = (int)(sundown);
+	su_min = (int)((sunrise - su) * 60);
+	sd_min = (int)((sundown - sd) * 60);
 
-    su_min = (int)((sunrise - su) * 60);
-    sd_min = (int)((sundown - sd) * 60);
+	mvwprintw(win, 3, 0, time_buf);
+	mvwprintw(win, 7, 40, "Sun   : %02d:%02d-%02d:%02d UTC", su, su_min, sd,
+		  sd_min);
+    }
 
-    mvwprintw(win, 3, 0, time_buf);
-    mvwprintw(win, 7, 40, "sun   : %02d:%02d-%02d:%02d UTC", su, su_min, sd,
-	      sd_min);
 
-    lastwwv[75] = '\0';		/* cut the bell chars */
-    if ((strlen(lastwwv) >= 28) && (r != 0))
-	mvwprintw(win, 10, 40, "Condx: %s", lastwwv + 26);	/* print WWV info  */
+    show_condx(win);
 
+    // show frequency chart
     q = 34.0;
     row = 4;
     while (q >= 2.0) {
@@ -284,48 +423,49 @@ int muf(void) {
     mvwprintw(win, 20, 0, "---------------------------");	/* 27 dashes */
     mvwprintw(win, 21, 0, " 0 2 4 6 8 10  14  18  22 H (UTC)");
     mvwprintw(win, 4, 30, "MHz");
-    refreshp();
-    for (t = 1; t <= 24; t++) {
-	ab = 0.0;
-	k = 0.5;
-	interlat();
-	mini_f2();
-	mf = ff;
 
-	k = n - 0.5;
-	interlat();
-	mini_f2();
-
-	if (ff < mf)
-	    mf = ff;
-	ve = 21 - (long) floor(mf / 2.0 + 0.5);
-
-	ho = t + 1;
-	if (ve < 4)
-	    ve = 4;
-	mvwprintw(win, (int) ve, (int) ho, "+");
-
-	while (k <= n - 0.25) {
+    if (countrynr != 0) {
+	for (t = 1; t <= 24; t++) {
+	    ab = 0.0;
+	    k = 0.5;
 	    interlat();
-	    e_layer();
-	    ab += ls;
-	    k += 0.5;
-	}
-	ve = 20 - (long) floor(ab + 0.5);
-	if (ve < 4)
-	    ve = 4;
-	if (ve > 20)
-	    ve = 20;
+	    mini_f2();
+	    mf = ff;
 
-	mvwprintw(win, (int) ve, (int) ho, "-");
+	    k = n - 0.5;
+	    interlat();
+	    mini_f2();
+
+	    if (ff < mf)
+		mf = ff;
+	    double ve = 21 - (long) floor(mf / 2.0 + 0.5);
+
+	    double ho = t + 1;
+	    if (ve < 4)
+		ve = 4;
+	    mvwprintw(win, (int) ve, (int) ho, "+");
+
+	    while (k <= n - 0.25) {
+		interlat();
+		e_layer();
+		ab += ls;
+		k += 0.5;
+	    }
+	    ve = 20 - (long) floor(ab + 0.5);
+	    if (ve < 4)
+		ve = 4;
+	    if (ve > 20)
+		ve = 20;
+
+	    mvwprintw(win, (int) ve, (int) ho, "-");
+	}
     }
+
     mvwprintw(win, 23, 0, " --- Press a key to continue --- ");
     refreshp();
-    (void)key_get();
+    key_get();
 
     hide_panel(pan);
     del_panel(pan);
     delwin(win);
-
-    return (0);
 }

--- a/src/muf.h
+++ b/src/muf.h
@@ -21,6 +21,8 @@
 #ifndef MUF_H
 #define MUF_H
 
-int muf(void);
+extern int month;
+
+void muf(void);
 
 #endif /* end of include guard: MUF_H */

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -33,6 +33,7 @@
 #include "fldigixmlrpc.h"
 #include "getctydata.h"
 #include "getpx.h"
+#include "getwwv.h"
 #include "lancode.h"
 #include "locator2longlat.h"
 #include "parse_logcfg.h"
@@ -224,7 +225,6 @@ int parse_logcfg(char *inputbuffer) {
     extern int packetinterface;
     extern int tncport;
     extern int tnc_serial_rate;
-    extern char lastwwv[];
     extern int serial_rate;
     extern rig_model_t myrig_model;
     extern char *rigportname;
@@ -596,7 +596,6 @@ int parse_logcfg(char *inputbuffer) {
     char **fields;
     char teststring[80];
     char buff[40];
-    char outputbuff[80];
     int ii;
     int jj, hh;
     char *tk_ptr;
@@ -895,20 +894,12 @@ int parse_logcfg(char *inputbuffer) {
 	}
 	case 42: {
 	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strcat(buff, fields[1]);
-	    outputbuff[0] = '\0';
-	    sprintf(outputbuff, "WWV R=%d\n", atoi(buff));
-	    strcpy(lastwwv, outputbuff);
+            wwv_set_r(atoi(fields[1]));
 	    break;
 	}
 	case 43: {
 	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strcat(buff, fields[1]);
-	    outputbuff[0] = '\0';
-	    sprintf(outputbuff, "WWV SFI=%d\n", atoi(buff));
-	    strcpy(lastwwv, outputbuff);
+            wwv_set_sfi(atoi(fields[1]));
 	    break;
 	}
 	case 45: {

--- a/src/qrb.c
+++ b/src/qrb.c
@@ -52,9 +52,6 @@
 
 #include "qrb.h"
 
-#define ARC_IN_KM 111.2
-#define RADIAN  (180.0 / M_PI)
-
 
 /* Compute the Bearing and Range */
 

--- a/src/qrb.h
+++ b/src/qrb.h
@@ -21,6 +21,8 @@
 #ifndef QRB_H
 #define QRB_H
 
+#define ARC_IN_KM 111.2
+#define RADIAN  (180.0 / M_PI)
 
 int qrb(double lon1, double lat1, double lon2, double lat2,
 	double *distance, double *azimuth);

--- a/src/setparameters.c
+++ b/src/setparameters.c
@@ -32,7 +32,6 @@
 #include "clear_display.h"
 #include "checklogfile.h"
 #include "getmessages.h"
-#include "getwwv.h"
 #include "readcalls.h"
 #include "scroll_log.h"
 #include "setcontest.h"
@@ -143,8 +142,6 @@ int setparameters(void) {
 	    }
 
 	    setcontest();	/* set contest parameters */
-
-	    getwwv();		/* get the latest wwv info from packet */
 
 	    scroll_log();	/* read the last 5  log lines and set the qso number */
 				/* read the logfile for score and dupe */

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -38,6 +38,7 @@
 #include <time.h>
 
 #include "dxcc.h"
+#include "getwwv.h"
 #include "qrb.h"
 #include "showinfo.h"
 #include "tlf.h"
@@ -125,7 +126,7 @@ void showinfo(int x) {
     getyx(stdscr, cury, curx);
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 
-    mvprintw(LINES - 1, 0, backgrnd_str);
+    mvaddstr(LINES - 1, 0, backgrnd_str);
 
     if (contstr[0] != '-') {
 	mvprintw(LINES - 1, 0, " %s  %s", pxstr, countrystr);
@@ -137,8 +138,10 @@ void showinfo(int x) {
 	}
 
 	mvprintw(LINES - 1, LINELENGTH - 17, "   DX time: %s", timebuff);
+    } else {
+        wwv_show_footer();
     }
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
-    mvprintw(cury, curx, "");
+    move(cury, curx);
 }

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -41,6 +41,7 @@
 #include "bandmap.h"
 #include "clear_display.h"
 #include "get_time.h"
+#include "getwwv.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "ignore_unused.h"
 #include "lancode.h"
@@ -92,7 +93,6 @@ char tln_input_buffer[2 * BUFFERSIZE];
 void setup_splitlayout();
 
 void addlog(char *s) {
-    extern char lastwwv[];
     extern char spot_ptr[MAX_SPOTS][82];
     extern char lastmsg[];
     extern int nr_of_spots;
@@ -142,8 +142,7 @@ void addlog(char *s) {
     // \todo drop it later tb mar11
     bm_add(s);
 
-    if ((strncmp(s, "WWV", 3) == 0) || strncmp(s, "WCY", 3) == 0)
-	strncpy(lastwwv, s, 82);
+    wwv_add(s);
 
     if (tln_loglines >= maxtln_loglines) {
 	temp = loghead;

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -68,22 +68,16 @@ void update_line(char *timestr) {
 
     extern struct tm *time_ptr;
 
-    static int daysecs = 0;
-    char time_buf[40] = "";
+    char time_buf[40];
 
     attron(COLOR_PAIR(C_WINDOW) | A_STANDOUT);
-    strncpy(time_buf, timestr, 8);
+
     mvaddstr(12, 0, band[bandinx]);
-    mvprintw(12, 17, time_buf);
 
-    daysecs++;
-
-    if (daysecs >= 60) {		// update the date 1x per minute
-	daysecs = 0;
-	get_time();
-	strftime(time_buf, 60, "%d-%b-%y", time_ptr);
-	mvprintw(12, 7, time_buf);
-    }
+    strncpy(time_buf, timestr, 8);
+    mvaddstr(12, 17, time_buf);
+    strftime(time_buf, 60, "%d-%b-%y", time_ptr);
+    mvaddstr(12, 7, time_buf);
 }
 
 const char *FREQ_DISPLAY_FORMAT = " %s: %7.1f";
@@ -127,7 +121,6 @@ void time_update(void) {
     char time_buf[11];
     int currentterm = 0;
     static int s = 0;
-    static int m = 0;
     static int bm_timeout = 0;
     static int oldsecs = -1;  	/* trigger immediate update */
 
@@ -182,14 +175,12 @@ void time_update(void) {
 	strftime(time_buf, 10, "%H:%M:%S", time_ptr);
 	time_buf[5] = '\0';
 
-	if ((time_buf[6] == '1') && (m >= 30)) {
-
-	    m = 0;
-	    getwwv();
-	    printcall();
-
-	} else {
-	    m++;
+	static time_t prev_wwv_time = 0;
+	if (lastwwv_time > prev_wwv_time) { // is there a newer WWV message?
+	    prev_wwv_time = lastwwv_time;
+	    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+	    mvprintw(LINES - 1, 0, backgrnd_str);
+	    wwv_show_footer();              // print WWV info
 	}
 
 	currentterm = miniterm;

--- a/test/data.c
+++ b/test/data.c
@@ -279,7 +279,6 @@ int commentfield = 0;		/* 1 if we are in comment/excahnge input */
 /*-------------------------------------packet-------------------------------*/
 char spot_ptr[MAX_SPOTS][82];		/* Array of cluster spot lines */
 int nr_of_spots;			/* Anzahl Lines in spot_ptr array */
-char lastwwv[120] = "";
 int packetinterface = 0;
 int fdSertnc = 0;
 int fdFIFO = 0;
@@ -391,8 +390,6 @@ double QTH_Long = -7.;
 double DEST_Lat = 51.;
 double DEST_Long = 1.;
 
-double r = 50;
-int m = 1;
 char hiscountry[40];
 
 int this_second;

--- a/test/test_wwv.c
+++ b/test/test_wwv.c
@@ -1,0 +1,85 @@
+#include "test.h"
+
+#include "../src/getwwv.h"
+
+// OBJECT ../src/getwwv.o
+
+int setup_default(void **state) {
+
+    ssn_r = 10.0;
+    lastwwv[0] = 0;
+
+    return 0;
+}
+
+void test_wwv_check_not_wwv(void **state) {
+    char *s = "DX de DL3DTH-#:   1816.5  ON7PQ        CW 30 dB 23 WPM CQ             2201Z";
+    wwv_add(s);
+    assert_int_equal(0, strlen(lastwwv));
+    assert_in_range(ssn_r, 9.99, 10.01);    // unchanged
+}
+
+void test_wwv_check(void **state) {
+    char *s = "WWV de VA6AAA <18>:   SFI=74, A=5, K=0, No Storms -> No Storms";
+    wwv_add(s);
+    assert_in_range(ssn_r, 4.43, 4.45);     // 74 --> 4.44
+    g_strchomp(lastwwv);
+    assert_string_equal(lastwwv, "Condx: 18 GMT                       SFI=74");
+}
+
+void test_wwv_check_wcy(void **state) {
+    char *s = "WCY de DK0WCY-1 <07> : K=3 expK=4 A=10 R=0 SFI=71 SA=qui GMF=qui Au=no";
+    wwv_add(s);
+    assert_in_range(ssn_r, 1.10, 1.12);     // 71 --> 1.11
+    g_strchomp(lastwwv);
+    assert_string_equal(lastwwv, "Condx: 07 GMT              R=0      SFI=71");
+}
+
+void test_wwv_check_wcy_sa(void **state) {
+    char *s = "WCY de DK0WCY-1 <17> : K=3 expK=4 A=10 R=11 SFI=71 SA=eru GMF=qui Au=no";
+    wwv_add(s);
+    assert_in_range(ssn_r, 1.10, 1.12);     // 71 --> 1.11
+    g_strchomp(lastwwv);
+    assert_string_equal(lastwwv,
+			"Condx: 17 GMT              R=11     SFI=71     eruptive");
+}
+
+void test_wwv_check_wcy_sa_gmf(void **state) {
+    char *s = "WCY de DK0WCY-1 <17> : K=3 expK=4 A=10 R=11 SFI=71 SA=eru GMF=act Au=no";
+    wwv_add(s);
+    assert_in_range(ssn_r, 1.10, 1.12);     // 71 --> 1.11
+    g_strchomp(lastwwv);
+    assert_string_equal(lastwwv,
+			"Condx: 17 GMT              R=11     SFI=71     eruptive  act");
+}
+
+void test_wwv_check_wcy_sa_gmf_aur(void **state) {
+    char *s = "WCY de DK0WCY-1 <17> : K=3 expK=4 A=10 R=0 SFI=71 SA=eru GMF=act Au=au";
+    wwv_add(s);
+    assert_in_range(ssn_r, 1.10, 1.12);     // 71 --> 1.11
+    g_strchomp(lastwwv);
+    assert_int_equal(70, strlen(lastwwv));
+    assert_string_equal(lastwwv,
+			"Condx: 17 GMT              R=0      SFI=71     eruptive  act   AURORA!");
+// original:            "Condx: 17 GMT              R=0 S    SFI=71      eruptive   act     AURORA!"
+}
+
+void test_wwv_check_wcy_sa_aur(void **state) {
+    char *s = "WCY de DK0WCY-1 <17> : K=3 expK=4 A=10 R=11 SFI=71 SA=eru GMF=qui Au=au";
+    wwv_add(s);
+    assert_in_range(ssn_r, 1.10, 1.12);     // 71 --> 1.11
+    g_strchomp(lastwwv);
+    assert_int_equal(70, strlen(lastwwv));
+    assert_string_equal(lastwwv,
+			"Condx: 17 GMT              R=11     SFI=71     eruptive        AURORA!");
+}
+
+void test_wwv_check_wcy_no_gmt(void **state) {
+    char *s = "WCY de DK0WCY-1 #### : K=3 expK=4 A=10 R=0 SFI=71 SA=qui GMF=qui Au=no";
+    wwv_add(s);
+    assert_in_range(ssn_r, 1.10, 1.12);     // 71 --> 1.11
+    g_strchomp(lastwwv);
+    assert_string_equal(lastwwv, "Condx:                     R=0      SFI=71");
+}
+
+


### PR DESCRIPTION
WWV messages are parsed by TLF, but they were shown in the footer just until the next screen rewrite. The parsed data is displayed in the MUF screen (`Ctrl-P`) starting at position 40, thereby potentially losing half of the string.  The parsing was also a bit sloppy.

There are a number of improvements/fixes:

- fixed parsing and status (footer) line generation
- footer shows the last WWV info for 3 minutes after its receipt
- MUF screen shows the parsed and also the original info. Both are split on multiple lines if needed.
- no MUF calculation if destination is not known
- MUF calc uses same Earth radius as `qrb.h` (ARC_IN_KM), now the distance matches on MUF screen and on the footer after search
- `parse_logcfg.c` calls setter functions instead of creating a fake WWV string
- on call input line date is updated not every 60s but 2s, i.e. one doesn't have to wait a minute to get the right date after 0:00. The performance impact is minimal.
- MUF's global variables got better names than `r` and `m`.
- added reference and attribution to `muf.c` source
- `cleanup` is called after startup
- found some places where `spaces()` could be used
- in `globalvars.h` moved `tlf.h` after the system includes
- added test for WWV parsing (it includes an original result with some issues)

Some `mvprintw` were changed to `mvaddstr`. The potential issue with using `mvprintw` for "just" showing a string is that it interprets the argument as a format string and in case it contains `%` the the result will not be as expected.

Also started using `move` instead of `mvprintw` for cursor positioning.