### PR TITLE
Updated man page + help.txt

### DIFF
--- a/share/help.txt
+++ b/share/help.txt
@@ -1,93 +1,94 @@
 Keys (shortcuts) to be used in TLF
 
-If you want to see some of the start up parameters try: 'tlf -h'.
+To see the start up parameters try: 'tlf -?'.
 
 <ALT+?>
-Alt-a     Cluster info                  Alt-b   Band up
-Alt-t     Tune                          Alt-n   Note in log
-Alt-v     Band down (CW Speed?)         Alt-p   turn PTT on/off
-Alt-h     show help.txt                 Alt-w   CW Weight
-Alt-i     See talk messages             Alt-j   See QRG's
-Alt-k     CW from Keyboard              Alt-x   exit program (Alt-q)
-Alt-m     Multi display (Alt-c)         Alt-s   Score window (Alt-r)
-Alt-,     show Bandmap                  Alt-j   show frequency
-Alt-z     show worked zones             Alt-g   grab Call (min. 2 letters from bandmap)
+Alt-A     Cluster info                  Alt-B   Band up
+Alt-T     Tune                          Alt-N   Note in log
+Alt-V     Band down (CW Speed?)         Alt-P   Turn PTT on/off
+Alt-H     Show help.txt                 Alt-W   CW Weight
+Alt-I     See talk messages             Alt-J   See QRG's
+Alt-K     CW from Keyboard              Alt-X   Exit program (Alt-q)
+Alt-M     Multi display (Alt-c)         Alt-S   Score window (Alt-r)
+Alt-,     Show bandmap                  Alt-J   Show frequency
+Alt-Z     Show worked zones             Alt-G   Grab call (min. 2 letters from bandmap)
 
 <CTRL+?>
-Ctrl-a         add a spot to list
-Ctrl-c         Quit tlf                 Ctrl-b    Cluster send
-Ctrl-g         Grab a bandmap spot      Ctrl-p    MUF display
-Ctrl-page-up   Auto CQ delay +          Ctrl-page-down Auto CQ delay -
-Ctrl-k         CW from keyboard         Ctrl-f    frequency control window 
-Ctrl-t         Send message             Ctrl-r    LPT0 pin 14 on/off (SSB mic)
+Ctrl-A      Add a spot to list
+Ctrl-C      Quit Tlf                    Ctrl-B    Cluster send
+Ctrl-G      Grab a bandmap spot         Ctrl-P    MUF display
+Ctrl-PgUp   Auto CQ delay +             Ctrl-PgDn Auto CQ delay -
+Ctrl-K      CW from keyboard            Ctrl-F    Frequency control window
+Ctrl-T      Send message                Ctrl-R    LPT0 pin 14 on/off (SSB mic)
 
 
-<direct Keyboard commands>
-'+'       Switch RUN/S&P (default, TR Log mode)
-'+'       Send exchange (CT log mode)
-'Insert'  Log QSO (CT log mode)
-PG-UP     CW + 2wpm
-PG-DWN    CW - 2wpm
-','       CW from Keyboard
-'.'       filter bandmap content
-';'       Note in log              
-F1 - F12  Send F1 - F12 msg          
-TAB       Switch fields            
-ENTER     Log qso, call cq         
-SPACE     Switch from call input to exchange field
-'\'       Log qso w/o CW           
-Up-arrow  Edit prev qso            
-'-'       Delete last qso          
-'_'       confirm last serial nr   
-'='       confirm last call        
-L-arrow   Edit call                
-L/R Arrow Band change              
-ESCAPE    stop TX            
-'"'       Talk message             
-'#'       save/go to a MEM Frequency
-!         New shell                
+<direct keyboard commands>
++         Switch RUN/S&P (default, TR Log mode)
++         Send exchange (CT log mode)
+Insert    Log QSO (CT log mode)
+PgUp      CW + 2wpm
+PgDown    CW - 2wpm
+,         CW from Keyboard
+.         Filter bandmap content
+;         Note in log
+F1 - F12  Send F1 - F12 msg
+Shift-F1  Restore CQ frequency from MEM and call CQ
+Tab       Switch fields
+Enter     Log QSO, call CQ
+Space     Switch from call input to exchange field
+\         Log QSO w/o CW
+Up-arrow  Edit prev QSO
+-         Delete last QSO
+_         Confirm last serial nr
+=         Confirm last call
+L-arrow   Edit call
+L/R arrow Band change
+Escape    Stop TX
+"         Talk message
+#         Save/go to a MEM frequency
+$         Switch to MEM and clear it (pop)
+%         Swap TRX and MEM
+!         New shell
 
 <commands from "Call" field>
