### PR TITLE
Refactor readcalls

### DIFF
--- a/ToDo
+++ b/ToDo
@@ -17,7 +17,7 @@ Planned for later versions
 
 [x] automatically switch back to 'Run' mode from "grab spot" after QSO (tnx
     Zoli)
-[ ] document new behaviour in man page aftre tests
+[ ] document new behaviour in man page after tests
 [x] Add contest name to Header of ADIF file (suggested by SP3RXO)
 [ ] Refactor write_adif function. Use an add_adif_field() helper and also 
     already existing get_next_record() function.

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -88,7 +88,7 @@ int addcall(void) {
     extern t_pfxnummulti pfxnummulti[MAXPFXNUMMULT];
     extern int pfxnummultinr;
     extern int addcallarea;
-    extern int continentlist_only;
+    extern bool continentlist_only;
     extern char continent[];
     extern int exclude_multilist_type;
     extern int trxmode;
@@ -162,7 +162,7 @@ int addcall(void) {
 	}
     }
 
-    if (continentlist_only == 1) {
+    if (continentlist_only) {
 	if (!is_in_continentlist(continent)) {
 	    add_ok = 0;
 	    addcty = 0;
@@ -171,7 +171,7 @@ int addcall(void) {
 	}
     }
 
-    if (continentlist_only == 0
+    if (!continentlist_only
 	    && exclude_multilist_type == EXCLUDE_CONTINENT) {
 	if (is_in_continentlist(continent)) {
 	    add_ok = 0;
@@ -272,7 +272,7 @@ int addcall2(void) {
     extern int pfxnummultinr;
     extern int addcallarea;
     extern int countrynr;
-    extern int continentlist_only;
+    extern bool continentlist_only;
     extern char continent[];
 
     extern int pfxmultab;
@@ -361,13 +361,13 @@ int addcall2(void) {
     }
 
 
-    if (continentlist_only == 1) {
+    if (continentlist_only) {
 	if (!is_in_continentlist(dxcc_by_index(j)->continent)) {
 	    excl_add_veto = 1;
 	}
     }
 
-    if (continentlist_only == 0
+    if (!continentlist_only
 	    && exclude_multilist_type == EXCLUDE_CONTINENT) {
 	if (is_in_continentlist(dxcc_by_index(j)->continent)) {
 	    excl_add_veto = 1;

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -173,7 +173,7 @@ int addcall(void) {
 
     if (continentlist_only == 0
 	    && exclude_multilist_type == EXCLUDE_CONTINENT) {
-        if (is_in_continentlist(continent)) {
+	if (is_in_continentlist(continent)) {
 	    add_ok = 0;
 	    addcty = 0;
 	    addcallarea = 0;

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -39,23 +39,26 @@
 #include "addcall.h"
 #include "addmult.h"
 #include "addpfx.h"
+#include "bands.h"
+#include "dxcc.h"
 #include "getctydata.h"
 #include "getpx.h"
+#include "get_time.h"
+#include "log_utils.h"
 #include "paccdx.h"
 #include "searchcallarray.h"
 #include "tlf.h"
 #include "zone_nr.h"
-#include "get_time.h"
-#include "dxcc.h"
-#include "bands.h"
 
 int excl_add_veto;
-/* This variable helps to handle in other modules, that station is multiplier or not */
-/* In addcall2(), this variable helps to handle the excluded multipliers, which came from lan_logline
- * the Tlf scoring logic is totally completely different in local and LAN source
- * the addcall() function doesn't increment the band_score[] array, that maintains the score()
- * function. Here, the addcall2() is need to separate the points and multipliers.
- * This variable is used in readcall() too.
+/* This variable helps to handle in other modules, that station is multiplier
+ * or not */
+/* In addcall2(), this variable helps to handle the excluded multipliers,
+ * which came from lan_logline the Tlf scoring logic is totally completely
+ * different in local and LAN source the addcall() function doesn't increment
+ * the band_score[] array, that maintains the score() function. Here, the
+ * addcall2() is need to separate the points and multipliers.  This variable
+ * is used in readcall() too.
  */
 
 int addcall(void) {
@@ -250,7 +253,7 @@ int addcall(void) {
 
     addmult();			/* for wysiwyg */
 
-    return (j);
+    return j;
 }
 
 /* -------------------------for network qso's-----------------------------------------*/
@@ -320,7 +323,7 @@ int addcall2(void) {
 
     j = getctynr(hiscall);
 
-    bandinx = get_band(lan_logline);
+    bandinx = log_get_band(lan_logline);
 
     /* calculate QSO timestamp from lan_logline */
     memset(&qsotime, 0, sizeof(struct tm));
@@ -398,7 +401,7 @@ int addcall2(void) {
 
     if (add_ok == 1) {
 
-	bandinx = get_band(lan_logline);
+	bandinx = log_get_band(lan_logline);
 	band_score[bandinx]++;
 
 	worked[i].band |= inxes[bandinx];	/* worked on this band */
@@ -467,7 +470,7 @@ int addcall2(void) {
 		}
 	    }
 
-	    bandinx = get_band(lan_logline);
+	    bandinx = log_get_band(lan_logline);
 
 	    add_pfx(lancopy, bandinx);
 	}
@@ -475,52 +478,6 @@ int addcall2(void) {
 
     addmult2();			/* for wysiwyg from LAN */
 
-    return (j);
+    return j;
 }
 
-int get_band(char *logline) {
-
-    int j = 0;
-
-    switch (atoi(logline)) {
-
-	case 160:
-	    j = BANDINDEX_160;
-	    break;
-
-	case 80:
-	    j = BANDINDEX_80;
-	    break;
-
-	case 40:
-	    j = BANDINDEX_40;
-	    break;
-
-	case 20:
-	    j = BANDINDEX_20;
-	    break;
-
-	case 15:
-	    j = BANDINDEX_15;
-	    break;
-
-	case 10:
-	    j = BANDINDEX_10;
-	    break;
-
-	case 12:
-	    j = BANDINDEX_12;
-	    break;
-
-	case 17:
-	    j = BANDINDEX_17;
-	    break;
-
-	case 30:
-	    j = BANDINDEX_30;
-	    break;
-
-    }
-
-    return (j);
-}

--- a/src/bands.c
+++ b/src/bands.c
@@ -72,48 +72,37 @@ int inxes[NBANDS] = \
 
 /** Converts bandnumber to bandindex */
 int bandnr2index(int nr) {
-    int j = BANDINDEX_OOB;
-
     switch (nr) {
 
 	case 160:
-	    j = BANDINDEX_160;
-	    break;
+	    return BANDINDEX_160;
 
 	case 80:
-	    j = BANDINDEX_80;
-	    break;
+	    return BANDINDEX_80;
 
 	case 40:
-	    j = BANDINDEX_40;
-	    break;
+	    return BANDINDEX_40;
 
 	case 20:
-	    j = BANDINDEX_20;
-	    break;
+	    return BANDINDEX_20;
 
 	case 15:
-	    j = BANDINDEX_15;
-	    break;
+	    return BANDINDEX_15;
 
 	case 10:
-	    j = BANDINDEX_10;
-	    break;
+	    return BANDINDEX_10;
 
 	case 12:
-	    j = BANDINDEX_12;
-	    break;
+	    return BANDINDEX_12;
 
 	case 17:
-	    j = BANDINDEX_17;
-	    break;
+	    return BANDINDEX_17;
 
 	case 30:
-	    j = BANDINDEX_30;
-	    break;
-
+	    return BANDINDEX_30;
+	default:
+	    return BANDINDEX_OOB;
     }
-    return j;
 }
 
 

--- a/src/bands.c
+++ b/src/bands.c
@@ -69,6 +69,63 @@ int inxes[NBANDS] = \
     BANDOOB
 };
 
+
+/** Converts bandnumber to bandindex */
+int bandnr2index(int nr) {
+    int j = BANDINDEX_OOB;
+
+    switch (nr) {
+
+	case 160:
+	    j = BANDINDEX_160;
+	    break;
+
+	case 80:
+	    j = BANDINDEX_80;
+	    break;
+
+	case 40:
+	    j = BANDINDEX_40;
+	    break;
+
+	case 20:
+	    j = BANDINDEX_20;
+	    break;
+
+	case 15:
+	    j = BANDINDEX_15;
+	    break;
+
+	case 10:
+	    j = BANDINDEX_10;
+	    break;
+
+	case 12:
+	    j = BANDINDEX_12;
+	    break;
+
+	case 17:
+	    j = BANDINDEX_17;
+	    break;
+
+	case 30:
+	    j = BANDINDEX_30;
+	    break;
+
+    }
+    return j;
+}
+
+
+/* converts bandindex to bandnumber */
+static int bandnr[NBANDS] =
+{ 160, 80, 40, 30, 20, 17, 15, 12, 10, 0 };
+
+int bandindex2nr(int index) {
+    return bandnr[index];
+}
+
+
 extern int bandinx;
 
 void next_band(int direction) {

--- a/src/bands.h
+++ b/src/bands.h
@@ -38,6 +38,18 @@ extern const unsigned int bandcorner[NBANDS][2];
 extern const unsigned int cwcorner[NBANDS];
 extern const unsigned int ssbcorner[NBANDS];
 
+/** \brief converts bandnumber to bandindex
+ *
+ * \parameter   bandnumber
+ * \return	bandindex or BANDINDEX_OOB if no ham radio band
+ */
+int bandnr2index(int nr);
+
+
+/** \brief converts bandindex to bandnumber */
+int bandindex2nr(int index);
+
+
 /** Switch to next band
  *
  * Switch to next ham radio band up or down. Wrap around if lowest or highest

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -467,7 +467,7 @@ int getexchange(void) {
 	    } else if (((serial_section_mult == 1) || (sectn_mult == 1))
 		       && ((x != TAB) && (strlen(section) < 1))) {
 		if (serial_or_section == 0 || (serial_or_section == 1
-					       && country_found(hiscall) == 1)) {
+					       && country_found(hiscall))) {
 		    mvprintw(13, 54, "section?", section);
 		    mvprintw(12, 54, comment);
 		    refreshp();

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -240,8 +240,7 @@ int getexchange(void) {
 		if ((ctcomp != 0) && (strlen(hiscall) > 2)) {
 		    if (comment[0] == '\0') {
 			x = -1;
-		    }
-		    else {
+		    } else {
 			/* F4 (TU macro) */
 			send_standard_message(3);
 
@@ -279,9 +278,9 @@ int getexchange(void) {
 	    }
 
 	    case 176 ... 185: {	/* Alt-0 to Alt-9 */
-	        send_standard_message(x - 162);	/* Messages 15-24 */
+		send_standard_message(x - 162);	/* Messages 15-24 */
 
-	        break;
+		break;
 	    }
 
 	    /* <Home>--edit exchange field, position cursor to left end of field.
@@ -348,8 +347,7 @@ int getexchange(void) {
 		    /* Don't log if exchange field is empty. */
 		    if (comment[0] == '\0') {
 			x = -1;
-		    }
-		    else {
+		    } else {
 			/* Log without sending a message. */
 			x = BACKSLASH;
 		    }
@@ -383,7 +381,7 @@ int getexchange(void) {
 
 	/* <Enter>, <Tab>, Ctl-K, '\' */
 	if (x == '\n' || x == KEY_ENTER || x == TAB
-	    || x == CTRL_K || x == BACKSLASH) {
+		|| x == CTRL_K || x == BACKSLASH) {
 
 	    if ((exchange_serial == 1 && comment[0] >= '0'
 		    && comment[0] <= '9')) {	/* align serial nr. */

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -38,7 +38,6 @@ extern int cqww;
 extern int arrldx_usa;
 extern int pacc_pa_flg;
 extern int country_mult;
-extern int other_flg;
 extern char hiscall[20];
 extern int total;
 extern int band_score[NBANDS];		// QSO/band

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -29,7 +29,7 @@
 #include "bands.h"
 
 /* for the following code we assume that we have well formatted log lines,
- * which has to be checked separatley if needed */
+ * which has to be checked separately if needed */
 
 /** check if logline is only a comment */
 bool log_is_comment(char *buffer) {

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -20,16 +20,61 @@
 *    util functions to work with lines from log
 *
 ---------------------------------------------------------------------------*/
+#include <ctype.h>
+#include <glib.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+
+#include "bands.h"
+
+/* for the following code we assume that we have well formatted log lines,
+ * which has to be checked separatley if needed */
 
 /** check if logline is only a comment */
 bool log_is_comment(char *buffer) {
 
-    if (buffer[0] != ';' && strlen(buffer) > 60) /** \todo better check */
+    if (buffer[0] != ';')
 	return 0;
     else
 	return 1;
 }
 
+
+/** read bandindex from logline */
+int log_get_band(char *logline) {
+
+    int nr = 0;
+    char band[4];
+
+    g_strlcpy(band, logline, 4);
+
+    nr = atoi(band);
+
+    return bandnr2index(nr);
+}
+
+
+/** read mode from logline
+ * -1 if no recognized mode */
+int log_get_mode(char *logline) {
+    if (strncasecmp("CW ", logline + 3, 3) == 0) {
+	return CWMODE;
+    }
+    if (strncasecmp("SSB", logline + 3, 3) == 0) {
+	return SSBMODE;
+    }
+    if (strncasecmp("DIG", logline + 3, 3) == 0) {
+	return DIGIMODE;
+    }
+    return -1;
+}
+
+/** read points from logline */
+int log_get_points(char *logline) {
+    char tmpbuf[3];
+
+    g_strlcpy(tmpbuf, logline + 76, 3);
+    return atoi(tmpbuf);
+}
 

--- a/src/log_utils.h
+++ b/src/log_utils.h
@@ -26,5 +26,8 @@
 #include <stdbool.h>
 
 bool log_is_comment(char *buffer);
+int log_get_band(char *logline);
+int log_get_mode(char *logline);
+int log_get_points(char *logline);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -128,11 +128,11 @@ int my_country_points = -1;
 int my_cont_points = -1;
 int dx_cont_points = -1;
 char countrylist[255][6];
-int countrylist_only = 0;
+bool countrylist_only = false;
 int countrylist_points = -1;
 char continent_multiplier_list[7][3]; // SA, NA, EU, AF, AS and OC
 int continentlist_points = -1;
-int continentlist_only = 0;
+bool continentlist_only = false;
 int exclude_multilist_type = EXCLUDE_NONE;
 bool mult_side = false;
 /* end LZ3NY mods */

--- a/src/main.c
+++ b/src/main.c
@@ -115,7 +115,6 @@ int pfxmult = 0;
 int pfxmultab = 0;
 int exc_cont = 0;
 int manise80;
-int other_flg;
 int one_point = 0;
 int two_point = 0;
 int three_point = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -133,7 +133,7 @@ int countrylist_points = -1;
 char continent_multiplier_list[7][3]; // SA, NA, EU, AF, AS and OC
 int continentlist_points = -1;
 int continentlist_only = 0;
-int exclude_multilist_type = 0;
+int exclude_multilist_type = EXCLUDE_NONE;
 int mult_side = 0;
 /* end LZ3NY mods */
 

--- a/src/main.c
+++ b/src/main.c
@@ -134,7 +134,7 @@ char continent_multiplier_list[7][3]; // SA, NA, EU, AF, AS and OC
 int continentlist_points = -1;
 int continentlist_only = 0;
 int exclude_multilist_type = EXCLUDE_NONE;
-int mult_side = 0;
+bool mult_side = false;
 /* end LZ3NY mods */
 
 int portable_x2 = 0;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -281,9 +281,9 @@ int parse_logcfg(char *inputbuffer) {
     extern int my_cont_points;
     extern int dx_cont_points;
     extern int countrylist_points;
-    extern int countrylist_only;
+    extern bool countrylist_only;
     extern int continentlist_points;
-    extern int continentlist_only;
+    extern bool continentlist_only;
     char c_temp[11];
     extern bool mult_side;
     extern char countrylist[][6];
@@ -1228,9 +1228,9 @@ int parse_logcfg(char *inputbuffer) {
 	    break;
 	}
 	case 97: {		// COUNTRY_LIST_ONLY
-	    countrylist_only = 1;
+	    countrylist_only = true;
 	    if (mult_side == 1)
-		countrylist_only = 0;
+		countrylist_only = false;
 
 	    break;
 	}
@@ -1603,7 +1603,7 @@ int parse_logcfg(char *inputbuffer) {
 	    break;
 	}
 	case 165: {		// CONTINENT_LIST_ONLY
-	    continentlist_only = 1;
+	    continentlist_only = true;
 	    break;
 	}
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1785,7 +1785,7 @@ int parse_logcfg(char *inputbuffer) {
 		    sleep(5);
 		    exit(1);
 		}
-		exclude_multilist_type = 1;
+		exclude_multilist_type = EXCLUDE_CONTINENT;
 	    } else if (strcmp(g_strchomp(fields[1]), "COUNTRYLIST") == 0) {
 		if (strlen(countrylist[0]) == 0) {
 		    showmsg
@@ -1793,7 +1793,7 @@ int parse_logcfg(char *inputbuffer) {
 		    sleep(5);
 		    exit(1);
 		}
-		exclude_multilist_type = 2;
+		exclude_multilist_type = EXCLUDE_COUNTRY;
 	    } else {
 		showmsg
 		("WARNING: choose one of these for EXCLUDE_MULTILIST: CONTINENTLIST, COUNTRYLIST");

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1154,8 +1154,8 @@ int parse_logcfg(char *inputbuffer) {
 
 	    int counter = 0;
 	    static char country_list_raw[50] = ""; 	/* use only first
-						   	COUNTRY_LIST
-						   	definition */
+						       COUNTRY_LIST
+						       definition */
 	    char temp_buffer[255] = "";
 	    char buffer[255] = "";
 	    FILE *fp;
@@ -1273,7 +1273,7 @@ int parse_logcfg(char *inputbuffer) {
 	    if (verbose) {
 		gchar *tmp;
 		tmp = g_strdup_printf("  Phone message #%d is %s", ii - 103,
-		     ph_message[ii - 103]);	// (W9WI)
+				      ph_message[ii - 103]);	// (W9WI)
 		showmsg(tmp);
 		g_free(tmp);
 	    }
@@ -1540,8 +1540,8 @@ int parse_logcfg(char *inputbuffer) {
 
 	    int counter = 0;
 	    static char cont_multiplier_list[50] = ""; 	/* use only first
-						   	CONTINENT_LIST
-						   	definition */
+						       CONTINENT_LIST
+						       definition */
 	    char temp_buffer[255] = "";
 	    char buffer[255] = "";
 	    FILE *fp;
@@ -1718,7 +1718,7 @@ int parse_logcfg(char *inputbuffer) {
 	    if (verbose) {
 		gchar *tmp;
 		tmp = g_strdup_printf("  QTC RECV phone message #%d is %s",
-		    ii - 194, qtc_phrecv_message[ii - 194]);
+				      ii - 194, qtc_phrecv_message[ii - 194]);
 		showmsg(tmp);
 		g_free(tmp);
 	    }
@@ -1730,7 +1730,7 @@ int parse_logcfg(char *inputbuffer) {
 	    if (verbose) {
 		gchar *tmp;
 		tmp = g_strdup_printf("  QTC SEND phone message #%d is %s",
-		    ii - 208, qtc_phrecv_message[ii - 208]);
+				      ii - 208, qtc_phrecv_message[ii - 208]);
 		showmsg(tmp);
 		g_free(tmp);
 	    }

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -60,7 +60,7 @@ extern char *cabrillo;
 extern rmode_t digi_mode;
 extern int ctcomp;
 
-int exist_in_country_list();
+bool exist_in_country_list();
 
 void KeywordRepeated(char *keyword);
 void KeywordNotSupported(char *keyword);
@@ -277,7 +277,6 @@ int parse_logcfg(char *inputbuffer) {
     extern int serial_or_section;
 
     /* LZ3NY mods */
-    extern int mult_side;
     extern int my_country_points;
     extern int my_cont_points;
     extern int dx_cont_points;
@@ -286,11 +285,8 @@ int parse_logcfg(char *inputbuffer) {
     extern int continentlist_points;
     extern int continentlist_only;
     char c_temp[11];
-    extern int my_cont_points;
-    extern int dx_cont_points;
-    extern int mult_side;
+    extern bool mult_side;
     extern char countrylist[][6];
-
     extern char continent_multiplier_list[7][3];
     extern int exclude_multilist_type;
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -61,7 +61,6 @@ extern rmode_t digi_mode;
 extern int ctcomp;
 
 int exist_in_country_list();
-int continent_found();
 
 void KeywordRepeated(char *keyword);
 void KeywordNotSupported(char *keyword);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -50,7 +50,7 @@
 #include "tlf_curses.h"
 #include "zone_nr.h"
 
-extern int continentlist_only;
+extern bool continentlist_only;
 extern int pfxnummultinr;
 extern t_pfxnummulti pfxnummulti[];
 extern int exclude_multilist_type;
@@ -131,7 +131,7 @@ int lookup_country_in_pfxnummult_array(int n) {
 bool check_veto() {
     bool excl_add_veto = false;
 
-    if (continentlist_only == 0 &&
+    if (!continentlist_only &&
 	    exclude_multilist_type == EXCLUDE_CONTINENT) {
 	if (is_in_continentlist(continent)) {
 	    excl_add_veto = true;
@@ -273,7 +273,7 @@ int readcalls(void) {
 	strcpy(tmpbuf, presentcall);
 	countrynr = getctydata(tmpbuf);
 
-	if (continentlist_only == 1) {
+	if (continentlist_only) {
 	    if (!is_in_continentlist(continent)) {
 		band_score[bandindex]++;
 		continue;

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -50,12 +50,10 @@
 #include "tlf_curses.h"
 #include "zone_nr.h"
 
-extern char continent_multiplier_list[7][3];
 extern int continentlist_only;
 extern int pfxnummultinr;
 extern t_pfxnummulti pfxnummulti[];
 extern int exclude_multilist_type;
-extern char countrylist[][6];
 
 
 void init_scoring(void) {
@@ -130,13 +128,12 @@ int lookup_country_in_pfxnummult_array(int n) {
     return found;
 }
 
-
 bool check_veto() {
     bool excl_add_veto = false;
 
     if (continentlist_only == 0 &&
 	    exclude_multilist_type == EXCLUDE_CONTINENT) {
-	if (continent_found()) {
+	if (is_in_continentlist(continent)) {
 	    excl_add_veto = true;
 	}
     }
@@ -277,7 +274,7 @@ int readcalls(void) {
 	countrynr = getctydata(tmpbuf);
 
 	if (continentlist_only == 1) {
-	    if (!continent_found()) {
+	    if (!is_in_continentlist(continent)) {
 		band_score[bandindex]++;
 		continue;
 	    }

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -158,7 +158,7 @@ char *get_multi_from_line(char *logline) {
 
 int readcalls(void) {
 
-    char inputbuffer[160];
+    char inputbuffer[LOGLINELEN + 1];
     char tmpbuf[20];
     char checkcall[20];
     int z = 0;
@@ -188,20 +188,14 @@ int readcalls(void) {
 	exit(1);
     }
 
-    while (fgets(inputbuffer, 90, fp) != NULL) {
+    while (fgets(inputbuffer, LOGLINELEN + 1, fp) != NULL) {
 	int l = 0;
 
-	// sanitize input line
-	strcat(inputbuffer, spaces(50)); /* repair the logfile */
+	// drop trailing newline
 	inputbuffer[LOGLINELEN - 1] = '\0';
 
-	for (int t = 0; t <= strlen(inputbuffer); t++) {
-	    if (inputbuffer[t] == '\n')
-		inputbuffer[t] = ' ';
-	}
-
 	// remember logline in qsos[] field
-	strncpy(qsos[linenr], inputbuffer, LOGLINELEN);
+	g_strlcpy(qsos[linenr], inputbuffer, sizeof(qsos[0]));
 	linenr++;
 
 	show_progress(linenr);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -111,16 +111,6 @@ void show_progress(int linenr) {
     }
 }
 
-bool is_in_countrylist(int countrynr) {
-    int ci = 0;
-    while (strlen(countrylist[ci]) != 0) {
-	if (getctynr(countrylist[ci]) == countrynr) {
-	    return true;
-	}
-	ci++;
-    }
-    return false;
-}
 
 // lookup the current country 'n' from the outer loop
 // pfxnummulti[I].countrynr contains the country codes,

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -219,7 +219,6 @@ int readcalls(void) {
 		multbuffer[0] = '\0';
 
 		if (arrlss == 1) {
-		    other_flg = 0;
 
 		    if (inputbuffer[63] == ' ')
 			strncpy(multbuffer, inputbuffer + 64, 3);
@@ -267,23 +266,7 @@ int readcalls(void) {
 
 		remember_multi(multbuffer, bandindex, 0);
 
-	    }			// end wysiwig
-
-	    if (other_flg == 1) {	/* mult = max 3 characters */
-
-		strncpy(multbuffer, inputbuffer + 54, 3);
-		multbuffer[3] = '\0';
-
-		if (multbuffer[3] == ' ')
-		    multbuffer[3] = '\0';
-		if (multbuffer[2] == ' ')
-		    multbuffer[2] = '\0';
-		if (multbuffer[1] == ' ')
-		    multbuffer[1] = '\0';
-
-		remember_multi(multbuffer, bandindex, 0);
 	    }
-
 	}
 
 	/*  lookup worked stations */

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -44,6 +44,7 @@
 #include "log_utils.h"
 #include "paccdx.h"
 #include "readqtccalls.h"
+#include "searchcallarray.h"
 #include "startmsg.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
@@ -71,7 +72,6 @@ int readcalls(void) {
     char zonebuf[3];
     char checkcall[20];
     int i = 0, l = 0, n = 0;
-    int m = 0;
     int t;
     int z = 0;
     int add_ok;
@@ -110,6 +110,7 @@ int readcalls(void) {
 	    }
 	}
     }
+    nr_worked = 0;
 
     for (i = 1; i <= MAX_DATALINES - 1; i++)
 	countries[i] = 0;
@@ -315,15 +316,10 @@ int readcalls(void) {
 	}
 
 	/*  lookup worked stations */
-	for (int k = 0; k < i; k++) {
-	    m = strcmp(worked[k].call, presentcall);
-
-	    if (m == 0) {
-		l = k;
-		break;
-	    } else
-		l = i;
-
+	l = searchcallarray(presentcall);
+	if (l == -1) {		    /* if not found, use next free slot */
+	    l = nr_worked;
+	    nr_worked++;
 	}
 
 	/* and fill in according entry */
@@ -441,22 +437,16 @@ int readcalls(void) {
 	    }
 
 	}
-
-	if (l == i)
-	    i++;
     }
 
     fclose(fp);
-
-    /* remember nuber of callarray entries */
-    nr_worked = i;
 
     if (wpx == 1) {
 
 	/* build prefixes_worked array from list of worked stations */
 	InitPfx();
 
-	for (n = 0; n < i; n++) {
+	for (n = 0; n < nr_worked; n++) {
 	    strcpy(checkcall, worked[n].call);
 	    getpx(checkcall);
 	    /* FIXME: wpx is counting pfx only once so bandindex is not

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -47,7 +47,6 @@
 #include "searchcallarray.h"
 #include "startmsg.h"
 #include "tlf_curses.h"
-#include "ui_utils.h"
 #include "zone_nr.h"
 
 extern char continent_multiplier_list[7][3];
@@ -339,8 +338,7 @@ int readcalls(void) {
 		}
 		ci++;
 	    }
-	    if (cont_in_list == 1 && continentlist_only == 0
-		    && exclude_multilist_type == 1) {
+	    if (cont_in_list == 1) {
 		excl_add_veto = 1;
 	    }
 	}

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -115,14 +115,12 @@ int readcalls(void) {
 
     char inputbuffer[160];
     char tmpbuf[20];
-    char zonebuf[3];
     char checkcall[20];
     int z = 0;
     int add_ok;
     char multbuffer[40];
     char presentcall[20];	// copy of call..
     char *tmpptr;
-    int points;
     int pfxnumcntidx;
     int pxnr;
     int excl_add_veto;
@@ -200,13 +198,12 @@ int readcalls(void) {
 	}
 
 	if (contest == 1) {
-	    g_strlcpy(tmpbuf, inputbuffer + 76, 3);	/* get the points */
-	    points = atoi(tmpbuf);
-	    total = total + points;
+	    // get points
+	    total = total + log_get_points(inputbuffer);
 
 	    if ((cqww == 1) || (itumult == 1) || (wazmult == 1)) {
-		g_strlcpy(zonebuf, inputbuffer + 54, 3); /* get the zone */
-		z = zone_nr(zonebuf);
+		// get the zone
+		z = zone_nr(inputbuffer + 54);
 	    }
 
 	    if (wysiwyg_once == 1 ||

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -176,12 +176,11 @@ int readcalls(void) {
 	bandindex = log_get_band(inputbuffer);
 
 	/* get the country number, not known at this point */
-	strncpy(presentcall, inputbuffer + 29, 13);
-	presentcall[13] = '\0';
-
+	g_strlcpy(presentcall, inputbuffer + 29, 14);
 	tmpptr = strchr(presentcall, ' ');
 	if (tmpptr)
 	    *tmpptr = '\0';
+
 	strcpy(tmpbuf, presentcall);
 	countrynr = getctydata(tmpbuf);
 
@@ -201,14 +200,12 @@ int readcalls(void) {
 	}
 
 	if (contest == 1) {
-	    strncpy(tmpbuf, inputbuffer + 76, 2);	/* get the points */
-	    tmpbuf[2] = '\0';
+	    g_strlcpy(tmpbuf, inputbuffer + 76, 3);	/* get the points */
 	    points = atoi(tmpbuf);
 	    total = total + points;
 
 	    if ((cqww == 1) || (itumult == 1) || (wazmult == 1)) {
-		strncpy(zonebuf, inputbuffer + 54, 2);	/* get the zone */
-		zonebuf[2] = '\0';
+		g_strlcpy(zonebuf, inputbuffer + 54, 3); /* get the zone */
 		z = zone_nr(zonebuf);
 	    }
 
@@ -300,9 +297,7 @@ int readcalls(void) {
 	}
 
 	/* and fill in according entry */
-	strncpy(worked[l].call, inputbuffer + 29, 19);
-	worked[l].call[19] = 0;
-	strtok(worked[l].call, " \r");	/* delimit first word */
+	g_strlcpy(worked[l].call, presentcall, sizeof(worked[0].call));
 
 	worked[l].country = countrynr;
 	g_strlcpy(worked[l].exchange, inputbuffer + 54, 12);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -290,13 +290,13 @@ int readcalls(void) {
 	    }
 
 	    if (wysiwyg_once == 1 ||
-		wysiwyg_multi == 1 ||
-		unique_call_multi != 0 ||
-		arrlss == 1 ||
-		serial_section_mult == 1 ||
-		serial_grid4_mult == 1 ||
-		sectn_mult == 1 ||
-		((dx_arrlsections == 1)
+		    wysiwyg_multi == 1 ||
+		    unique_call_multi != 0 ||
+		    arrlss == 1 ||
+		    serial_section_mult == 1 ||
+		    serial_grid4_mult == 1 ||
+		    sectn_mult == 1 ||
+		    ((dx_arrlsections == 1)
 		     && ((countrynr == w_cty) || (countrynr == ve_cty)))) {
 		// get multi info
 		char *multbuffer = get_multi_from_line(inputbuffer);
@@ -329,7 +329,7 @@ int readcalls(void) {
 
 	/* calculate QSO timestamp from logline */
 	memset(&qsotime, 0, sizeof(struct tm));
-	strptime(inputbuffer+7, "%d-%b-%y %H:%M", &qsotime);
+	strptime(inputbuffer + 7, "%d-%b-%y %H:%M", &qsotime);
 	worked[l].qsotime[qsomode][bandindex] = mktime(&qsotime);
 
 
@@ -461,7 +461,7 @@ int readcalls(void) {
 		 * eg: K0, K1, K2, ..., K9 */
 		for (int pfxnr = 0; pfxnr < 10; pfxnr++) {
 		    count_contest_bands(pfxnummulti[pfxnumcntidx].qsos[pfxnr],
-			    countryscore);
+					countryscore);
 		}
 	    } else {
 		// simple 'country_mult', but works together with pfxnummulti

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -186,6 +186,25 @@ char *get_multi_from_line(char *logline) {
 }
 
 
+void count_if_worked(int check, unsigned int bandindex, int *count) {
+    if (bandindex >= NBANDS)
+	return;
+
+    if ((check & inxes[bandindex]) != 0)
+	count[bandindex]++;
+}
+
+void count_contest_bands(int check, int *count) {
+    count_if_worked(check, BANDINDEX_160, count);
+    count_if_worked(check, BANDINDEX_80, count);
+    count_if_worked(check, BANDINDEX_40, count);
+    count_if_worked(check, BANDINDEX_20, count);
+    count_if_worked(check, BANDINDEX_15, count);
+    count_if_worked(check, BANDINDEX_10, count);
+}
+
+
+
 int readcalls(void) {
 
     char inputbuffer[LOGLINELEN + 1];
@@ -396,106 +415,41 @@ int readcalls(void) {
 
     if ((cqww == 1) || (itumult == 1) || (wazmult == 1)) {
 	for (int n = 1; n < MAX_ZONES; n++) {
-	    if ((zones[n] & BAND160) != 0)
-		zonescore[BANDINDEX_160]++;
-	    if ((zones[n] & BAND80) != 0)
-		zonescore[BANDINDEX_80]++;
-	    if ((zones[n] & BAND40) != 0)
-		zonescore[BANDINDEX_40]++;
-	    if ((zones[n] & BAND20) != 0)
-		zonescore[BANDINDEX_20]++;
-	    if ((zones[n] & BAND15) != 0)
-		zonescore[BANDINDEX_15]++;
-	    if ((zones[n] & BAND10) != 0)
-		zonescore[BANDINDEX_10]++;
+	    count_contest_bands(zones[n], zonescore);
 	}
     }
 
     if (cqww == 1) {
 	for (int n = 1; n <= MAX_DATALINES - 1; n++) {
-	    if ((countries[n] & BAND160) != 0)
-		countryscore[BANDINDEX_160]++;
-	    if ((countries[n] & BAND80) != 0)
-		countryscore[BANDINDEX_80]++;
-	    if ((countries[n] & BAND40) != 0)
-		countryscore[BANDINDEX_40]++;
-	    if ((countries[n] & BAND20) != 0)
-		countryscore[BANDINDEX_20]++;
-	    if ((countries[n] & BAND15) != 0)
-		countryscore[BANDINDEX_15]++;
-	    if ((countries[n] & BAND10) != 0)
-		countryscore[BANDINDEX_10]++;
+	    count_contest_bands(countries[n], countryscore);
 	}
     }
-    /* end cqww */
+
     if (dx_arrlsections == 1) {
-
-	int cntr;
-
-	for (cntr = 1; cntr < MAX_DATALINES; cntr++) {
-
+	for (int cntr = 1; cntr < MAX_DATALINES; cntr++) {
 	    if (cntr != w_cty && cntr != ve_cty) {	// W and VE don't count here...
-		if ((countries[cntr] & BAND160) != 0)
-		    countryscore[BANDINDEX_160]++;
-		if ((countries[cntr] & BAND80) != 0)
-		    countryscore[BANDINDEX_80]++;
-		if ((countries[cntr] & BAND40) != 0)
-		    countryscore[BANDINDEX_40]++;
-		if ((countries[cntr] & BAND20) != 0)
-		    countryscore[BANDINDEX_20]++;
-		if ((countries[cntr] & BAND15) != 0)
-		    countryscore[BANDINDEX_15]++;
-		if ((countries[cntr] & BAND10) != 0)
-		    countryscore[BANDINDEX_10]++;
+		count_contest_bands(countries[cntr], countryscore);
 	    }
 	}
-    }				// end dx_arrlsections
+    }
 
     if (arrldx_usa == 1) {
-
-	int cntr;
-	for (cntr = 1; cntr < MAX_DATALINES; cntr++) {
+	for (int cntr = 1; cntr < MAX_DATALINES; cntr++) {
 	    if (cntr != w_cty && cntr != ve_cty) {	// W and VE don't count here...
-		if ((countries[cntr] & BAND160) != 0)
-		    countryscore[BANDINDEX_160]++;
-		if ((countries[cntr] & BAND80) != 0)
-		    countryscore[BANDINDEX_80]++;
-		if ((countries[cntr] & BAND40) != 0)
-		    countryscore[BANDINDEX_40]++;
-		if ((countries[cntr] & BAND20) != 0)
-		    countryscore[BANDINDEX_20]++;
-		if ((countries[cntr] & BAND15) != 0)
-		    countryscore[BANDINDEX_15]++;
-		if ((countries[cntr] & BAND10) != 0)
-		    countryscore[BANDINDEX_10]++;
+		count_contest_bands(countries[cntr], countryscore);
 	    }
 	}
-
     }
-    /* end arrldx_usa */
 
     if (pacc_pa_flg == 1) {
-
 	for (int n = 1; n < MAX_DATALINES; n++) {
-	    if ((countries[n] & BAND160) != 0)
-		countryscore[BANDINDEX_160]++;
-	    if ((countries[n] & BAND80) != 0)
-		countryscore[BANDINDEX_80]++;
-	    if ((countries[n] & BAND40) != 0)
-		countryscore[BANDINDEX_40]++;
-	    if ((countries[n] & BAND20) != 0)
-		countryscore[BANDINDEX_20]++;
-	    if ((countries[n] & BAND15) != 0)
-		countryscore[BANDINDEX_15]++;
-	    if ((countries[n] & BAND10) != 0)
-		countryscore[BANDINDEX_10]++;
+	    count_contest_bands(countries[n], countryscore);
 	}
     }
 
     if (country_mult == 1 || pfxnummultinr > 0) {
 
 	for (int n = 1; n <= MAX_DATALINES - 1; n++) {
-
 	    // first, check pfxnummultinr array, the country 'n' exists
 	    int pfxnumcntnr = -1;
 	    // pfxnummultinr is length of pfxnummulti array
@@ -521,39 +475,12 @@ int readcalls(void) {
 		// each element represent a number of the country code
 		// eg: K0, K1, K2, ..., K9
 		for (pfxnum = 0; pfxnum < 10; pfxnum++) {
-		    if ((pfxnummulti[pfxnumcntnr].qsos[pfxnum] & BAND160) != 0) {
-			countryscore[BANDINDEX_160]++;
-		    }
-		    if ((pfxnummulti[pfxnumcntnr].qsos[pfxnum] & BAND80) != 0) {
-			countryscore[BANDINDEX_80]++;
-		    }
-		    if ((pfxnummulti[pfxnumcntnr].qsos[pfxnum] & BAND40) != 0) {
-			countryscore[BANDINDEX_40]++;
-		    }
-		    if ((pfxnummulti[pfxnumcntnr].qsos[pfxnum] & BAND20) != 0) {
-			countryscore[BANDINDEX_20]++;
-		    }
-		    if ((pfxnummulti[pfxnumcntnr].qsos[pfxnum] & BAND15) != 0) {
-			countryscore[BANDINDEX_15]++;
-		    }
-		    if ((pfxnummulti[pfxnumcntnr].qsos[pfxnum] & BAND10) != 0) {
-			countryscore[BANDINDEX_10]++;
-		    }
+		    count_contest_bands(pfxnummulti[pfxnumcntnr].qsos[pfxnum],
+			    countryscore);
 		}
 	    } else {
-		// simple 'country_mult', but it's works together with pfxnummultinr
-		if ((countries[n] & BAND160) != 0)
-		    countryscore[BANDINDEX_160]++;
-		if ((countries[n] & BAND80) != 0)
-		    countryscore[BANDINDEX_80]++;
-		if ((countries[n] & BAND40) != 0)
-		    countryscore[BANDINDEX_40]++;
-		if ((countries[n] & BAND20) != 0)
-		    countryscore[BANDINDEX_20]++;
-		if ((countries[n] & BAND15) != 0)
-		    countryscore[BANDINDEX_15]++;
-		if ((countries[n] & BAND10) != 0)
-		    countryscore[BANDINDEX_10]++;
+		// simple 'country_mult', but works together with pfxnummultinr
+		count_contest_bands(countries[n], countryscore);
 	    }
 	}
     }

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -117,40 +117,28 @@ void show_progress(int linenr) {
  * ATTENTION! return value needs to be freed
  */
 char *get_multi_from_line(char *logline) {
-    char *multbuffer = g_malloc(40);
-
-    multbuffer[0] = '\0';
+    char *multbuffer = g_malloc(20);
 
     if (arrlss == 1) {
 
 	if (logline[63] == ' ')
-	    strncpy(multbuffer, logline + 64, 3);
+	    g_strlcpy(multbuffer, logline + 64, 4);
 	else
-	    strncpy(multbuffer, logline + 63, 3);
-
-	multbuffer[3] = '\0';
+	    g_strlcpy(multbuffer, logline + 63, 4);
 
     } else if (serial_section_mult == 1) {
 
-	memset(multbuffer, 0, 39);
-
-	strncpy(multbuffer, logline + 68, 3);
+	g_strlcpy(multbuffer, logline + 68, 4);
 	g_strchomp(multbuffer);
 
     } else if (sectn_mult == 1) {
-	memset(multbuffer, 0, 39);
 
-	strncpy(multbuffer, logline + 68, 3);
+	g_strlcpy(multbuffer, logline + 68, 4);
 	g_strchomp(multbuffer);
 
     } else if (serial_grid4_mult == 1) {
 
-	memset(multbuffer, 0, 39);
-
-	for (int t = 0; t < 4; t++) {
-
-	    multbuffer[t] = logline[t + 59];
-	}
+	g_strlcpy(multbuffer, logline + 59, 5);
 
     } else if (unique_call_multi != 0) {
 
@@ -159,10 +147,7 @@ char *get_multi_from_line(char *logline) {
 
     } else {
 
-	strncpy(multbuffer, logline + 54, 10);	// normal case
-
-	multbuffer[10] = '\0';
-
+	g_strlcpy(multbuffer, logline + 54, 11);	// normal case
 	g_strchomp(multbuffer);
 
     }

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -111,6 +111,66 @@ void show_progress(int linenr) {
     }
 }
 
+
+/* pick up multi string from logline
+ *
+ * ATTENTION! return value needs to be freed
+ */
+char *get_multi_from_line(char *logline) {
+    char *multbuffer = g_malloc(40);
+
+    multbuffer[0] = '\0';
+
+    if (arrlss == 1) {
+
+	if (logline[63] == ' ')
+	    strncpy(multbuffer, logline + 64, 3);
+	else
+	    strncpy(multbuffer, logline + 63, 3);
+
+	multbuffer[3] = '\0';
+
+    } else if (serial_section_mult == 1) {
+
+	memset(multbuffer, 0, 39);
+
+	strncpy(multbuffer, logline + 68, 3);
+	g_strchomp(multbuffer);
+
+    } else if (sectn_mult == 1) {
+	memset(multbuffer, 0, 39);
+
+	strncpy(multbuffer, logline + 68, 3);
+	g_strchomp(multbuffer);
+
+    } else if (serial_grid4_mult == 1) {
+
+	memset(multbuffer, 0, 39);
+
+	for (int t = 0; t < 4; t++) {
+
+	    multbuffer[t] = logline[t + 59];
+	}
+
+    } else if (unique_call_multi != 0) {
+
+	g_strlcpy(multbuffer, logline + 68, 10);
+	g_strchomp(multbuffer);
+
+    } else {
+
+	strncpy(multbuffer, logline + 54, 10);	// normal case
+
+	multbuffer[10] = '\0';
+
+	g_strchomp(multbuffer);
+
+    }
+
+    return multbuffer;
+}
+
+
 int readcalls(void) {
 
     char inputbuffer[160];
@@ -118,7 +178,6 @@ int readcalls(void) {
     char checkcall[20];
     int z = 0;
     int add_ok;
-    char multbuffer[40];
     char presentcall[20];	// copy of call..
     char *tmpptr;
     int pfxnumcntidx;
@@ -207,65 +266,18 @@ int readcalls(void) {
 	    }
 
 	    if (wysiwyg_once == 1 ||
-		    wysiwyg_multi == 1 ||
-		    unique_call_multi != 0 ||
-		    arrlss == 1 ||
-		    serial_section_mult == 1 ||
-		    serial_grid4_mult == 1 ||
-		    sectn_mult == 1 ||
-		    ((dx_arrlsections == 1)
+		wysiwyg_multi == 1 ||
+		unique_call_multi != 0 ||
+		arrlss == 1 ||
+		serial_section_mult == 1 ||
+		serial_grid4_mult == 1 ||
+		sectn_mult == 1 ||
+		((dx_arrlsections == 1)
 		     && ((countrynr == w_cty) || (countrynr == ve_cty)))) {
-
-		multbuffer[0] = '\0';
-
-		if (arrlss == 1) {
-
-		    if (inputbuffer[63] == ' ')
-			strncpy(multbuffer, inputbuffer + 64, 3);
-		    else
-			strncpy(multbuffer, inputbuffer + 63, 3);
-
-		    multbuffer[3] = '\0';
-
-		} else if (serial_section_mult == 1) {
-
-		    memset(multbuffer, 0, 39);
-
-		    strncpy(multbuffer, inputbuffer + 68, 3);
-		    g_strchomp(multbuffer);
-
-		} else if (sectn_mult == 1) {
-		    memset(multbuffer, 0, 39);
-
-		    strncpy(multbuffer, inputbuffer + 68, 3);
-		    g_strchomp(multbuffer);
-
-		} else if (serial_grid4_mult == 1) {
-
-		    memset(multbuffer, 0, 39);
-
-		    for (int t = 0; t < 4; t++) {
-
-			multbuffer[t] = inputbuffer[t + 59];
-		    }
-
-		} else if (unique_call_multi != 0) {
-
-		    g_strlcpy(multbuffer, inputbuffer + 68, 10);
-		    g_strchomp(multbuffer);
-
-		} else {
-
-		    strncpy(multbuffer, inputbuffer + 54, 10);	// normal case
-
-		    multbuffer[10] = '\0';
-
-		    g_strchomp(multbuffer);
-
-		}
-
+		// get multi info
+		char *multbuffer = get_multi_from_line(inputbuffer);
 		remember_multi(multbuffer, bandindex, 0);
-
+		g_free(multbuffer);
 	    }
 	}
 

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -122,6 +122,26 @@ bool is_in_countrylist(int countrynr) {
     return false;
 }
 
+
+bool check_veto() {
+    bool excl_add_veto = false;
+
+    if (continentlist_only == 0 &&
+	    exclude_multilist_type == EXCLUDE_CONTINENT) {
+	if (continent_found()) {
+	    excl_add_veto = true;
+	}
+    }
+
+    if (exclude_multilist_type == EXCLUDE_COUNTRY) {
+	if (is_in_countrylist(countrynr)) {
+	    excl_add_veto = true;
+	}
+    }
+
+    return excl_add_veto;
+}
+
 /* pick up multi string from logline
  *
  * ATTENTION! return value needs to be freed
@@ -331,20 +351,7 @@ int readcalls(void) {
 	    add_ok = true;
 	}
 
-
-	excl_add_veto = false;
-
-	if (continentlist_only == 0 && exclude_multilist_type == 1) {
-	    if (continent_found()) {
-		excl_add_veto = true;
-	    }
-	}
-
-	if (exclude_multilist_type == 2) {
-	    if (is_in_countrylist(countrynr)) {
-		excl_add_veto = true;
-	    }
-	}
+	excl_add_veto = check_veto();
 
 	if (add_ok) {
 

--- a/src/readcalls.h
+++ b/src/readcalls.h
@@ -22,6 +22,7 @@
 #ifndef READCALLS_H
 #define READCALLS_H
 
+int lookup_country_in_pfxnummult_array(int n);
 int readcalls(void);
 int log_read_n_score();
 int synclog(char *synclogfile);

--- a/src/score.c
+++ b/src/score.c
@@ -173,9 +173,9 @@ int scoreByContinentOrCountry() {
     extern char hiscall[];
 
     extern int countrylist_points;
-    extern int countrylist_only;
+    extern bool countrylist_only;
 
-    extern int continentlist_only;
+    extern bool continentlist_only;
     extern int continentlist_points;
 
     extern int my_country_points;
@@ -191,7 +191,7 @@ int scoreByContinentOrCountry() {
     int inList = 0;
 
     inList = exist_in_country_list();
-    if (countrylist_only == 1) {
+    if (countrylist_only) {
 	if (inList == 1 && countrylist_points != -1)
 	    points = countrylist_points;
     } else {
@@ -222,7 +222,7 @@ int scoreByContinentOrCountry() {
     }
 
     /* HA2OS mods */
-    if (continentlist_only == 1) {
+    if (continentlist_only) {
 	// only continent list allowed
 	if (is_in_continentlist(continent)) {
 	    // are we are on DX continent or not

--- a/src/score.c
+++ b/src/score.c
@@ -37,12 +37,14 @@
 #include "tlf.h"
 
 extern char countrylist[][6];
+extern char continent_multiplier_list[7][3];
 
 int calc_continent(int zone);
 
 /* check if countrynr is in countrylist */
 bool is_in_countrylist(int countrynr) {
     int i = 0;
+
     while (strlen(countrylist[i]) != 0) {
 	if (getctynr(countrylist[i]) == countrynr) {
 	    return true;
@@ -111,20 +113,24 @@ int exist_in_country_list() {
 }
 
 
+bool is_in_continentlist(char *continent) {
+    int i = 0;
+
+    while (strlen(continent_multiplier_list[i]) != 0) {
+	if (strcmp(continent_multiplier_list[i], continent) == 0) {
+	    return true;
+	}
+	i++;
+    }
+    return false;
+}
+
+
 /* HA2OS - check if continent is in CONTINENT_LIST from logcfg.dat */
 int continent_found() {
     extern char continent[];
-    extern char continent_multiplier_list[7][3];
 
-    int mit_fg = 0;
-
-    while (strlen(continent_multiplier_list[mit_fg]) != 0) {
-	if (strcmp(continent_multiplier_list[mit_fg], continent) == 0) {
-	    return 1;
-	}
-	mit_fg++;
-    }
-    return 0;
+    return (is_in_continentlist(continent));
 }
 
 

--- a/src/score.c
+++ b/src/score.c
@@ -25,6 +25,7 @@
  *--------------------------------------------------------------*/
 
 
+#include <ctype.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -74,7 +75,7 @@ bool country_found(char prefix[]) {
     return is_in_countrylist(countrynr);
 }
 
-int exist_in_country_list() {
+bool exist_in_country_list() {
 
     extern char pxstr[];
     char prefix[10];
@@ -82,27 +83,24 @@ int exist_in_country_list() {
     strcpy(prefix, pxstr);
 
     if (country_found(prefix)) {
-	return 1;
-    } else {
-	if ((prefix[strlen(prefix) - 1] < 58)	/* last char '0'..'9' */
-		&& (prefix[strlen(prefix) - 1] > 47)) {
-	    prefix[strlen(prefix) - 1] = '\0';  /* strip number */
-	    if (country_found(prefix)) {
-		return 1;
-	    } else {
-		if ((prefix[strlen(prefix) - 1] < 58) /* see above */
-			&& (prefix[strlen(prefix) - 1] > 47)) {
-		    prefix[strlen(prefix) - 1] = '\0';
-		    if (country_found(prefix))
-			return 1;
-		    else
-			return 0;
-		} else
-		    return 0;
-	    }
-	} else
-	    return 0;
+	return true;
     }
+
+    if (!isdigit(prefix[strlen(prefix) - 1])) { /* last char '0'..'9' */
+	return false;
+    }
+
+    prefix[strlen(prefix) - 1] = '\0';  /* strip trailing digit */
+    if (country_found(prefix)) {	/* and try again */
+	return true;
+    }
+
+    if (!isdigit(prefix[strlen(prefix) - 1])) {
+	return false;
+    }
+
+    prefix[strlen(prefix) - 1] = '\0';	/* last try */
+    return country_found(prefix);
 }
 
 

--- a/src/score.c
+++ b/src/score.c
@@ -26,6 +26,7 @@
 
 
 #include <math.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -35,8 +36,22 @@
 #include "qrb.h"
 #include "tlf.h"
 
+extern char countrylist[][6];
 
 int calc_continent(int zone);
+
+/* check if countrynr is in countrylist */
+bool is_in_countrylist(int countrynr) {
+    int i = 0;
+    while (strlen(countrylist[i]) != 0) {
+	if (getctynr(countrylist[i]) == countrynr) {
+	    return true;
+	}
+	i++;
+    }
+    return false;
+}
+
 
 /* check if hiscall is in COUNTRY_LIST from logcfg.dat */
 int country_found(char prefix[]) {
@@ -44,7 +59,6 @@ int country_found(char prefix[]) {
     extern int countrynr;
     extern char hiscall[];
     extern char call[];
-    extern char countrylist[][6];
 
     char tmpcall[15];
     int counter = 0;

--- a/src/score.c
+++ b/src/score.c
@@ -56,14 +56,13 @@ bool is_in_countrylist(int countrynr) {
 
 
 /* check if hiscall is in COUNTRY_LIST from logcfg.dat */
-int country_found(char prefix[]) {
+bool country_found(char prefix[]) {
 
     extern int countrynr;
     extern char hiscall[];
     extern char call[];
 
     char tmpcall[15];
-    int counter = 0;
 
     if (strlen(hiscall) == 0) {
 	strcpy(tmpcall, call);
@@ -72,13 +71,7 @@ int country_found(char prefix[]) {
 
     countrynr = getctydata(tmpcall);
 
-    while (strlen(countrylist[counter]) != 0) {
-	if (getctydata(countrylist[counter]) == getctydata(tmpcall)) {
-	    return 1;
-	}
-	counter++;
-    }
-    return 0;
+    return is_in_countrylist(countrynr);
 }
 
 int exist_in_country_list() {
@@ -88,22 +81,22 @@ int exist_in_country_list() {
 
     strcpy(prefix, pxstr);
 
-    if (country_found(prefix) == 1) {
-	return (1);
+    if (country_found(prefix)) {
+	return 1;
     } else {
 	if ((prefix[strlen(prefix) - 1] < 58)	/* last char '0'..'9' */
 		&& (prefix[strlen(prefix) - 1] > 47)) {
 	    prefix[strlen(prefix) - 1] = '\0';  /* strip number */
-	    if (country_found(prefix) == 1) {
+	    if (country_found(prefix)) {
 		return 1;
 	    } else {
 		if ((prefix[strlen(prefix) - 1] < 58) /* see above */
 			&& (prefix[strlen(prefix) - 1] > 47)) {
 		    prefix[strlen(prefix) - 1] = '\0';
-		    if (country_found(prefix) == 1)
-			return (1);
+		    if (country_found(prefix))
+			return 1;
 		    else
-			return (0);
+			return 0;
 		} else
 		    return 0;
 	    }
@@ -490,6 +483,6 @@ int calc_continent(int zone) {
 	default:
 	    strncpy(continent, "??", 3);
     }
-    return (0);
+    return 0;
 }
 

--- a/src/score.c
+++ b/src/score.c
@@ -113,6 +113,7 @@ int exist_in_country_list() {
 }
 
 
+/* HA2OS - check if continent is in CONTINENT_LIST from logcfg.dat */
 bool is_in_continentlist(char *continent) {
     int i = 0;
 
@@ -123,14 +124,6 @@ bool is_in_continentlist(char *continent) {
 	i++;
     }
     return false;
-}
-
-
-/* HA2OS - check if continent is in CONTINENT_LIST from logcfg.dat */
-int continent_found() {
-    extern char continent[];
-
-    return (is_in_continentlist(continent));
 }
 
 
@@ -238,10 +231,10 @@ int scoreByContinentOrCountry() {
     }
 
     /* HA2OS mods */
-    // only continent list allowed
     if (continentlist_only == 1) {
-	if (continent_found() == 1) {
-	    // if we are on DX continent
+	// only continent list allowed
+	if (is_in_continentlist(continent)) {
+	    // are we are on DX continent or not
 	    if (strcmp(continent, mycontinent) == 0) {
 		points = my_cont_points;
 	    } else if (continentlist_points != -1) {

--- a/src/score.h
+++ b/src/score.h
@@ -25,7 +25,7 @@
 
 int score(void);
 int score2(char *line);
-int country_found(char prefix[]);
+bool country_found(char prefix[]);
 bool is_in_countrylist(int countrynr);
 bool is_in_continentlist(char *continent);
 

--- a/src/score.h
+++ b/src/score.h
@@ -27,6 +27,6 @@ int score(void);
 int score2(char *line);
 int country_found(char prefix[]);
 bool is_in_countrylist(int countrynr);
-int continent_found();
+bool is_in_continentlist(char *continent);
 
 #endif /* end of include guard: _SCORE_H */

--- a/src/score.h
+++ b/src/score.h
@@ -21,10 +21,12 @@
 
 #ifndef _SCORE_H
 #define _SCORE_H
+#include <stdbool.h>
 
 int score(void);
 int score2(char *line);
 int country_found(char prefix[]);
+bool is_in_countrylist(int countrynr);
 int continent_found();
 
 #endif /* end of include guard: _SCORE_H */

--- a/src/score.h
+++ b/src/score.h
@@ -25,5 +25,6 @@
 int score(void);
 int score2(char *line);
 int country_found(char prefix[]);
+int continent_found();
 
 #endif /* end of include guard: _SCORE_H */

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -47,7 +47,6 @@ void setcontest(void) {
     extern int pacc_pa_flg;
     extern int stewperry_flg;
     extern int universal;
-    extern int other_flg;
     extern int exchange_serial;
     extern int wysiwyg_multi;
     extern int w_cty;
@@ -156,7 +155,6 @@ void setcontest(void) {
     }
     if (strcmp(whichcontest, "arrl_ss") == 0) {
 	arrlss = 1;
-	other_flg = 1;
 	two_point = 1;
 	qso_once = 1;
 	exchange_serial = 1;
@@ -207,7 +205,6 @@ void setcontest(void) {
     }
 
     if (strcmp(whichcontest, "other") == 0) {
-	other_flg = 1;
 	one_point = 1;
 	recall_mult = 1;
 	wysiwyg_multi = 1;

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -27,6 +27,7 @@
 #include <math.h>
 
 #include "addpfx.h"
+#include "bands.h"
 #include "focm.h"
 #include "globalvars.h"		// Includes tlf.h
 #include "last10.h"
@@ -54,9 +55,6 @@ static int bi_warc[6] = {
     BANDINDEX_30,  BANDINDEX_17, BANDINDEX_12
 };
 
-/* bands as numbers */
-static int bandnr[NBANDS] =
-{ 160, 80, 40, 30, 20, 17, 15, 12, 10, 0 };
 
 void printfield(int y, int x, int number);
 void stewperry_show_summary(int points, float fixedmult);
@@ -103,7 +101,7 @@ void display_header(int *bi) {
 	if (bandinx == bi[i]) {		/* highlight active band */
 	    attrset(COLOR_PAIR(C_DUPE));
 	}
-	printw("%3d", bandnr[bi[i]]);
+	printw("%3d", bandindex2nr(bi[i]));
     }
 
     /* show number of QSO */

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -123,6 +123,10 @@ enum {
 #define UNIQUECALL_ALL      1
 #define UNIQUECALL_BAND     2
 
+#define EXCLUDE_NONE 0
+#define EXCLUDE_CONTINENT 1
+#define EXCLUDE_COUNTRY 2
+
 #define LOGLINELEN (88)		/* Length of logline in logfile
 				   (including linefeed) */
 #define MINITEST_DEFAULT_PERIOD 600

--- a/test/data.c
+++ b/test/data.c
@@ -83,7 +83,7 @@ int countrylist_points = -1;
 char continent_multiplier_list[7][3]; // SA, NA, EU, AF, AS and OC
 int continentlist_points = -1;
 int continentlist_only = 0;
-int exclude_multilist_type = 0;
+int exclude_multilist_type = EXCLUDE_NONE;
 int mult_side = 0;
 /* end LZ3NY mods */
 

--- a/test/data.c
+++ b/test/data.c
@@ -65,7 +65,6 @@ int pfxmult = 0;
 int pfxmultab = 0;
 int exc_cont = 0;
 int manise80;
-int other_flg;
 int one_point = 0;
 int two_point = 0;
 int three_point = 0;

--- a/test/data.c
+++ b/test/data.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include "../src/globalvars.h"
@@ -84,7 +85,7 @@ char continent_multiplier_list[7][3]; // SA, NA, EU, AF, AS and OC
 int continentlist_points = -1;
 int continentlist_only = 0;
 int exclude_multilist_type = EXCLUDE_NONE;
-int mult_side = 0;
+bool mult_side = false;
 /* end LZ3NY mods */
 
 int portable_x2 = 0;

--- a/test/data.c
+++ b/test/data.c
@@ -79,11 +79,11 @@ int my_country_points = -1;
 int my_cont_points = -1;
 int dx_cont_points = -1;
 char countrylist[255][6];
-int countrylist_only = 0;
+bool countrylist_only = false;
 int countrylist_points = -1;
 char continent_multiplier_list[7][3]; // SA, NA, EU, AF, AS and OC
 int continentlist_points = -1;
-int continentlist_only = 0;
+bool continentlist_only = false;
 int exclude_multilist_type = EXCLUDE_NONE;
 bool mult_side = false;
 /* end LZ3NY mods */

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -29,8 +29,8 @@ extern t_pfxnummulti pfxnummulti[MAXPFXNUMMULT];
 extern int pfxnummultinr;
 extern char continent_multiplier_list[7][3];
 extern char countrylist[][6];
-extern int continentlist_only;
-extern int countrylist_only;
+extern bool continentlist_only;
+extern bool countrylist_only;
 extern int exclude_multilist_type;
 
 int add_pfx(char *call) {
@@ -61,13 +61,13 @@ int setup_default(void **state) {
     strcpy(countrylist[1], "CE");
     strcpy(countrylist[2], "");
 
-    countrylist_only = 0;
+    countrylist_only = false;
 
     strcpy(continent_multiplier_list[0], "EU");
     strcpy(continent_multiplier_list[1], "NA");
     strcpy(continent_multiplier_list[2], "");
 
-    continentlist_only = 0;
+    continentlist_only = false;
 
     exclude_multilist_type = EXCLUDE_NONE;
 
@@ -130,7 +130,7 @@ void test_addcall_pfxnum_notinList(void **state) {
 }
 
 void test_addcall_continentlistonly(void **state) {
-    continentlist_only = 1;
+    continentlist_only = true;
     strcpy(hiscall, "LZ1AB");
     addcall();
     assert_int_equal(excl_add_veto, false);
@@ -429,7 +429,7 @@ void test_add2_warc(void **state) {
 
 
 void test_addcall2_continentlistonly(void **state) {
-    continentlist_only = 1;
+    continentlist_only = true;
     strcpy(lan_logline, logline_PY);
     addcall2();
     assert_int_equal(excl_add_veto, true);

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -8,11 +8,12 @@
 // OBJECT ../src/addcall.o
 // OBJECT ../src/addmult.o
 // OBJECT ../src/bands.o
-// OBJECT ../src/searchcallarray.o
+// OBJECT ../src/dxcc.o
 // OBJECT ../src/getctydata.o
 // OBJECT ../src/getpx.o
-// OBJECT ../src/dxcc.o
 // OBJECT ../src/get_time.o
+// OBJECT ../src/log_utils.o
+// OBJECT ../src/searchcallarray.o
 // OBJECT ../src/zone_nr.o
 
 

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -1,28 +1,37 @@
 #include "test.h"
 
 #include "../src/addcall.h"
-#include "../src/globalvars.h"
 #include "../src/dxcc.h"
 #include "../src/getctydata.h"
+#include "../src/globalvars.h"
+#include "../src/score.h"
 
 // OBJECT ../src/addcall.o
 // OBJECT ../src/addmult.o
 // OBJECT ../src/bands.o
 // OBJECT ../src/dxcc.o
+// OBJECT ../src/focm.o
 // OBJECT ../src/getctydata.o
 // OBJECT ../src/getpx.o
 // OBJECT ../src/get_time.o
+// OBJECT ../src/locator2longlat.o
 // OBJECT ../src/log_utils.o
+// OBJECT ../src/qrb.o
+// OBJECT ../src/score.o
 // OBJECT ../src/searchcallarray.o
 // OBJECT ../src/zone_nr.o
 
 
 /* these are missing from globalvars */
+extern int excl_add_veto;
 extern int dupe;
 extern t_pfxnummulti pfxnummulti[MAXPFXNUMMULT];
 extern int pfxnummultinr;
 extern char continent_multiplier_list[7][3];
 extern char countrylist[][6];
+extern int continentlist_only;
+extern int countrylist_only;
+extern int exclude_multilist_type;
 
 int add_pfx(char *call) {
     return 0;
@@ -33,7 +42,6 @@ int pacc_pa(void) {
 }
 
 long timecorr = 0;
-
 
 /* setups */
 int setup_default(void **state) {
@@ -49,9 +57,19 @@ int setup_default(void **state) {
     /* it may be a bug that addcall does not initialize addcallarea */
     addcallarea = 0;
 
-    strcpy(countrylist[0], "");
+    strcpy(countrylist[0], "DL");
+    strcpy(countrylist[1], "CE");
+    strcpy(countrylist[2], "");
 
-    strcpy(continent_multiplier_list[0], "");
+    countrylist_only = 0;
+
+    strcpy(continent_multiplier_list[0], "EU");
+    strcpy(continent_multiplier_list[1], "NA");
+    strcpy(continent_multiplier_list[2], "");
+
+    continentlist_only = 0;
+
+    exclude_multilist_type = EXCLUDE_NONE;
 
     pfxnummultinr = 0;
     memset(pfxnummulti, 0, sizeof(pfxnummulti));
@@ -65,6 +83,7 @@ int setup_default(void **state) {
     strcpy(filename, TOP_SRCDIR);
     strcat(filename, "/share/cty.dat");
     assert_int_equal(load_ctydata(filename), 0);
+
 
     return 0;
 }
@@ -110,11 +129,49 @@ void test_addcall_pfxnum_notinList(void **state) {
     assert_int_equal(addcallarea, 0);
 }
 
+void test_addcall_continentlistonly(void **state) {
+    continentlist_only = 1;
+    strcpy(hiscall, "LZ1AB");
+    addcall();
+    assert_int_equal(excl_add_veto, false);
+    strcpy(hiscall, "PY2BBB");
+    addcall();
+    assert_int_equal(excl_add_veto, true);
+}
+
+void test_addcall_exclude_continent(void **state) {
+    exclude_multilist_type = EXCLUDE_CONTINENT;
+    strcpy(hiscall, "LZ1AB");
+    addcall();
+    assert_int_equal(excl_add_veto, true);
+    strcpy(hiscall, "PY2BBB");
+    addcall();
+    assert_int_equal(excl_add_veto, false);
+}
+
+void test_addcall_exclude_country (void **state) {
+    exclude_multilist_type = EXCLUDE_COUNTRY;
+    strcpy(hiscall, "LZ1AB");
+    addcall();
+    assert_int_equal(excl_add_veto, false);
+    strcpy(hiscall, "DL1AAA");
+    addcall();
+    assert_int_equal(excl_add_veto, true);
+}
+
+
+/* addcall2 */
 char logline[] =
     "160CW  08-Feb-11 17:06 0025  LZ1AB          599  599  20            LZ  20   1  ";
 
-char logline_2[] =
+char logline_HA[] =
     "160CW  08-Feb-11 17:06 0025  HA1AB          599  599  19            LZ  20   1  ";
+
+char logline_PY[] =
+    "160CW  08-Feb-11 17:06 0025  PY1AB          599  599  19            PY  20   1  ";
+
+char logline_DL[] =
+    "160CW  08-Feb-11 17:06 0025  DL1AB          599  599  19            PY  20   1  ";
 
 void test_addcall2_nopfxnum(void **state) {
     strcpy(lan_logline, logline);
@@ -143,7 +200,7 @@ void test_addcall2_pfxnum_inList(void **state) {
 }
 
 void test_addcall2_pfxnum_notinList(void **state) {
-    strcpy(lan_logline, logline_2);
+    strcpy(lan_logline, logline_HA);
     addcall2();
     assert_int_equal(addcallarea, 0);
 }
@@ -295,7 +352,7 @@ void test_add2_country_2_stations(void **state) {
 void test_add2_2_countries(void **state) {
     strcpy(lan_logline, logline);
     addcall2();
-    strcpy(lan_logline, logline_2);
+    strcpy(lan_logline, logline_HA);
     addcall2();
     assert_int_equal(countryscore[BANDINDEX_160], 2);
     assert_int_equal(countries[getctynr("LZ0AA")], BAND160);
@@ -343,7 +400,7 @@ void test_add2_zone_2_stations(void **state) {
 void test_add2_2_zones(void **state) {
     strcpy(lan_logline, logline);
     addcall2();
-    strcpy(lan_logline, logline_2);
+    strcpy(lan_logline, logline_HA);
     addcall2();
     assert_int_equal(zonescore[BANDINDEX_160], 2);
     assert_int_equal(zones[19], BAND160);
@@ -368,5 +425,36 @@ void test_add2_warc(void **state) {
     addcall2();
     assert_int_equal(countries[getctynr("LZ0AA")], BAND30);
     assert_int_equal(zones[20], BAND30);
+}
+
+
+void test_addcall2_continentlistonly(void **state) {
+    continentlist_only = 1;
+    strcpy(lan_logline, logline_PY);
+    addcall2();
+    assert_int_equal(excl_add_veto, true);
+    strcpy(lan_logline, logline);
+    addcall2();
+    assert_int_equal(excl_add_veto, false);
+}
+
+void test_addcall2_exclude_continent(void **state) {
+    exclude_multilist_type = EXCLUDE_CONTINENT;
+    strcpy(lan_logline, logline);
+    addcall2();
+    assert_int_equal(excl_add_veto, true);
+    strcpy(lan_logline, logline_PY);
+    addcall2();
+    assert_int_equal(excl_add_veto, false);
+}
+
+void test_addcall2_exclude_country (void **state) {
+    exclude_multilist_type = EXCLUDE_COUNTRY;
+    strcpy(lan_logline, logline);
+    addcall2();
+    assert_int_equal(excl_add_veto, false);
+    strcpy(lan_logline, logline_DL);
+    addcall2();
+    assert_int_equal(excl_add_veto, true);
 }
 

--- a/test/test_bands.c
+++ b/test/test_bands.c
@@ -32,6 +32,36 @@ void test_IsWarcIndex(void **state) {
     assert_int_equal(IsWarcIndex(BANDINDEX_10), 0);
 }
 
+/* test conversion from bandnumber to bandindex */
+void test_bandnr2index(void **state) {
+    assert_int_equal(bandnr2index(160), BANDINDEX_160);
+    assert_int_equal(bandnr2index(80), BANDINDEX_80);
+    assert_int_equal(bandnr2index(40), BANDINDEX_40);
+    assert_int_equal(bandnr2index(30), BANDINDEX_30);
+    assert_int_equal(bandnr2index(20), BANDINDEX_20);
+    assert_int_equal(bandnr2index(17), BANDINDEX_17);
+    assert_int_equal(bandnr2index(15), BANDINDEX_15);
+    assert_int_equal(bandnr2index(12), BANDINDEX_12);
+    assert_int_equal(bandnr2index(10), BANDINDEX_10);
+    assert_int_equal(bandnr2index(99), BANDINDEX_OOB);
+    assert_int_equal(bandnr2index(0), BANDINDEX_OOB);
+}
+
+/* test conversion from bandindex to bandnumber */
+void test_bandindex2nr(void **state) {
+    assert_int_equal(bandindex2nr(BANDINDEX_160), 160);
+    assert_int_equal(bandindex2nr(BANDINDEX_80), 80);
+    assert_int_equal(bandindex2nr(BANDINDEX_40), 40);
+    assert_int_equal(bandindex2nr(BANDINDEX_30), 30);
+    assert_int_equal(bandindex2nr(BANDINDEX_20), 20);
+    assert_int_equal(bandindex2nr(BANDINDEX_17), 17);
+    assert_int_equal(bandindex2nr(BANDINDEX_15), 15);
+    assert_int_equal(bandindex2nr(BANDINDEX_12), 12);
+    assert_int_equal(bandindex2nr(BANDINDEX_10), 10);
+    assert_int_equal(bandindex2nr(BANDINDEX_OOB), 0);
+}
+
+
 /* test switch to next band UP or DOWN */
 void test_nextBandUp(void **state) {
     bandinx = BANDINDEX_12;

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -15,7 +15,7 @@
 int location_unknown(char *call);
 int getpfxindex(char *checkcallptr, char **normalized_call);
 
-char countrylist[255][6];
+extern char countrylist[255][6];
 
 
 int setup_default(void **state) {

--- a/test/test_logutils.c
+++ b/test/test_logutils.c
@@ -1,0 +1,56 @@
+#include "test.h"
+
+#include "../src/log_utils.h"
+#include "../src/globalvars.h"
+
+// OBJECT ../src/log_utils.o
+// OBJECT ../src/bands.o
+
+
+#define QSO1 " 40SSB 12-Jan-18 16:34 0006  SP9ABC         599  599  15                    10         "
+#define QSO_BAD1 " 60SSB 12-Jan-18 16:34 0006  SP9ABC         599  599  15                     1         "
+
+
+/* check test for commented logline */
+void test_iscomment(void **state) {
+    assert_int_equal(log_is_comment(";Hi"), 1);
+}
+
+void test_isnocomment(void **state) {
+    assert_int_equal(log_is_comment("Hi"), 0);
+}
+
+
+/* test reading used band index */
+void test_getband_ok(void **state) {
+    assert_int_equal(log_get_band(QSO1), BANDINDEX_40);
+}
+
+void test_getband_wrongband(void **state) {
+    assert_int_equal(log_get_band(QSO_BAD1), BANDINDEX_OOB);
+}
+
+/* test reading mode */
+void test_getmode_ok (void **state) {
+    assert_int_equal(log_get_mode(QSO1), SSBMODE);
+}
+
+void test_getmode_ignores_case (void **state) {
+    char *tmp = g_strdup(QSO1);
+    memcpy(tmp + 3, "ssb", 3);
+    assert_int_equal(log_get_mode(tmp), SSBMODE);
+    g_free(tmp);
+}
+
+void test_getmode_error (void **state) {
+    char *tmp = g_strdup(QSO1);
+    memcpy(tmp + 3, "x y", 3);
+    assert_int_equal(log_get_mode(tmp), -1);
+    g_free(tmp);
+}
+
+
+/* test reading points */
+void test_getpoints (void **state) {
+    assert_int_equal(log_get_points(QSO1), 10);
+}

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -23,6 +23,8 @@
 // OBJECT ../src/zone_nr.o
 
 /* missing from globalvar.h */
+extern t_pfxnummulti pfxnummulti[MAXPFXNUMMULT];
+extern int pfxnummultinr;
 extern char continent_multiplier_list[7][3];
 extern char countrylist[][6];
 
@@ -58,8 +60,15 @@ int setup_default (void **state) {
     strcpy(countrylist[0], "DL");
     strcpy(countrylist[1], "CE");
     strcpy(countrylist[2], "");
+
+    memset(pfxnummulti, 0, sizeof(pfxnummulti));
+    pfxnummulti[0].countrynr = 12;
+    pfxnummulti[1].countrynr = 42;
+    pfxnummultinr = 2;
+
     return 0;
 }
+
 
 /* test is_in_countrylist() */
 void test_in_countrylist(void **state) {
@@ -75,4 +84,15 @@ void test_in_countrylist_keeps_countrynr(void **state) {
     assert_int_equal(is_in_countrylist(getctynr("DL")), true);
     assert_int_equal(is_in_countrylist(getctynr("OE")), false);
     assert_int_equal(countrynr, 42);
+}
+
+
+/* test lookup country in pfxnummult */
+void test_lookup_not_in_pfxnummult(void **state) {
+    assert_int_equal(lookup_country_in_pfxnummult_array(1), -1);
+}
+
+
+void test_lookup_in_pfxnummult(void **state) {
+    assert_int_equal(lookup_country_in_pfxnummult_array(42), 1);
 }

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -27,6 +27,8 @@ extern t_pfxnummulti pfxnummulti[MAXPFXNUMMULT];
 extern int pfxnummultinr;
 extern char continent_multiplier_list[7][3];
 extern char countrylist[][6];
+extern int exclude_multilist_type;
+extern int continentlist_only;
 
 // dummy functions
 void get_time(void) {}
@@ -47,7 +49,7 @@ int pacc_pa(void) {
 }
 
 /* private prototypes */
-bool is_in_countrylist(int x);
+bool check_veto();
 
 
 int setup_default (void **state) {
@@ -60,6 +62,13 @@ int setup_default (void **state) {
     strcpy(countrylist[0], "DL");
     strcpy(countrylist[1], "CE");
     strcpy(countrylist[2], "");
+
+    strcpy(continent_multiplier_list[0], "EU");
+    strcpy(continent_multiplier_list[1], "NA");
+    strcpy(continent_multiplier_list[2], "");
+
+    exclude_multilist_type = EXCLUDE_NONE;
+    continentlist_only = 0;
 
     memset(pfxnummulti, 0, sizeof(pfxnummulti));
     pfxnummulti[0].countrynr = 12;
@@ -78,4 +87,35 @@ void test_lookup_not_in_pfxnummult(void **state) {
 
 void test_lookup_in_pfxnummult(void **state) {
     assert_int_equal(lookup_country_in_pfxnummult_array(42), 1);
+}
+
+
+/* test check_veto() */
+void test_veto_eclude_none (void **state) {
+    assert_int_equal(check_veto(), false);
+}
+
+void test_veto_exclude_country (void **state) {
+    exclude_multilist_type = EXCLUDE_COUNTRY;
+    countrynr = getctynr("HB9ABC");
+    assert_int_equal(check_veto(), false);
+    countrynr = getctynr("DL1AAA");
+    assert_int_equal(check_veto(), true);
+}
+
+void test_veto_exclude_continent_contlist_only (void **state) {
+    continentlist_only = 1;
+    exclude_multilist_type = EXCLUDE_CONTINENT;
+    strcpy(continent, "EU");
+    assert_int_equal(check_veto(), false);
+    strcpy(continent, "AF");
+    assert_int_equal(check_veto(), false);
+}
+
+void test_veto_exclude_continent (void **state) {
+    exclude_multilist_type = EXCLUDE_CONTINENT;
+    strcpy(continent, "EU");
+    assert_int_equal(check_veto(), true);
+    strcpy(continent, "AF");
+    assert_int_equal(check_veto(), false);
 }

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -70,23 +70,6 @@ int setup_default (void **state) {
 }
 
 
-/* test is_in_countrylist() */
-void test_in_countrylist(void **state) {
-    assert_int_equal(is_in_countrylist(getctynr("DL")), true);
-}
-
-void test_not_in_countrylist(void **state) {
-    assert_int_equal(is_in_countrylist(getctynr("OE")), false);
-}
-
-void test_in_countrylist_keeps_countrynr(void **state) {
-    countrynr = 42;
-    assert_int_equal(is_in_countrylist(getctynr("DL")), true);
-    assert_int_equal(is_in_countrylist(getctynr("OE")), false);
-    assert_int_equal(countrynr, 42);
-}
-
-
 /* test lookup country in pfxnummult */
 void test_lookup_not_in_pfxnummult(void **state) {
     assert_int_equal(lookup_country_in_pfxnummult_array(1), -1);

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -28,7 +28,7 @@ extern int pfxnummultinr;
 extern char continent_multiplier_list[7][3];
 extern char countrylist[][6];
 extern int exclude_multilist_type;
-extern int continentlist_only;
+extern bool continentlist_only;
 
 // dummy functions
 void get_time(void) {}
@@ -68,7 +68,7 @@ int setup_default (void **state) {
     strcpy(continent_multiplier_list[2], "");
 
     exclude_multilist_type = EXCLUDE_NONE;
-    continentlist_only = 0;
+    continentlist_only = false;
 
     memset(pfxnummulti, 0, sizeof(pfxnummulti));
     pfxnummulti[0].countrynr = 12;
@@ -104,7 +104,7 @@ void test_veto_exclude_country (void **state) {
 }
 
 void test_veto_exclude_continent_contlist_only (void **state) {
-    continentlist_only = 1;
+    continentlist_only = true;
     exclude_multilist_type = EXCLUDE_CONTINENT;
     strcpy(continent, "EU");
     assert_int_equal(check_veto(), false);

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -1,0 +1,78 @@
+#include "test.h"
+
+#include <stdbool.h>
+
+#include "../src/tlf.h"
+#include "../src/dxcc.h"
+#include "../src/readctydata.h"
+#include "../src/globalvars.h"
+#include "../src/getctydata.h"
+#include "../src/readcalls.h"
+
+// OBJECT ../src/log_utils.o
+// OBJECT ../src/addmult.o
+// OBJECT ../src/addpfx.o
+// OBJECT ../src/bands.o
+// OBJECT ../src/dxcc.o
+// OBJECT ../src/getctydata.o
+// OBJECT ../src/getpx.o
+// OBJECT ../src/locator2longlat.o
+// OBJECT ../src/readcalls.o
+// OBJECT ../src/searchcallarray.o
+// OBJECT ../src/score.o
+// OBJECT ../src/zone_nr.o
+
+/* missing from globalvar.h */
+extern char continent_multiplier_list[7][3];
+extern char countrylist[][6];
+
+// dummy functions
+void get_time(void) {}
+void readqtccalls() {}
+void shownr(char *msg, int x) {}
+void spaces(int n) {} /* needs more care */
+
+int qrb(double a, double b, double c, double d) {
+    return 1;
+}
+
+int foc_score(char *a) {
+    return 1;
+}
+
+int pacc_pa(void) {
+    return 0;
+}
+
+/* private prototypes */
+bool is_in_countrylist(int x);
+
+
+int setup_default (void **state) {
+    char filename[100];
+
+    strcpy(filename, TOP_SRCDIR);
+    strcat(filename, "/share/cty.dat");
+    assert_int_equal(load_ctydata(filename), 0);
+
+    strcpy(countrylist[0], "DL");
+    strcpy(countrylist[1], "CE");
+    strcpy(countrylist[2], "");
+    return 0;
+}
+
+/* test is_in_countrylist() */
+void test_in_countrylist(void **state) {
+    assert_int_equal(is_in_countrylist(getctynr("DL")), true);
+}
+
+void test_not_in_countrylist(void **state) {
+    assert_int_equal(is_in_countrylist(getctynr("OE")), false);
+}
+
+void test_in_countrylist_keeps_countrynr(void **state) {
+    countrynr = 42;
+    assert_int_equal(is_in_countrylist(getctynr("DL")), true);
+    assert_int_equal(is_in_countrylist(getctynr("OE")), false);
+    assert_int_equal(countrynr, 42);
+}

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -1,8 +1,9 @@
 #include "test.h"
 
+#include "../src/dxcc.h"
+#include "../src/getctydata.h"
 #include "../src/score.h"
 #include "../src/tlf.h"
-#include "../src/dxcc.h"
 
 #include "../src/globalvars.h"
 
@@ -12,9 +13,9 @@
 // OBJECT ../src/dxcc.o
 // OBJECT ../src/focm.o
 // OBJECT ../src/getctydata.o
-// OBJECT ../src/qrb.o
-// OBJECT ../src/locator2longlat.o
 // OBJECT ../src/getpx.o
+// OBJECT ../src/locator2longlat.o
+// OBJECT ../src/qrb.o
 
 // ===========
 // these are missing from globalvars
@@ -253,6 +254,27 @@ static void init_countrylist() {
     strcpy(countrylist[3], "");
 }
 
+
+/* test is_in_countrylist() */
+void test_in_countrylist(void **state) {
+    init_countrylist();
+    assert_int_equal(is_in_countrylist(getctynr("DL")), true);
+}
+
+void test_not_in_countrylist(void **state) {
+    init_countrylist();
+    assert_int_equal(is_in_countrylist(getctynr("CE")), false);
+}
+
+void test_in_countrylist_keeps_countrynr(void **state) {
+    init_countrylist();
+    countrynr = 42;
+    assert_int_equal(is_in_countrylist(getctynr("DL")), true);
+    assert_int_equal(is_in_countrylist(getctynr("CE")), false);
+    assert_int_equal(countrynr, 42);
+}
+
+
 void test_country_found(void **state) {
     /* nothing to find in empty list */
     strcpy(hiscall, "LZ1AB");
@@ -268,6 +290,8 @@ void test_country_found(void **state) {
     strcpy(hiscall, "K3LA");
     assert_int_equal(country_found(""), 1);
 }
+
+
 
 void test_scoreByCorC_listOnly(void **state) {
     countrylist_only = 1;

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -293,7 +293,7 @@ void test_country_found(void **state) {
 
 
 static void init_continentlist() {
-    strcpy(continent_multiplier_list[0], "AS");
+    strcpy(continent_multiplier_list[0], "EU");
     strcpy(continent_multiplier_list[1], "NA");
     strcpy(continent_multiplier_list[2], "");
 }
@@ -314,20 +314,7 @@ void test_in_continentlist(void **state) {
 }
 
 
-int continent_found();
-void test_continent_found(void **state) {
-    init_continentlist();
-    strcpy(continent, "NA");
-    assert_int_equal(continent_found(), true);
-}
-
-void test_continent_not_found(void **state) {
-    init_continentlist();
-    strcpy(continent, "EU");
-    assert_int_equal(continent_found(), false);
-}
-
-void test_scoreByCorC_listOnly(void **state) {
+void test_scoreByCorC_countrylistOnly(void **state) {
     countrylist_only = 1;
     check_call_points("LZ1AB", 0);
     check_call_points("DL3XYZ", 0);
@@ -339,6 +326,17 @@ void test_scoreByCorC_listOnly(void **state) {
     countrylist_points = 4;
     check_call_points("LZ1AB", 0);
     check_call_points("DL3XYZ", 4);
+}
+
+void test_scoreByCorC_continentlistOnly(void **state) {
+    continentlist_only = 1;
+    check_call_points("LZ1AB", 0);
+
+    init_continentlist();
+    my_cont_points = 1;
+    check_call_points("LZ1AB", 1);
+    continentlist_points = 2;
+    check_call_points("XE2AAA", 2);
 }
 
 void test_scoreByCorC_notInList(void **state) {

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -292,6 +292,40 @@ void test_country_found(void **state) {
 }
 
 
+static void init_continentlist() {
+    strcpy(continent_multiplier_list[0], "AS");
+    strcpy(continent_multiplier_list[1], "NA");
+    strcpy(continent_multiplier_list[2], "");
+}
+
+void test_empty_continentlist(void **state) {
+    assert_int_equal(is_in_continentlist(""), false);
+    assert_int_equal(is_in_continentlist("SA"), false);
+}
+
+void test_not_in_continnetlist(void ** state) {
+    init_continentlist();
+    assert_int_equal(is_in_continentlist("SA"), false);
+}
+
+void test_in_continentlist(void **state) {
+    init_continentlist();
+    assert_int_equal(is_in_continentlist("NA"), true);
+}
+
+
+int continent_found();
+void test_continent_found(void **state) {
+    init_continentlist();
+    strcpy(continent, "NA");
+    assert_int_equal(continent_found(), true);
+}
+
+void test_continent_not_found(void **state) {
+    init_continentlist();
+    strcpy(continent, "EU");
+    assert_int_equal(continent_found(), false);
+}
 
 void test_scoreByCorC_listOnly(void **state) {
     countrylist_only = 1;

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -26,10 +26,10 @@ extern int mycountrynr;
 extern int my_country_points;
 extern int my_cont_points;
 extern int dx_cont_points;
-extern int countrylist_only;
+extern bool countrylist_only;
 extern int countrylist_points;
 extern char countrylist[][6];
-extern int continentlist_only;
+extern bool continentlist_only;
 extern int continentlist_points;
 extern char mycontinent[];
 extern char continent_multiplier_list[7][3];
@@ -84,11 +84,11 @@ int setup_default(void **state) {
     my_cont_points = -1;
     dx_cont_points = -1;
 
-    countrylist_only = 0;
+    countrylist_only = false;
     countrylist_points = -1;
     strcpy(countrylist[0], "");
 
-    continentlist_only = 0;
+    continentlist_only = false;
     continentlist_points = -1;
     strcpy(continent_multiplier_list[0], "");
 
@@ -315,7 +315,7 @@ void test_in_continentlist(void **state) {
 
 
 void test_scoreByCorC_countrylistOnly(void **state) {
-    countrylist_only = 1;
+    countrylist_only = true;
     check_call_points("LZ1AB", 0);
     check_call_points("DL3XYZ", 0);
 
@@ -329,7 +329,7 @@ void test_scoreByCorC_countrylistOnly(void **state) {
 }
 
 void test_scoreByCorC_continentlistOnly(void **state) {
-    continentlist_only = 1;
+    continentlist_only = true;
     check_call_points("LZ1AB", 0);
 
     init_continentlist();


### PR DESCRIPTION
Main goal of the proposed change is a serious refactoring of the readcall() function.
As new features got added in last years it also grows to a tangled net which was nearly unmaintainable.

The patch contains mostly the following parts
- factor out initialization 
- factor out reading and decoding values from recorded log lines and handling of multis
- drop redundant local variables and use existing ones if they exist (e.g. nr_worked)
- switch to g_strlcpy where appropriate
- simplify the code by dropping redundant tests
- factor out lookup if station is in country  or continent list and use that functions throughout TLF
- factor out scoring logic which counts worked countries and zones 

There were some other changes made:
- drop 'other_flag' variable which was superseded by wysiwyg_multiband
- use test for country and continent list in score.c
- move some variables and prototypes to bool type
- add some tests for factored out functions

As there were nearly no tests in place the patch was made as a series of small steps to enable to follow the made transformations.
The code got some moderate testing in comparing results for known contests before and after modification but could use a second look from outside.

So it would be good if some people could have a look at it and come back with comments, suggestions and/or error reports.