### PR TITLE
Fix manual keying using Fldigi

### DIFF
--- a/src/fldigixmlrpc.h
+++ b/src/fldigixmlrpc.h
@@ -22,8 +22,7 @@
 #ifndef FLDIGIXMLRPC_H
 #define FLDIGIXMLRPC_H
 
-#define FLDIGI_TX   1
-#define FLDIGI_RX   2
+#include <stdbool.h>
 
 extern int fldigi_set_callfield;
 
@@ -40,7 +39,7 @@ void xmlrpc_showinfo();
 int fldigi_get_log_call();
 int fldigi_get_log_serial_number();
 void fldigi_clear_connerr();
-int fldigi_toggle(void);
-int fldigi_isenabled(void);
+bool fldigi_toggle(void);
+bool fldigi_isenabled(void);
 
 #endif /* end of include guard: FLDIGIXMLRPC_H */

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -92,6 +92,7 @@ extern int exchange_serial;
 extern int highqsonr;
 
 
+extern cqmode_t cqmode;
 extern int trxmode;
 extern rmode_t rigmode;
 extern freq_t freq;


### PR DESCRIPTION
This fix addresses the issue described in #102. Currently keying sends Fldigi messages (both Fn keys and individual keystrokes) using this logic:
 * abort running TX if any
 * append message + "^r" to TX widget
 * start TX

This is fine for Fn messages but unusable for interactive keying (Ctrl-K).

This PR doesn't solve all the problems related to digi keying but at least makes interactive keying usable by supporting manual TX/RX control.
There are two main areas of change:
*  `keyer.c` handles `{` and `}` as _start-tx_ and _switch-to-rx_ also for Fldigi keying. There were already provisions for this for MFJ1278.	Similarly `|` key inserts a line break.
* `fldigi_send_text()` in `fldigixmlrpc.c` checks if interactive mode is used and in that case it doesn't abort TX and makes TX/RX handling based in user input.
	TX/RX control is done using Ctrl-T and Ctrl-R characters as for MFJ1278.
	
The keyer window got also some minor changes:
* now Ctrl-K or Alt-K closes keying mode gracefully, without aborting a running TX.
	This allows switching back to the main screen for call editing, entering serial etc. while TX is still active.
	Currently user has to wait until end of TX before closing keyer. Escape still exits with stopping TX.
 * backspace char is sent even when keyer input field is empty.

The latter is due to the issue that Tlf keyer input and the actual Fldigi TX widget content can get out of sync if `}`/`|` and backspace is used as the former two characters are not represented on the keyer input line.
A use case: one prepares a text for transmission by typing `ABCX}`. Before starting TX with `{` user want correct `X` to `D`.
Keyer input shows `ABCX` so pressing backspace removes `X`, but on Fldigi side it removes the final `r`.
To fix typing user still has to type backspace-backspace-D-}. This makes keyer input field quite mangled, but at least Fldigi shows the correct text.

Now, if in a new keying session one wants to change `E}` into `R}` then it wouldn't be possible without allowing backspacing past the beginning of the input field.
Another option would be to actually insert ^r and | into the input line. 
However this requires a bit more changes in keyer.c and since Fldigi UI is anyway visible the user can use it to check the typing.

There is also an issue with Fldigi itself: it doesn't handle backspacing correctly while transmitting. Fldigi stucks in TX mode and although this works from Fldigi UI, it doesn't via XML RPC. Will file a bug report once I figure out how...

There are multiple ways to use interactive digi keying, but given the quirks above the recommended procedure is
* type the text, correct it if needed
* press `{` and `}`, they're normally located on adjecent keys, a quick tap is enough and order is irrelevant
* exit keyer mode with Ctrl-K

Boolified flags in `fldigixmlrpc` and flattened a bit `fldigi_xmlrpc_query()`.

Notes:
* even though comment in `fldigi_xmlrpc_query()` says that Tlf reconnects to Fldigi automatically, this is not the case.
* Fn messages contain leading (or trailing?) new lines although not specified explicitly in config file. This is partly useful, partly not, depending on the use case. I'll check this later.
 