### PR TITLE
Fix frequency selection when working with Fldigi

### DIFF
--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -115,11 +115,10 @@ void gettxinfo(void) {
     pbwidth_t bwidth;
     int retval;
     int retvalmode;
-    static double last_freq_time = 0.0;
+    int fldigi_shift_freq;
 
+    static double last_freq_time = 0.0;
     static int oldbandinx;
-    static int fldigi_carrier;
-    static int fldigi_shift_freq;
 
     if (!trx_control)
 	return;
@@ -175,8 +174,7 @@ void gettxinfo(void) {
 	}
 
 	if (trxmode == DIGIMODE && (digikeyer == GMFSK || digikeyer == FLDIGI)) {
-	    fldigi_carrier = fldigi_get_carrier();
-	    rigfreq += (freq_t)fldigi_carrier;
+	    rigfreq += (freq_t)fldigi_get_carrier();
 	    if (rigmode == RIG_MODE_RTTY || rigmode == RIG_MODE_RTTYR) {
 		fldigi_shift_freq = fldigi_get_shift_freq();
 		if (fldigi_shift_freq != 0) {
@@ -245,7 +243,8 @@ void gettxinfo(void) {
 	}
 
     } else {
-	// set rig frequency to `reqf'
+	// set rig frequency (or carrier) to `reqf'
+	reqf -= fldigi_get_carrier();
 	retval = rig_set_freq(my_rig, RIG_VFO_CURR, (freq_t) reqf);
 
 	if (retval != RIG_OK) {

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -93,7 +93,7 @@ static freq_t execute_grab(spot *data) {
     extern char hiscall[];
     extern cqmode_t cqmode;
 
-    freq_t f = data->freq - fldigi_get_carrier();
+    freq_t f = data->freq;
     set_outfreq(f);
     send_bandswitch(f);
 


### PR DESCRIPTION
When using Fldigi the operating frequency is corrected by the pitch of audio frequency used as carrier. The value shown by Tlf is thus the actual carrier frequency.
This was not done in the reverse direction: rig's VFO was set directly, resulting in an offset. The only place considering the carrier offset was in `grabspot`.
For RTTY Tlf even corrects the frequency by half of FSK shift (85 Hz) to show the mark frequency. This causes issues when Fldigi is not in RTTY but say PSK. It took me some time to figure out why the freqs displayed by the two programs plus the rig do not match...

The main change is moving `fldigi_get_carrier` correction from `grabspot` to the central place in `gettxinfo`. This way the freq value handled by Tlf is always the carrier frequency.

`fldigi_xmlrpc_get_carrier()` now checks Fldigi modem type and applies further correction only it's RTTY.

Minor changes:
* flattened somewhat `fldigi_xmlrpc_get_carrier()` by taking early exit
* changed conditional to `#ifdef HAVE_LIBXMLRPC` as in other functions
* application name is taken from `PACKAGE_NAME` defined in `config.h`
* `int fldigi_shift_freq` doesn't have to be static in `gettxinfo()`

(next PR will be a bigger one: rework of time handling. I also have config file parsing improvement in the queue.)
