### PR TITLE
Check minitest setting for dupe evaluation on bandmap

### DIFF
--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -71,20 +71,6 @@ void bm_add(char *s);
 
 void bm_menu();
 
-/** check if call is new multi
- *
- * \return true if new multi
- */
-int bm_ismulti(char *call, spot *data, int band);
-
-
-/** check if call is a dupe
- *
- * \return true if is dupe
- */
-int bm_isdupe(char *call, int band);
-
-
 /** add a new spot to bandmap data
  * \param call  	the call to add
  * \param freq	 	on which frequency heard

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -115,6 +115,7 @@ extern int dxped;
 extern int addzone;
 extern int do_cabrillo;
 extern rmode_t digi_mode;
+extern int minitest;    // minitest period length in seconds, 0 if not used
 
 extern char message[][80];
 extern char *digi_message[];

--- a/src/searchlog.h
+++ b/src/searchlog.h
@@ -21,6 +21,7 @@
 #ifndef SEARCHLOG_H
 #define SEARCHLOG_H
 
+#include <stdbool.h>
 #include <glib.h>
 
 #define CALLMASTER_SIZE 16000
@@ -35,6 +36,8 @@ int load_callmaster(void);
 
 /* search 'hiscall' in the log */
 void searchlog(void);
+
+bool worked_in_current_minitest_period(int found);
 
 void InitSearchPanel(void);
 void ShowSearchPanel(void);


### PR DESCRIPTION
In a minitest stations can be worked again once the current period is over. This was correctly handled by the dupe checking in `searchlog`.  The same check was added to `bandmap` so that stations show up again when using dupe filtering mode.

Boolified and made private `bm_ismulti` and `bm_isdupe`.

Formatting changes are due to `astyle`.