-:ssb      Switch to ssb                 
-:cwm      Switch to cw                  
-:dig      Switch to rtty                
-:hel      Help                          
-:mes      Set cw messages              
-:set      Edit config file              
-:cfg      Edit config file              
-:sim      CW CQWW Simulator             
-:ZONes    show list of zones to be worked
-:cty      list of coutries to be worked
-:cqd      CW delay
-:rit      reset RIT after QSO is logged
-:VIEw     show complete log
-:EDIt     edit the log
-:LISt     list CW messages
-:MESsage  change CW messages
-:CHEck    open Check window
-:NOCheck  close Check window
-:pac      open Terminal
-:CLUster  open Terminal
-:SPOts    only DX spots sorted by time
-:FILter   filter DX Cluster content
-:map      filter band map content
-:SYNc     synchronize log in network
-:EXIt     exit program
-:MULt     toggle remaing multi display
-:CONtest  toggle contest mode on/off
-:SCOre    toggle score window on/off
-:FREq     show frequency
+:SSB      Switch to SSB
+:CWm      Switch to CW
+:DIG      Switch to digital mode
+:HELp     Help
+:MESsages Set CW messages
+:SET      Edit config file
+:CFG      Edit config file
+:SIMulate CW CQWW Simulator
+:ZONes    Show list of zones to be worked
+:CTY      List of coutries to be worked
+:CQDelay  CW delay
+:RIT      Reset RIT after QSO is logged
+:VIEw     Show complete log
+:EDIt     Edit the log
+:LISt     List CW messages
+:MESsage  Change CW messages
+:CHEck    Open Check window
+:NOCheck  Close Check window
+:         Telnet window, use : to get back to Tlf
+:PACket   Open Terminal
+:CLUster  Open Terminal
+:SPOts    Only DX spots sorted by time
+:FILter   Filter DX Cluster content
+:MAP      Filter band map content
+:SYNc     Synchronize log in network
+:EXIt     Exit program
+:MULt     Toggle remaining multi display
+:CONtest  Toggle contest mode on/off
+:SCOre    Toggle score window on/off
+:REScore  Rescore
+:FREq     Show frequency
 :CLOff    Cluster off
-:INFo     network status
-:TRXcont  toggle TRX control on/off
+:INFo     Network status
+:TRXcont  Toggle TRX control on/off
 :CHAR     Autosend: number of chars before starting to send
-:DEBug_tty test rig link
-:SOUnd    record sound files
-:wri      Write cabrillo
-:adi      Write Adif
-:exi      Exit tlf
-:inf      Network info
-:         Telnet window
-:ton      Set sidetone (0 = off)
-:res      Rescore
-:sou      Sound utility
+:DEBug_tty Test rig link
+:SOUnd    Record sound files
+:WRIte    Write cabrillo
+:ADIf     Write Adif
+:EXIt     Exit tlf
+:TONe     Set sidetone (0 = off)

--- a/src/netkeyer.c
+++ b/src/netkeyer.c
@@ -169,7 +169,7 @@ int netkeyer(int cw_op, char *cwmessage) {
 	g_strlcat(buf, cwmessage, BUFSIZE);
     }
 
-    sendto_rc = sendto(socket_descriptor, buf, strlen(buf) + 1,
+    sendto_rc = sendto(socket_descriptor, buf, strlen(buf),
 		       0, (struct sockaddr *) &address,
 		       sizeof(address));
     if (sendto_rc == -1) {

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -77,7 +77,7 @@ data, frequency data, local talk, serial numbers, time sync etc.
 .SH OPTIONS
 Options given to @PACKAGE_NAME@ on the command line.
 .TP
-.B \-h
+.B \-?
 Show summary of options and exit.
 .TP
 .BI \-f\  config_file
@@ -240,7 +240,7 @@ Turn the dupe check window On|Off.
 .
 .TP
 .BR :CQD elay
-Change Auto_CQ delay (in 1/2 seconds, with Up/Down arrow keys).
+Change Auto_CQ delay (in 1/2 seconds, with PageUp/PageDown keys).
 .
 .TP
 .BR :CLO ff
@@ -639,6 +639,10 @@ In CQ mode, send message F1 (CQ).
 In S&P mode send message F6 (MY).
 .
 .TP
+.B Shift-F1
+Restore previous CQ frequency from MEM and send message F1 (CQ).
+.
+.TP
 .B F2-F11
 Send CW, RTTY or VOICE messages 2 through 11.
 .
@@ -752,7 +756,15 @@ In RTTY (DIGIMODE), keyboard mode switch controller to command mode
 .
 .TP
 .BR #\  (Hash)
-Transceiver VFO frequency \(-> mem, mem \(-> transceiver VFO frequency.
+Transceiver VFO frequency \(-> MEM, MEM \(-> transceiver VFO frequency.
+.
+.TP
+.BR $\  (Dollar)
+Pop MEM frequency: MEM \(-> transceiver VFO frequency and clear MEM.
+.
+.TP
+.BR %\  (Percent)
+Swap transceiver VFO frequency and MEM.
 .
 .TP
 .BR !\  (Exclamation)


### PR DESCRIPTION
Described the recently added MEM operations (`$` , `%`, `Shift-F1`).
Somewhat normalised the key naming and capitalisation.
Fixed CQD keys and the command line help option.

The second commit is not related to the docs, just didn't want to make a separate branch for it. It fixes sending the unnecessary trailing `NUL` char to the keyer. Cwdaemon 0.10.2 works OK without it (and also any other well-behaved keyer should).
 