### PR TITLE
Giving the initial serial value

### DIFF
--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -172,6 +172,17 @@ int getidxbybandstr(char *confband) {
     return -1;
 }
 
+void setnext_qsonumber(char * field) {
+    if (field != NULL) {
+	if (atoi(field) > 0) {
+	    highqsonr = atoi(field);
+	}
+	else {
+	    showmsg("WARNING: serial could be a positive integer...\n");
+	    exit(1);
+	}
+    }
+}
 
 static int confirmation_needed;
 
@@ -928,6 +939,7 @@ int parse_logcfg(char *inputbuffer) {
 	    break;
 	}
 	case 52: {
+	    setnext_qsonumber(fields[1]);
 	    exchange_serial = 1;
 	    break;
 	}
@@ -1104,6 +1116,7 @@ int parse_logcfg(char *inputbuffer) {
 	    break;
 	}
 	case 88: {
+	    setnext_qsonumber(fields[1]);
 	    serial_section_mult = 1;
 	    break;
 	}
@@ -1418,6 +1431,7 @@ int parse_logcfg(char *inputbuffer) {
 	    break;
 	}
 	case 147: {
+	    setnext_qsonumber(fields[1]);
 	    serial_grid4_mult = 1;
 	    break;
 	}
@@ -1489,6 +1503,7 @@ int parse_logcfg(char *inputbuffer) {
 	    break;
 	}
 	case 161: {
+	    setnext_qsonumber(fields[1]);
 	    serial_or_section = 1;
 	    break;
 	}

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -91,6 +91,10 @@ void get_next_serial(void) {
     else
 	qsonum = mm + 1;
 
+    // modify last qso if it set in logcfg.dat (SERIAL_EXCHANGE=NN)
+    if (highqsonr > qsonum) {
+	qsonum = highqsonr;
+    }
     qsonr_to_str();
 }
 

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1780,6 +1780,11 @@ Multiplier is section from multipliers file.
 .B SERIAL+SECTION
 Exchange is serial number and section, multiplier is section from multiplier
 file.  Mults count per band.
+.UE .
+
+In some cases, you need to set up the first QSO number with a simple assignment,
+(eg. more periods with continuous serial):
+\fBSERIAL+SECTION\fR=\fI42\fR
 .
 .TP
 .B SERIAL_OR_SECTION
@@ -1787,11 +1792,22 @@ Exchange is serial number or section.  This option is similar to
 SERIAL+SECTION, except the exchange could be a serial OR the section.  The
 options was introduced for HA-DX, where HA stations give the shortest form of
 their county, other stations give serial.
+.UE .
+
+In some cases, you need to set up the first QSO number with a simple assignment,
+(eg. more periods with continuous serial):
+\fBSERIAL_OR_SECTION\fR=\fI42\fR
 .
 .TP
 .B SERIAL+GRID4
 Exchange is serial number and grid (e.g. JO21QI), multipler is 4-character
 grid (JO21).  Mults count per band.
+.UE .
+
+In some cases, you need to set up the first QSO number with a simple assignment,
+(eg. more periods with continuous serial):
+\fBSERIAL+GRID4\fR=\fI42\fR
+.
 .
 .TP
 .B DX_&_SECTIONS
@@ -1831,6 +1847,11 @@ Exchange is continent (NA, SA, EU, AS, AF, OC).
 .TP
 .B SERIAL_EXCHANGE
 Exchange is serial number (formats exchange field).
+.UE .
+
+In some cases, you need to set up the first QSO number with a simple assignment,
+(eg. more periods with continuous serial):
+\fBSERIAL_EXCHANGE\fR=\fI42\fR
 .
 .TP
 .B MIXED


### PR DESCRIPTION
In some cases, we need to start the serial number other than 0001 - eg. a contest with more periods with continuous serial (like SCWC - sorry, didn't find any online documentation). This patch can helps to split the periods.