### PR TITLE
Change rst

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ tlf_SOURCES = \
 	addarea.c addcall.c addmult.c addpfx.c addspot.c audio.c autocq.c \
 	background_process.c bandmap.c bands.c \
 	cabrillo_utils.c calledit.c callinput.c changefreq.c changepars.c \
-	checklogfile.c checkqtclogfile.c \
+	change_rst.c checklogfile.c checkqtclogfile.c \
 	checkparameters.c cleanup.c clear_display.c clusterinfo.c cw_utils.c \
 	dxcc.c \
 	deleteqso.c displayit.c \
@@ -43,7 +43,7 @@ noinst_HEADERS = \
 	addarea.h addcall.h addmult.h addpfx.h addspot.h audio.h autocq.h \
 	background_process.h bandmap.h bands.h \
 	cabrillo_utils.h calledit.h callinput.h changefreq.h changepars.h \
-	checklogfile.h checkqtclogfile.h \
+	change_rst.h checklogfile.h checkqtclogfile.h \
 	checkparameters.h cleanup.h clear_display.h clusterinfo.h \
 	cw_utils.h \
 	dxcc.h \

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -37,6 +37,7 @@
 #include "bandmap.h"
 #include "calledit.h"
 #include "callinput.h"
+#include "change_rst.h"
 #include "changefreq.h"
 #include "changepars.h"
 #include "clear_display.h"
@@ -454,14 +455,11 @@ int callinput(void) {
 	    case KEY_PPAGE: {
 		if ((change_rst == 1) && (strlen(hiscall) != 0)) {	// change RST
 
-		    if (his_rst[1] <= 56) {
+		    rst_s_up();
 
-			his_rst[1]++;
-
-			if (!no_rst)
-			    mvprintw(12, 44, his_rst);
-			mvprintw(12, 29, hiscall);
-		    }
+		    if (!no_rst)
+			mvprintw(12, 44, his_rst);
+		    mvprintw(12, 29, hiscall);
 
 		} else {	// change cw speed
 		    speedup();
@@ -478,13 +476,11 @@ int callinput(void) {
 	    case KEY_NPAGE: {
 		if ((change_rst == 1) && (strlen(hiscall) != 0)) {
 
-		    if (his_rst[1] > 49) {
-			his_rst[1]--;
+		    rst_s_down();
 
-			if (!no_rst)
-			    mvprintw(12, 44, his_rst);
-			mvprintw(12, 29, hiscall);
-		    }
+		    if (!no_rst)
+			mvprintw(12, 44, his_rst);
+		    mvprintw(12, 29, hiscall);
 
 		} else {
 

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -132,7 +132,6 @@ int callinput(void) {
     extern char ituzone[];
     extern int ctcomp;
     extern int nob4;
-    extern int change_rst;
     extern int weight;
     extern int k_pin14;
     extern int k_ptt;
@@ -453,9 +452,9 @@ int callinput(void) {
 
 	    // <Page-Up>, change RST if call field not empty, else increase CW speed.
 	    case KEY_PPAGE: {
-		if ((change_rst == 1) && (strlen(hiscall) != 0)) {	// change RST
+		if (change_rst && (strlen(hiscall) != 0)) {	// change RST
 
-		    rst_s_up();
+		    rst_sent_up();
 
 		    if (!no_rst)
 			mvprintw(12, 44, his_rst);
@@ -474,9 +473,9 @@ int callinput(void) {
 
 	    // <Page-Down>, change RST if call field not empty, else decrease CW speed.
 	    case KEY_NPAGE: {
-		if ((change_rst == 1) && (strlen(hiscall) != 0)) {
+		if (change_rst && (strlen(hiscall) != 0)) {
 
-		    rst_s_down();
+		    rst_sent_down();
 
 		    if (!no_rst)
 			mvprintw(12, 44, his_rst);

--- a/src/change_rst.c
+++ b/src/change_rst.c
@@ -20,8 +20,11 @@
 
 #include <glib.h>
 #include <string.h>
+#include <stdbool.h>
 #include "change_rst.h"
 #include "globalvars.h"
+
+bool change_rst = false;
 
 GPtrArray *rst_sent = NULL;
 GPtrArray *rst_recv = NULL;
@@ -80,28 +83,28 @@ void rst_reset(void) {
     memcpy(my_rst, g_ptr_array_index(rst_recv, recv_index), 2);
 }
 
-void rst_r_up() {
+void rst_recv_up() {
     if (recv_index < rst_recv->len - 1) {
 	recv_index++;
 	memcpy(my_rst, g_ptr_array_index(rst_recv, recv_index), 2);
     }
 }
 
-void rst_r_down() {
+void rst_recv_down() {
     if (recv_index > 0) {
 	recv_index--;
 	memcpy(my_rst, g_ptr_array_index(rst_recv, recv_index), 2);
     }
 }
 
-void rst_s_up() {
+void rst_sent_up() {
     if (sent_index < rst_sent->len - 1) {
 	sent_index++;
 	memcpy(his_rst, g_ptr_array_index(rst_sent, sent_index), 2);
     }
 }
 
-void rst_s_down() {
+void rst_sent_down() {
     if (sent_index > 0) {
 	sent_index--;
 	memcpy(his_rst, g_ptr_array_index(rst_sent, sent_index), 2);

--- a/src/change_rst.c
+++ b/src/change_rst.c
@@ -1,0 +1,108 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2020 Thomas Beierlein <dl1jbe@darc.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+
+#include <glib.h>
+#include "change_rst.h"
+#include "globalvars.h"
+
+GPtrArray *rst_sent = NULL;
+GPtrArray *rst_recv = NULL;
+int sent_index, recv_index;
+
+static int cmp_rst (char **a, char **b) {
+    return g_ascii_strcasecmp(*a, *b);
+}
+
+void rst_init(char *init) {
+
+    char *default_rst = "33, 34, 35, 36, 37, 38, 39, \
+		      43, 44, 45, 46, 47, 48, 49, \
+		      53, 54, 55, 56, 57, 58, 59";
+
+    gchar **list;
+
+    if (rst_sent != NULL)
+	g_ptr_array_free(rst_sent, TRUE);
+    if (rst_recv != NULL)
+	g_ptr_array_free(rst_recv,TRUE);
+
+    rst_sent = g_ptr_array_new_full(25, g_free);
+    rst_recv = g_ptr_array_new_full(25, g_free);
+
+    list = g_strsplit(default_rst, ",", 0);
+    for (int i = 0; list[i] != NULL; i++) {
+	char *tmp = g_strdup(list[i]);
+	g_ptr_array_add(rst_recv, g_strdup(g_strstrip(tmp)));
+	g_free(tmp);
+    }
+    g_strfreev(list);
+    g_ptr_array_sort(rst_recv, (GCompareFunc)cmp_rst);
+
+    if (init != NULL) {
+	list = g_strsplit(init, ",", 0);
+    } else {
+	list = g_strsplit(default_rst, ",", 0);
+    }
+    for (int i = 0; list[i] != NULL; i++) {
+	char *tmp = g_strdup(list[i]);
+	g_ptr_array_add(rst_sent, g_strdup(g_strstrip(tmp)));
+	g_free(tmp);
+    }
+    g_strfreev(list);
+    g_ptr_array_sort(rst_sent, (GCompareFunc)cmp_rst);
+
+    rst_reset();
+}
+
+void rst_reset(void) {
+    sent_index = rst_sent->len - 1;
+    memcpy(his_rst, g_ptr_array_index(rst_sent, sent_index), 2);
+
+    recv_index = rst_recv->len - 1;
+    memcpy(my_rst, g_ptr_array_index(rst_recv, recv_index), 2);
+}
+
+void rst_r_up() {
+    if (recv_index < rst_recv->len - 1) {
+	recv_index++;
+	memcpy(my_rst, g_ptr_array_index(rst_recv, recv_index), 2);
+    }
+}
+
+void rst_r_down() {
+    if (recv_index > 0) {
+	recv_index--;
+	memcpy(my_rst, g_ptr_array_index(rst_recv, recv_index), 2);
+    }
+}
+
+void rst_s_up() {
+    if (sent_index < rst_sent->len - 1) {
+	sent_index++;
+	memcpy(his_rst, g_ptr_array_index(rst_sent, sent_index), 2);
+    }
+}
+
+void rst_s_down() {
+    if (sent_index > 0) {
+	sent_index--;
+	memcpy(his_rst, g_ptr_array_index(rst_sent, sent_index), 2);
+    }
+}

--- a/src/change_rst.c
+++ b/src/change_rst.c
@@ -19,6 +19,7 @@
 
 
 #include <glib.h>
+#include <string.h>
 #include "change_rst.h"
 #include "globalvars.h"
 

--- a/src/change_rst.h
+++ b/src/change_rst.h
@@ -24,8 +24,9 @@
 
 extern bool change_rst;
 
-void rst_init(char *init) ;
+void rst_init(char *init_string) ;
 void rst_reset(void);
+void rst_set_strings();
 void rst_recv_up();
 void rst_recv_down();
 void rst_sent_up();

--- a/src/change_rst.h
+++ b/src/change_rst.h
@@ -1,0 +1,30 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2020 Thomas Beierlein <dl1jbe@darc.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef CHANGE_RST_H
+#define CHANGE_RST_H
+
+void rst_init(char *init) ;
+void rst_reset(void);
+void rst_r_up();
+void rst_r_down();
+void rst_s_up();
+void rst_s_down();
+
+#endif

--- a/src/change_rst.h
+++ b/src/change_rst.h
@@ -20,11 +20,15 @@
 #ifndef CHANGE_RST_H
 #define CHANGE_RST_H
 
+#include <stdbool.h>
+
+extern bool change_rst;
+
 void rst_init(char *init) ;
 void rst_reset(void);
-void rst_r_up();
-void rst_r_down();
-void rst_s_up();
-void rst_s_down();
+void rst_recv_up();
+void rst_recv_down();
+void rst_sent_up();
+void rst_sent_down();
 
 #endif

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -24,6 +24,7 @@
 
 
 #include "globalvars.h"
+#include "change_rst.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
 #include "write_keyer.h"
@@ -31,8 +32,7 @@
 void cleanup_qso(void) {
     hiscall[0] = '\0';	    /* reset hiscall and comment */
     comment[0] = '\0';
-    his_rst[1] = '9';	    /* reset to 599 */
-    my_rst[1] = '9';
+    rst_reset();;	    /* reset to 599 */
     countrynr = 0;
 }
 

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include "cw_utils.h"
+#include "change_rst.h"
 #include "get_time.h"
 #include "getwwv.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
@@ -137,18 +138,11 @@ void clear_display(void) {
     qsonr_to_str();
     mvaddstr(12, 23, qsonrstr);
 
-    if (trxmode != SSBMODE) {
-	my_rst[2] = '9';
-	his_rst[2] = '9';
-    } else {
-	my_rst[2] = ' ';
-	his_rst[2] = ' ';
-    }
-
     if (no_rst) {
 	mvaddstr(12, 44, "   ");
 	mvaddstr(12, 49, "   ");
     } else {
+	rst_set_strings();
 	mvaddstr(12, 44, his_rst);
 	mvaddstr(12, 49, my_rst);
     }

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -69,7 +69,6 @@ int getexchange(void) {
     extern char cqzone[];
     extern char ituzone[];
     extern char my_rst[];
-    extern int change_rst;
     extern char ph_message[14][80];
     extern char hiscall[];
     extern char qsonrstr[];
@@ -299,8 +298,8 @@ int getexchange(void) {
 	    }
 
 	    case KEY_PPAGE: {	/* Page-Up--change MY RST */
-		if (change_rst == 1) {
-		    rst_r_up();
+		if (change_rst) {
+		    rst_recv_up();
 
 		    if (!no_rst)
 			mvprintw(12, 49, my_rst);
@@ -315,9 +314,9 @@ int getexchange(void) {
 
 	    }
 	    case KEY_NPAGE: {	/* Page-Down--change MY RST */
-		if (change_rst == 1) {
+		if (change_rst) {
 
-		    rst_r_down();
+		    rst_recv_down();
 
 		    if (!no_rst)
 			mvprintw(12, 49, my_rst);

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -31,6 +31,7 @@
 
 #include "addspot.h"
 #include "cw_utils.h"
+#include "change_rst.h"
 #include "keyer.h"
 #include "keystroke_names.h"
 #include "lancode.h"
@@ -299,12 +300,11 @@ int getexchange(void) {
 
 	    case KEY_PPAGE: {	/* Page-Up--change MY RST */
 		if (change_rst == 1) {
-		    if (my_rst[1] <= 56) {
-			my_rst[1]++;
+		    rst_r_up();
 
-			if (!no_rst)
-			    mvprintw(12, 49, my_rst);
-		    }
+		    if (!no_rst)
+			mvprintw(12, 49, my_rst);
+
 		} else {	/* speed up */
 		    speedup();
 
@@ -317,12 +317,11 @@ int getexchange(void) {
 	    case KEY_NPAGE: {	/* Page-Down--change MY RST */
 		if (change_rst == 1) {
 
-		    if (my_rst[1] > 49) {
-			my_rst[1]--;
+		    rst_r_down();
 
-			if (!no_rst)
-			    mvprintw(12, 49, my_rst);
-		    }
+		    if (!no_rst)
+			mvprintw(12, 49, my_rst);
+
 		} else {	/* speed down */
 		    speeddown();
 

--- a/src/main.c
+++ b/src/main.c
@@ -202,7 +202,6 @@ int demode = 0;			/* 1 =  send DE  before s&p call  */
 int contest = 0;		/* 0 =  General,  1  = contest */
 int announcefilter = FILTER_ANN; /*  filter cluster  announcements */
 int showscore_flag = 0;		/* show  score window */
-int change_rst = 0;
 char exchange[40];
 char whichcontest[40] = "qso";
 int defer_store = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,7 @@
 #include "addmult.h"
 #include "background_process.h"
 #include "bandmap.h"
+#include "change_rst.h"
 #include "checkparameters.h"
 #include "clear_display.h"
 #include "checklogfile.h"
@@ -902,6 +903,7 @@ int main(int argc, char *argv[]) {
 
     ui_init();
 
+    rst_init(NULL);
 
     strcat(logline0, backgrnd_str);
     strcat(logline1, backgrnd_str);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1425,7 +1425,15 @@ int parse_logcfg(char *inputbuffer) {
 	case 148: {
 	    change_rst = 1;
 	    if (g_strv_length(fields) == 2) {
-		/* TODO: check fields[1] for only RST values */
+		/* comma separated list of RS(T) vaules 33..39, 43..39, 53..59
+		 * allowed.
+		 */
+		if (!g_regex_match_simple(
+			"^([3-5][3-9]\\d?\\s*,\\s*)*[3-5][3-9]\\d?$",
+		        g_strstrip(fields[1]), G_REGEX_CASELESS,
+			(GRegexMatchFlags)0)) {
+		    WrongFormat(teststring);
+		}
 		rst_init(fields[1]);
 	    } else {
 		rst_init(NULL);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1,7 +1,7 @@
 /*
 * Tlf - contest logging program for amateur radio operators
 * Copyright (C) 2001-2002-2003-2004 Rein Couperus <pa0rct@amsat.org>
-* 		2011-2019           Thomas Beierlein <tb@forth-ev.de>
+* 		2011-2020           Thomas Beierlein <tb@forth-ev.de>
 * 		2013 		    Fred DH5FS
 *               2013-2016           Ervin Hegedus - HA2OS <airween@gmail.com>
 *
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include "bandmap.h"
+#include "change_rst.h"
 #include "cw_utils.h"
 #include "fldigixmlrpc.h"
 #include "getctydata.h"
@@ -1423,6 +1424,12 @@ int parse_logcfg(char *inputbuffer) {
 	}
 	case 148: {
 	    change_rst = 1;
+	    if (g_strv_length(fields) == 2) {
+		/* TODO: check fields[1] for only RST values */
+		rst_init(fields[1]);
+	    } else {
+		rst_init(NULL);
+	    }
 	    break;
 	}
 	case 149: {

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -298,7 +298,6 @@ int parse_logcfg(char *inputbuffer) {
     extern char controllerport[80];	// port for multi-mode controller
     extern char clusterlogin[];
     extern int cw_bandwidth;
-    extern int change_rst;
     extern char rttyoutput[];
     extern int logfrequency;
     extern int ignoredupe;
@@ -1423,9 +1422,9 @@ int parse_logcfg(char *inputbuffer) {
 	    break;
 	}
 	case 148: {
-	    change_rst = 1;
+	    change_rst = true;
 	    if (g_strv_length(fields) == 2) {
-		/* comma separated list of RS(T) vaules 33..39, 43..39, 53..59
+		/* comma separated list of RS(T) values 33..39, 43..39, 53..59
 		 * allowed.
 		 */
 		if (!g_regex_match_simple(

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -663,20 +663,20 @@ Toggle between the CQ and S&P modes.
 Increase CW (Morse Code) speed (from call and exchange fields).
 .IP
 If the cursor is in the call input field and it is not empty and CHANGE_RST is
-set: increase his S value (the leftmost of the RST pair).
+set: increase his RST.
 .IP
 If the cursor is in the exchange field and it is not empty and CHANGE_RST is
-set: increase my S value (the rightmost of the RST pair).
+set: increase my RST.
 .
 .TP
 .B PgDown
 Decrease CW (Morse Code) speed (from call input and exchange fields).
 .IP
 If the cursor is in the call input field and it is not empty and CHANGE_RST is
-set: decrease his S value (the leftmost of the RST pair).
+set: decrease his RST.
 .IP
 If the cursor is in the exchange field and it is not empty and CHANGE_RST is
-set: decrease my S value (the rightmost of the RST pair).
+set: decrease my RST.
 .
 .TP
 .B Ctrl-PgUp
@@ -1445,10 +1445,18 @@ updated by WWV or WCY messages.
 .
 .TP
 .B CHANGE_RST
-If set in logcfg.dat, PgUp and PgDown will change RST instead of CW speed if
-field is not empty.
+If set in logcfg.dat, PgUp and PgDown will change his/my RST instead of 
+CW speed if you are in call/exchange field and call field is not empty.
 .br
 Default is Off.
+.
+.TP
+\fBCHANGE_RST\fR=\fI33, 43, 47, 499, ...\fR
+Provide a comma separated list of RS(T) values which are used for his RST. Own
+RST will always be 33..39,43..49,53..59. 
+.br
+Providing a value for T is optional but will be ignored. 
+In CW and digi mode T will always be 9.
 .
 .TP
 .B NOB4

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -663,20 +663,20 @@ Toggle between the CQ and S&P modes.
 Increase CW (Morse Code) speed (from call and exchange fields).
 .IP
 If the cursor is in the call input field and it is not empty and CHANGE_RST is
-set: increase his RST.
+set: increase sent RST.
 .IP
 If the cursor is in the exchange field and it is not empty and CHANGE_RST is
-set: increase my RST.
+set: increase received RST.
 .
 .TP
 .B PgDown
 Decrease CW (Morse Code) speed (from call input and exchange fields).
 .IP
 If the cursor is in the call input field and it is not empty and CHANGE_RST is
-set: decrease his RST.
+set: decrease sent RST.
 .IP
 If the cursor is in the exchange field and it is not empty and CHANGE_RST is
-set: decrease my RST.
+set: decrease received RST.
 .
 .TP
 .B Ctrl-PgUp
@@ -1445,15 +1445,15 @@ updated by WWV or WCY messages.
 .
 .TP
 .B CHANGE_RST
-If set in logcfg.dat, PgUp and PgDown will change his/my RST instead of 
+If set in logcfg.dat, PgUp and PgDown will change sent/received RST instead of
 CW speed if you are in call/exchange field and call field is not empty.
 .br
 Default is Off.
 .
 .TP
 \fBCHANGE_RST\fR=\fI33, 43, 47, 499, ...\fR
-Provide a comma separated list of RS(T) values which are used for his RST. Own
-RST will always be 33..39,43..49,53..59. 
+Provide a comma separated list of RS(T) values which are used for the sent RST.
+Received RST will always be 33..39,43..49,53..59.
 .br
 Providing a value for T is optional but will be ignored. 
 In CW and digi mode T will always be 9.


### PR DESCRIPTION
Allow scrolling up  and down received and sent rapport between 33(9) and  59(9) if CHANGE_RST is set. 

Extend keywords so that you can provide a list of most used RST values for other stations rapport which will then be used for scrolling,  e.g. CHANGE_RST=339,479,599.

Allowed range is 33..39,43..49,53..59.
A value for T can be provided, but will be ignored, e.g. CHANGE_RST=338,.. will be accepted but always send as 339.


While the implementation can use some cleanup, I would like to get some feedback for functionality.

There should be one addition to allow to set received RS(d) directly. ATM I would prefer parsing the exchange field for starting with something like 'r479' taking that as received rapport and moving it from exchange field to my_RST. Any comments?