### PR TITLE
Fix time handling and CQWW simulator

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,7 +8,8 @@ tlf_SOURCES = \
 	background_process.c bandmap.c bands.c \
 	cabrillo_utils.c calledit.c callinput.c changefreq.c changepars.c \
 	change_rst.c checklogfile.c checkqtclogfile.c \
-	checkparameters.c cleanup.c clear_display.c clusterinfo.c cw_utils.c \
+	checkparameters.c cleanup.c clear_display.c clusterinfo.c \
+        cqww_simulator.c cw_utils.c \
 	dxcc.c \
 	deleteqso.c displayit.c \
 	edit_last.c editlog.c err_utils.c \
@@ -45,7 +46,7 @@ noinst_HEADERS = \
 	cabrillo_utils.h calledit.h callinput.h changefreq.h changepars.h \
 	change_rst.h checklogfile.h checkqtclogfile.h \
 	checkparameters.h cleanup.h clear_display.h clusterinfo.h \
-	cw_utils.h \
+	cqww_simulator.h cw_utils.h \
 	dxcc.h \
 	deleteqso.h displayit.h \
 	edit_last.h editlog.h  err_utils.h \

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -34,7 +34,6 @@
 #include <string.h>
 
 #include <glib.h>
-#include <time.h>
 
 #include "addcall.h"
 #include "addmult.h"
@@ -92,16 +91,16 @@ int addcall(void) {
     extern char continent[];
     extern int exclude_multilist_type;
     extern int trxmode;
-    extern struct tm *time_ptr;
 
     static int found = 0;
     static int i, j, z = 0;
     static int add_ok;
     int pfxnumcntidx = -1;
     int pxnr = 0;
+
     excl_add_veto = 0;
 
-    get_time();
+    time_t now = get_time();
 
     found = searchcallarray(hiscall);
 
@@ -113,7 +112,7 @@ int addcall(void) {
     } else
 	i = found;
 
-    worked[i].qsotime[trxmode][bandinx] = (long)mktime(time_ptr);
+    worked[i].qsotime[trxmode][bandinx] = now;
     j = getctydata(hiscall);
     worked[i].country = j;
     if (strlen(comment) >= 1) {		/* remember last exchange */
@@ -291,7 +290,6 @@ int addcall2(void) {
     int pxnr = 0;
     excl_add_veto = 0;
     char date_and_time[16];
-    struct tm qsotime;
     time_t qsotimets;
 
     g_strlcpy(hiscall, lan_logline + 29, 20);
@@ -316,10 +314,8 @@ int addcall2(void) {
     bandinx = log_get_band(lan_logline);
 
     /* calculate QSO timestamp from lan_logline */
-    memset(&qsotime, 0, sizeof(struct tm));
     strncpy(date_and_time, lan_logline + 7, 15);
-    strptime(date_and_time, "%d-%b-%y %H:%M", &qsotime);
-    qsotimets = mktime(&qsotime);
+    qsotimets = parse_time(date_and_time, DATE_TIME_FORMAT);
 
     worked[i].qsotime[trxmode][bandinx] = qsotimets;
     worked[i].country = j;

--- a/src/addspot.c
+++ b/src/addspot.c
@@ -47,7 +47,6 @@
 void add_to_spots(char *call, freq_t freq) {
 
     extern int lanspotflg;
-    extern struct tm *time_ptr;
     extern char thisnode;
 
     char spotline[160];
@@ -56,9 +55,7 @@ void add_to_spots(char *call, freq_t freq) {
     sprintf(spotline, "DX de TLF-%c:     %9.3f  %s", thisnode, freq / 1000.0, call);
     strcat(spotline, spaces(43));
 
-    get_time();
-
-    strftime(spottime, sizeof(spottime), "%H%MZ", time_ptr);
+    format_time(spottime, sizeof(spottime), "%H%MZ");
     strcpy(spotline + 70, spottime);
     strcat(spotline, "\n\n");
 

--- a/src/background_process.h
+++ b/src/background_process.h
@@ -26,8 +26,4 @@ void *background_process(void *);
 void stop_background_process(void);
 void start_background_process(void);
 
-void setSimulatorState(int n);
-
-
-
 #endif /* end of include guard: BACKGROUND_PROCESS_H */

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -42,6 +42,7 @@
 #include "changepars.h"
 #include "clear_display.h"
 #include "cleanup.h"
+#include "cqww_simulator.h"
 #include "cw_utils.h"
 #include "edit_last.h"
 #include "err_utils.h"
@@ -120,8 +121,6 @@ int callinput(void) {
     extern int announcefilter;
     extern char ph_message[14][80];
     extern SCREEN *mainscreen;
-    extern int simulator;
-    extern int simulator_mode;
     extern char talkarray[5][62];
     extern int lan_active;
     extern int zonedisplay;
@@ -605,10 +604,8 @@ int callinput(void) {
 			send_standard_message(0);	/* CQ */
 		    }
 
+		    set_simulator_state(CALL);
 
-		    if (simulator != 0) {
-			simulator_mode = 1;
-		    }
 		} else {
 
 		    if (cqmode == S_P)

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 
 #include "audio.h"
+#include "cqww_simulator.h"
 #include "changepars.h"
 #include "clear_display.h"
 #include "editlog.h"
@@ -88,7 +89,6 @@ int changepars(void) {
     extern int ctcomp;
     extern char *config_file;
     extern int miniterm;
-    extern int simulator;
     extern int cwkeyer;
     extern char synclogfile[];
     extern char sc_volume[];
@@ -259,7 +259,7 @@ int changepars(void) {
 		contest = CONTEST;
 		searchflg = SEARCHWINDOW;
 	    }
-	    mvprintw(13, 29, "CONTEST-mode is %d", contest);
+	    mvprintw(13, 29, "CONTEST-mode is %s", contest ? "on" : "off");
 	    refreshp();
 	    sleep(1);
 
@@ -441,9 +441,9 @@ int changepars(void) {
 		break;
 	    }
 
-	    if (simulator == 0) {
+	    if (!simulator) {
 
-		simulator = 1;
+		simulator = true;
 		cqmode = CQ;
 		if (ctcomp == 1) {
 		    TLF_LOG_INFO(
@@ -464,7 +464,7 @@ int changepars(void) {
 		    }
 		}
 	    } else {
-		simulator = 0;
+		simulator = false;
 		mvprintw(13, 29, "Simulator off");
 		refreshp();
 		sleep(1);
@@ -679,8 +679,7 @@ int changepars(void) {
 		if (fldigi_toggle()) {
 		    fldigi_clear_connerr();
 		    mvprintw(13, 29, "FLDIGI ON");
-	        }
-	        else {
+		} else {
 		    mvprintw(13, 29, "FLDIGI OFF");
 		}
 		refreshp();

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "cqww_simulator.h"
 #include "cw_utils.h"
 #include "change_rst.h"
 #include "get_time.h"
@@ -37,6 +38,7 @@
 #include "qsonr_to_str.h"
 #include "searchlog.h"		// Includes glib.h
 #include "showscore.h"
+#include "time_update.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
 
@@ -49,7 +51,7 @@ void show_header_line() {
     char *mode = "";
     switch (cqmode) {
 	case CQ:
-	    mode = "Log";
+	    mode = (simulator ? "Sim" : "Log");
 	    break;
 	case S_P:
 	    mode = "S&P";
@@ -86,11 +88,9 @@ void clear_display(void) {
     extern int arrldx_usa;
     extern char comment[];
     extern int searchflg;
-    extern struct tm *time_ptr;
     extern char whichcontest[];
     extern int no_rst;
 
-    char time_buf[80];
     int cury, curx;
 
     getyx(stdscr, cury, curx);
@@ -125,15 +125,15 @@ void clear_display(void) {
     get_time();
 
     if (trxmode == CWMODE)
-	strftime(time_buf, 60, "CW  %d-%b-%y %H:%M ", time_ptr);
+	mvaddstr(12, 3, "CW");
     else if (trxmode == SSBMODE)
-	strftime(time_buf, 60, "SSB %d-%b-%y %H:%M ", time_ptr);
+	mvaddstr(12, 3, "SSB");
     else
-	strftime(time_buf, 60, "DIG %d-%b-%y %H:%M ", time_ptr);
+	mvaddstr(12, 3, "DIG");
 
-    month = time_ptr->tm_mon;	/* month for muf calc */
-
-    mvaddstr(12, 3, time_buf);
+    char time_buf[20];
+    format_time(time_buf, sizeof(time_buf), DATE_TIME_FORMAT);
+    update_line(time_buf);
 
     qsonr_to_str();
     mvaddstr(12, 23, qsonrstr);

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -167,7 +167,6 @@ void clusterinfo(void) {
 int loadbandmap(void) {
 
     extern char *bandmap[MAX_SPOTS];
-    extern struct tm *time_ptr;
     extern int xplanet;
     extern char markerfile[];
     extern char lastmsg[];
@@ -213,8 +212,7 @@ int loadbandmap(void) {
 
     i = 0;
 
-    get_time();
-    sysminutes = 60 * time_ptr->tm_hour + time_ptr->tm_min;
+    sysminutes = get_minutes();
 
     /* parse log of cluster output and find DX announcements.
      * Copy them to bandmap array and find spot_age and spot_freq

--- a/src/cqww_simulator.c
+++ b/src/cqww_simulator.c
@@ -1,0 +1,164 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2001-2002-2003 Rein Couperus <pa0rct@amsat.org>
+ *               2011, 2014     Thomas Beierlein <tb@forth-ev.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <string.h>
+
+#include "cqww_simulator.h"
+#include "get_time.h"
+#include "getctydata.h"
+#include "globalvars.h"
+#include "searchlog.h"		// Includes glib.h
+#include "sendbuf.h"
+#include "set_tone.h"
+#include "tlf.h"
+#include "write_keyer.h"
+
+/* CW Simulator
+ * works only in RUN mode for CQWW contest
+ */
+
+bool simulator = false;
+
+static simstate_t simulator_state = IDLE;
+static pthread_mutex_t simulator_state_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+simstate_t get_simulator_state() {
+    if (!simulator || trxmode != CWMODE) {
+	return IDLE;
+    }
+
+    pthread_mutex_lock(&simulator_state_mutex);
+    simstate_t s = simulator_state;
+    pthread_mutex_unlock(&simulator_state_mutex);
+
+    return s;
+}
+
+void set_simulator_state(simstate_t s) {
+    if (!simulator || trxmode != CWMODE) {
+	return;
+    }
+
+    pthread_mutex_lock(&simulator_state_mutex);
+    simulator_state = s;
+    pthread_mutex_unlock(&simulator_state_mutex);
+}
+
+const char *cw_tones[] = {
+    "625", "800", "650", "750", "700",
+    "725", "675", "775", "600", "640"
+};
+#define NUM_TONES   (sizeof(cw_tones) / sizeof(char*))
+
+
+static char simulator_tone[5];
+static char tonecpy[5];
+
+static void set_simulator_tone() {
+    strcpy(tonecpy, tonestr);
+    strcpy(tonestr, simulator_tone);
+    write_tone();
+
+    sendmessage("  ");
+    write_keyer();      // two spaces delay
+}
+
+static void restore_tone() {
+    strcpy(tonestr, tonecpy);
+    write_tone();
+}
+
+void cqww_simulator(void) {
+
+    if (!simulator) {
+	return;
+    }
+
+    static int callnumber = 0;
+    static int repeat_count = 0;
+
+    char callcpy[80];
+
+    simstate_t state = get_simulator_state();
+
+    if (state == CALL) {
+
+	int this_second = get_time() % 60;
+
+	strcpy(simulator_tone, cw_tones[this_second % NUM_TONES]);
+
+	set_simulator_tone();
+
+	callnumber += 8327 +  this_second;  // "random"
+	callnumber %= callmaster->len;
+
+	sendmessage(CALLMASTERARRAY(callnumber));
+	write_keyer();
+
+	repeat_count = 0;
+	restore_tone();
+
+    } else if (state == FINAL) {
+
+	set_simulator_tone();
+
+	strcpy(callcpy, CALLMASTERARRAY(callnumber));
+	getctydata(callcpy);
+
+	char save = zone_export[0];
+	if (get_time() % 2 == 0) {  // use short numbers randomly
+	    zone_export[0] = short_number(zone_export[0]);
+	}
+
+	char *str = g_strdup_printf("TU 5NN %2s", zone_export);
+	sendmessage(str);
+	write_keyer();
+	g_free(str);
+	zone_export[0] = save;
+
+	repeat_count = 0;
+	restore_tone();
+
+    } else if (state == REPEAT) {
+
+	set_simulator_tone();
+
+	++repeat_count;
+	int slow = repeat_count / 2;
+	if (slow > 3) {
+	    slow = 3;
+	}
+
+	strcpy(callcpy, CALLMASTERARRAY(callnumber));
+	getctydata(callcpy);
+
+	char *str = g_strdup_printf("%s%s%s",
+				    "---" + 3 - slow,
+				    CALLMASTERARRAY(callnumber),
+				    "+++" + 3 - slow);
+	sendmessage(str);
+	write_keyer();
+
+	restore_tone();
+    }
+
+    set_simulator_state(IDLE);
+
+}

--- a/src/cqww_simulator.h
+++ b/src/cqww_simulator.h
@@ -1,6 +1,7 @@
 /*
  * Tlf - contest logging program for amateur radio operators
  * Copyright (C) 2001-2002-2003 Rein Couperus <pa0rct@amsat.org>
+ *               2014           Thomas Beierlein <tb@forth-ev.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,13 +19,17 @@
  */
 
 
-#ifndef SET_TONE_H
-#define SET_TONE_H
+#ifndef CQWW_SIMULATOR_H
+#define CQWW_SIMULATOR_H
 
-extern char tonestr[];
+#include <stdbool.h>
 
-void set_tone(void);
-void write_tone(void);
+extern bool simulator;
 
+typedef enum {IDLE, CALL, REPEAT, FINAL} simstate_t;
 
-#endif /* end of include guard: SET_TONE_H */
+simstate_t get_simulator_state();
+void set_simulator_state(simstate_t s);
+void cqww_simulator(void);
+
+#endif

--- a/src/get_time.h
+++ b/src/get_time.h
@@ -21,6 +21,19 @@
 #ifndef GET_TIME_H
 #define GET_TIME_H
 
-void get_time(void);
+#include <time.h>
+
+#define DATE_FORMAT         "%d-%b-%y"  // 23-Apr-20
+#define TIME_FORMAT         "%H:%M"
+#define DATE_TIME_FORMAT    DATE_FORMAT " " TIME_FORMAT
+
+time_t get_time();
+int get_minutes();
+
+time_t format_time(char *buffer, size_t size, const char *format);
+time_t format_time_with_offset(char *buffer, size_t size, const char *format,
+			       double offset);
+
+time_t parse_time(const char *buffer, const char *format);
 
 #endif /* GET_TIME_H */

--- a/src/getwwv.c
+++ b/src/getwwv.c
@@ -20,9 +20,9 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 
 #include "dxcc.h"
+#include "get_time.h"
 #include "printcall.h"
 #include "tlf.h"
 #include "tlf_curses.h"
@@ -53,7 +53,7 @@ void wwv_add(const char *s) {
     }
     *dest = 0;
 
-    lastwwv_time = time(NULL);
+    lastwwv_time = get_time();
 
     char gmt[10] = "";
     char *p = strstr(lastwwv_raw, "<");
@@ -109,7 +109,7 @@ void wwv_add(const char *s) {
 // show footer if WWV was received not later than 3 mins ago
 //
 void wwv_show_footer() {
-    if (lastwwv_time > time(NULL) - 3 * 60) {
+    if (lastwwv_time > get_time() - 3 * 60) {
 	mvprintw(LINES - 1, 0, lastwwv);
     }
 }

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -32,6 +32,7 @@
 #include <netinet/in.h>
 
 #include "err_utils.h"
+#include "get_time.h"
 #include "lancode.h"
 #include "tlf.h"
 #include "tlf_curses.h"
@@ -82,7 +83,6 @@ int lanqsos;
 char lastqsonr[5];
 int highqsonr;
 int landebug = 0;
-long lantime;
 long timecorr;
 int time_master;
 char thisnode = 'A'; 		/*  start with 'A' if not defined in
@@ -420,18 +420,12 @@ int send_freq(freq_t freq) {
 
 /* ----------------- send time message ----------*/
 
-int send_time(void) {
+void send_time(void) {
 
-    extern int timeoffset;
-
-    long now;
     char timebuffer[14];
 
-    now = (long)(time(0) + (timeoffset * 3600L));
+    time_t now = get_time();    // note: time master send UTC (timecorr=0)
 
-    sprintf(timebuffer, "%ld", now);
-    strcat(timebuffer, " ");
+    sprintf(timebuffer, "%ld ", now);
     send_lan_message(TIMESYNC, timebuffer);
-
-    return (0);
 }

--- a/src/lancode.h
+++ b/src/lancode.h
@@ -45,6 +45,6 @@ int lan_send(char *lanbuffer) ;
 int send_lan_message(int opcode, char *message);
 void talk(void);
 int send_freq(freq_t freq);
-int send_time(void) ;
+void send_time(void) ;
 
 #endif /* LANCODE_H */

--- a/src/last10.c
+++ b/src/last10.c
@@ -66,9 +66,7 @@ int last10(void) {
     input[17 + 2] = '\0';
     minsbefore += (atoi(input + 17) * 60);
 
-    get_time();
-
-    minsnow = time_ptr->tm_hour * 60 + time_ptr->tm_min;
+    minsnow = get_minutes();
 
     if ((minsnow - minsbefore) <= 0)
 	minsnow += 1440;

--- a/src/logit.c
+++ b/src/logit.c
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include "background_process.h"
+#include "cqww_simulator.h"
 #include "callinput.h"
 #include "clear_display.h"
 #include "getexchange.h"
@@ -116,11 +117,7 @@ void logit(void) {
 			refreshp();
 		    }
 
-		    if (strstr(hiscall, "?") != NULL) {
-			setSimulatorState(3);
-		    } else {
-			setSimulatorState(2);
-		    }
+		    set_simulator_state(FINAL);
 
 		    if ((cqww == 1) || (wazmult == 1) || (itumult == 1)) {
 
@@ -174,7 +171,7 @@ void logit(void) {
 		} else if (defer_store > 1) {
 		    if ((cqmode == CQ) && (contest == CONTEST)) {
 			send_standard_message(CQ_TU_MSG);	/* send cq return */
-			setSimulatorState(1);
+			set_simulator_state(CALL);
 
 			defer_store = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -319,7 +319,6 @@ rmode_t digi_mode = RIG_MODE_NONE;
 int txdelay = 0;
 int weight = 0;
 char weightbuf[4];
-char tonestr[5] = "600";
 int cqdelay = 8;
 int k_tune;
 int k_pin14;
@@ -360,14 +359,6 @@ int rig_comm_success = 0;
 /*----------------------------------fldigi---------------------------------*/
 char fldigi_url[50] = "http://localhost:7362/RPC2";
 
-/*---------------------------------simulator-------------------------------*/
-int simulator = 0;
-int simulator_mode = 0;
-int simulator_seed = 8327;
-int system_secs;
-char tonecpy[5];
-char simulator_tone[5];
-
 /*-------------------------------the log lines-----------------------------*/
 char qsos[MAX_QSOS][LOGLINELEN + 1];
 int nr_qsos = 0;
@@ -403,8 +394,7 @@ int bandinx = BANDINDEX_40;	/* start with 40m */
 int qsonum = 1;			/* nr of next QSO */
 int ymax, xmax;			/* screen size */
 
-pid_t pid;
-struct tm *time_ptr, time_ptr_cabrillo;
+struct tm time_ptr_cabrillo;
 
 freq_t freq;
 int logfrequency = 0;
@@ -434,8 +424,6 @@ double DEST_Lat = 51.;
 double DEST_Long = 1.;
 
 char hiscountry[40];
-
-int this_second;
 
 int wazmult = 0;		/* to add the ability of WAZ zones to be multiplier */
 int itumult = 0;		/* to add the ability of ITU zones to be multiplier */

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -138,10 +138,10 @@ void prepare_fixed_part(void) {
 	strcat(logline4, "DIG");
 
     if (do_cabrillo == 0) {
-	get_time();
-	strftime(time_buf, 60, " %d-%b-%y %H:%M ", time_ptr);
+	format_time(time_buf, sizeof(time_buf), " "DATE_TIME_FORMAT" ");
     } else {
-	strftime(time_buf, 60, " %d-%b-%y %H:%M ", &time_ptr_cabrillo);
+	strftime(time_buf, sizeof(time_buf), " "DATE_TIME_FORMAT" ",
+		 &time_ptr_cabrillo);
     }
     strcat(logline4, time_buf);
 
@@ -150,7 +150,7 @@ void prepare_fixed_part(void) {
 	    trx_control == 1 &&
 	    ((strcmp(whichcontest, "qso") == 0) ||
 	     (strcmp(whichcontest, "dxped") == 0))) {
-        char khz[5];
+	char khz[5];
 	sprintf(khz, " %3d", ((unsigned int)(freq / 1000.0)) % 1000);	// show freq.
 	strcat(logline4, khz);
 
@@ -270,12 +270,12 @@ void prepare_specific_part(void) {
 
     } else if ((cqww == 1) || (wazmult == 1) || (itumult == 1)) {
 	//-------------------------cqww----------------
-/*
-	if (strlen(zone_fix) > 1) {
-		strcat (logline4, zone_fix);
-	} else
-		strcat (logline4, zone_export);
-*/
+	/*
+		if (strlen(zone_fix) > 1) {
+			strcat (logline4, zone_fix);
+		} else
+			strcat (logline4, zone_export);
+	*/
 	if (trxmode == DIGIMODE && cqww == 1 && strlen(comment) < 5) {
 	    comment[2] = ' ';
 	    comment[3] = 'D';
@@ -324,12 +324,12 @@ void prepare_specific_part(void) {
 	fillto(73);
 
 	if (addzone != 0) {
-/*
-		if (strlen(zone_fix) > 1) {
-			strncat (logline4, zone_fix, 2);
-		} else
-			strncat (logline4, zone_export, 2);
-*/
+	    /*
+	    		if (strlen(zone_fix) > 1) {
+	    			strncat (logline4, zone_fix, 2);
+	    		} else
+	    			strncat (logline4, zone_export, 2);
+	    */
 	    if (strlen(comment) < 2) {
 		strcat(logline4, "0");
 		strncat(logline4, comment, 1);

--- a/src/muf.c
+++ b/src/muf.c
@@ -184,7 +184,6 @@ September 26, 1986.
 
 int month;
 
-extern struct tm *time_ptr;
 
 double yt;
 double xt;
@@ -322,9 +321,12 @@ void muf(void) {
     dx = dxcc_by_index(countrynr);
     strncpy(country, dx->countryname, 25);
 
+    time_t now = format_time(time_buf, sizeof(time_buf),
+			     "    " DATE_TIME_FORMAT " ");
 
-    get_time();
-    strftime(time_buf, sizeof(time_buf), "    %d-%b-%Y %H:%M ", time_ptr);
+    struct tm time_tm;
+    gmtime_r(&now, &time_tm);
+    month = time_tm.tm_mon;
 
     q = sin(xt / RADIAN) * sin(xr / RADIAN);
     x = q + cos(xt / RADIAN) * cos(xr / RADIAN) * cos(yt / RADIAN - yr / RADIAN);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -50,7 +50,6 @@
 extern int cwkeyer;
 extern int digikeyer;
 extern int keyer_backspace;
-extern char tonestr[];
 extern int partials;
 extern int use_part;
 extern int contest;

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -260,8 +260,7 @@ void start_qtc_recording() {
     if (record_run < 0 && qtcrec_record == 1
 	    && strlen((char *)qtcrec_record_command) > 0) {
 	strcpy(reccommand, qtcrec_record_command[0]);
-	get_time();
-	strftime(tempc, 60, "%y%m%d%H%M%S.wav", time_ptr);
+	format_time(tempc, sizeof(tempc), "%y%m%d%H%M%S.wav");
 	strcat(reccommand, tempc);
 	strcat(reccommand, qtcrec_record_command[1]);
 	record_run = system(reccommand);
@@ -614,9 +613,7 @@ void qtc_main_panel(int direction) {
 				showfield((3 * (currqtc + 1)) + 2);
 			    }
 
-			    get_time();
-			    tempc[0] = '\0';
-			    strftime(tempc, 40, "%d-%b-%y %H:%M", time_ptr);
+			    format_time(tempc, sizeof(tempc), DATE_TIME_FORMAT);
 			    g_strlcpy(qtcreclist.qtclines[currqtc].receivedtime, tempc, 16);
 			    qtcreclist.qtclines[currqtc].status = 2;
 			    show_status(currqtc);
@@ -681,9 +678,7 @@ void qtc_main_panel(int direction) {
 		    if (direction == SEND && trxmode != DIGIMODE) {
 			if (qtclist.qtclines[activefield - 3].sent == 0) {
 			    qtclist.qtclines[activefield - 3].sent = 1;
-			    get_time();
-			    tempc[0] = '\0';
-			    strftime(tempc, 40, "%d-%b-%y %H:%M", time_ptr);
+			    format_time(tempc, sizeof(tempc), DATE_TIME_FORMAT);
 			    g_strlcpy(qtclist.qtclines[activefield - 3].senttime, tempc, 16);
 			    qtclist.qtclines[activefield - 3].senttime[15] = '\0';
 			    qtclist.totalsent++;
@@ -748,9 +743,7 @@ void qtc_main_panel(int direction) {
 				    tempc, qtclist.serial, *qtccount, tempc,
 				    qtclist.serial, *qtccount);
 			}
-			timec[0] = '\0';
-			get_time();
-			strftime(timec, 40, "%d-%b-%y %H:%M", time_ptr);
+			format_time(timec, sizeof(timec), DATE_TIME_FORMAT);
 
 			for (ql = 0; ql < *qtccount; ql++) {
 			    qtclist.qtclines[ql].sent = 1;

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -32,6 +32,7 @@
 #include "cabrillo_utils.h"
 #include "cleanup.h"
 #include "getexchange.h"
+#include "get_time.h"
 #include "globalvars.h"
 #include "makelogline.h"
 #include "qtc_log.h"
@@ -275,7 +276,7 @@ void cab_qso_to_tlf(char *line, struct cabrillo_desc *cabdesc) {
 		break;
 	    case DATE:
 		strptime(tempstr, "%Y-%m-%d", &time_ptr_cabrillo);
-		strftime(qtc_line.date, 60, "%d-%b-%y", &time_ptr_cabrillo);
+		strftime(qtc_line.date, sizeof(qtc_line.date), DATE_FORMAT, &time_ptr_cabrillo);
 		break;
 	    case TIME:
 		timestr[0] = tempstr[0];
@@ -428,7 +429,7 @@ int readcabrillo(int mode) {
     } else {
 	tempstrp = g_strdup_printf("CABRILLO format: %s", cabrillo);
 	show_readcab_msg(mode, tempstrp);
-	g_free (tempstrp);
+	g_free(tempstrp);
 	sleep(1);
     }
 
@@ -444,9 +445,9 @@ int readcabrillo(int mode) {
 
     if ((fp2 = fopen(output_logfile, "w")) == NULL) {
 	tempstrp = g_strdup_printf("Can't open output logfile: %s.",
-							output_logfile);
+				   output_logfile);
 	show_readcab_msg(mode, tempstrp);
-	g_free (tempstrp);
+	g_free(tempstrp);
 	sleep(2);
 	do_cabrillo = 0;
 	free_cabfmt(cabdesc);
@@ -456,9 +457,9 @@ int readcabrillo(int mode) {
 
     if ((fp1 = fopen(input_logfile, "r")) == NULL) {
 	tempstrp = g_strdup_printf("Can't open input logfile: %s.",
-							input_logfile);
+				   input_logfile);
 	show_readcab_msg(mode, tempstrp);
-	g_free (tempstrp);
+	g_free(tempstrp);
 	sleep(2);
 	do_cabrillo = 0;
 	free_cabfmt(cabdesc);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -222,7 +222,6 @@ int readcalls(void) {
     int pfxnumcntidx;
     int pxnr;
     bool excl_add_veto;
-    struct tm qsotime;
     int qsomode;
     int linenr = 0;
 
@@ -328,9 +327,7 @@ int readcalls(void) {
 	}
 
 	/* calculate QSO timestamp from logline */
-	memset(&qsotime, 0, sizeof(struct tm));
-	strptime(inputbuffer + 7, "%d-%b-%y %H:%M", &qsotime);
-	worked[l].qsotime[qsomode][bandindex] = mktime(&qsotime);
+	worked[l].qsotime[qsomode][bandindex] = parse_time(inputbuffer + 7, DATE_TIME_FORMAT);
 
 
 	if (pfxmultab == 1) {
@@ -489,13 +486,11 @@ int log_read_n_score() {
 int synclog(char *synclogfile) {
 
     extern char logfile[];
-    extern struct tm *time_ptr;
 
     char wgetcmd[120] = "wget ftp://";	//user:password@hst/dir/file
     char date_buf[60];
 
-    get_time();
-    strftime(date_buf, 9, "%d%H%M", time_ptr);
+    format_time(date_buf, sizeof(date_buf), "%d%H%M");
 
     if (strlen(synclogfile) < 80)
 	strcat(wgetcmd, synclogfile);

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -424,7 +424,7 @@ bool worked_in_current_minitest_period(int found) {
 	return true;    // minitest is off, so the answer is yes
     }
 
-    long currtime = (long) mktime(time_ptr);
+    long currtime = get_time();
     long period_start = (currtime / minitest) * minitest;
     return worked[found].qsotime[trxmode][bandinx] >= period_start;
 }
@@ -737,8 +737,6 @@ void searchlog() {
 
     dxcc_data *dx;
     int zone;
-
-    get_time();
 
     if (!initialized) {
 	InitSearchPanel();

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -30,6 +30,7 @@
 
 #include <glib.h>
 
+#include "cqww_simulator.h"
 #include "callinput.h"
 #include "displayit.h"
 #include "globalvars.h"
@@ -250,8 +251,6 @@ void sendbuf(void) {
     extern char termbuf[];
     extern int cwkeyer;
     extern int digikeyer;
-    extern int simulator;
-    extern int simulator_mode;
     extern int sending_call;
 
     static char printlinebuffer[82] = "";
@@ -264,7 +263,7 @@ void sendbuf(void) {
 	ExpandMacro();
 
 	if ((strlen(buffer) + strlen(termbuf)) < 80) {
-	    if (simulator == 0)
+	    if (!simulator)
 		strcat(termbuf, buffer);
 //              if (sending_call == 1) {
 //                      strcat (termbuf, " ");
@@ -274,7 +273,7 @@ void sendbuf(void) {
 
 	g_strlcpy(printlinebuffer, termbuf, sizeof(printlinebuffer));
 
-	if (searchflg == 0 && simulator == 0)
+	if (!searchflg && !simulator)
 	    strncat(printlinebuffer, backgrnd_str,
 		    80 - strlen(printlinebuffer));
 	else {
@@ -293,9 +292,8 @@ void sendbuf(void) {
 
 	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
-	if (simulator_mode == 0) {
+	if (get_simulator_state() == IDLE) {
 	    mvprintw(5, 0, printlinebuffer);
-	    refreshp();
 	}
 	refreshp();
 
@@ -327,11 +325,13 @@ void sendbuf(void) {
 	    keyer_append(buffer);
 	}
 
-	if (simulator == 0) {
+	if (!simulator) {
 	    if (sending_call == 0)
 		displayit();
 	    refreshp();
-	}
+	} else {
+            set_simulator_state(REPEAT);
+        }
 
 	buffer[0] = '\0';
     }

--- a/src/set_tone.c
+++ b/src/set_tone.c
@@ -18,7 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 /* ------------------------------------------------------------
- *        Set Cw sidetone
+ *        Set CW sidetone
  *
  *--------------------------------------------------------------*/
 
@@ -26,19 +26,18 @@
 #include <stdlib.h>
 
 #include "err_utils.h"
+#include "globalvars.h"
 #include "netkeyer.h"
 #include "nicebox.h"	// Includes curses.h
 #include "set_tone.h"
 #include "tlf.h"
 
+char tonestr[5] = "600";
 
-int set_tone(void) {
-
-    extern char tonestr[];
-    extern int trxmode;
+void set_tone(void) {
 
     if (trxmode != CWMODE)
-	return (1);
+	return;
 
     nicebox(4, 40, 1, 6, "Tone");
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
@@ -50,14 +49,10 @@ int set_tone(void) {
     tonestr[3] = '\0';
 
     write_tone();
-
-    return (0);
 }
 
 void write_tone(void) {
 
-    extern int trxmode;
-    extern char tonestr[];
     extern char sc_volume[];
 
     if (netkeyer(K_TONE, tonestr) < 0) {

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -35,10 +35,10 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
-#include <time.h>
 
 #include "dxcc.h"
 #include "getwwv.h"
+#include "get_time.h"
 #include "qrb.h"
 #include "showinfo.h"
 #include "tlf.h"
@@ -53,8 +53,6 @@ void showinfo(int x) {
     extern char ituzone[];
     extern double DEST_Lat;
     extern double DEST_Long;
-    extern int timeoffset;
-    extern long timecorr;
     extern char itustr[];
     extern int mycountrynr;
 
@@ -71,8 +69,6 @@ void showinfo(int x) {
     dxcc_data *dx;
     prefix_data *pfx;
     double d;
-    time_t now;
-    struct tm *ptr1;
 
     if (x == SHOWINFO_DUMMY)
 	pfx = prefix_by_index(prefix_count());
@@ -104,9 +100,7 @@ void showinfo(int x) {
     else
 	d = dx->timezone;				/* GMT difference */
 
-    now = (time(0) + (long)((timeoffset - d) * 3600) + timecorr);
-    ptr1 = gmtime(&now);
-    strftime(timebuff, 80, "%H:%M", ptr1);
+    format_time_with_offset(timebuff, sizeof(timebuff), TIME_FORMAT, d);
 
     if (pfx->lat != INFINITY)
 	DEST_Lat = pfx->lat;
@@ -139,7 +133,7 @@ void showinfo(int x) {
 
 	mvprintw(LINES - 1, LINELENGTH - 17, "   DX time: %s", timebuff);
     } else {
-        wwv_show_footer();
+	wwv_show_footer();
     }
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -546,7 +546,7 @@ void sanitize(char *s) {
 	else if (*s == '\015');
 	else {
 	    *t++ = *s & 0x7f;
-        }
+	}
     }
     *t = '\0';
 }
@@ -586,7 +586,6 @@ void addtext(char *s) {
     extern int lan_active;
     extern char call[];
     extern char hiscall[];
-    extern struct tm *time_ptr;
     extern char talkarray[5][62];
 
     char lan_out[256];
@@ -689,8 +688,7 @@ void addtext(char *s) {
 		}
 
 		strcat(spotline, spaces(43));
-		get_time();
-		strftime(spottime, sizeof(spottime), "%H%MZ", time_ptr);
+		format_time(spottime, sizeof(spottime), "%H%MZ");
 		strcpy(spotline + 70, spottime);
 		spotline[75] = '\0';
 		strcat(spotline, " <<\n");

--- a/src/sunup.c
+++ b/src/sunup.c
@@ -35,7 +35,6 @@
 
 void sunup(double DEST_Lat, double *sunrise, double *sundown) {
 
-    extern struct tm *time_ptr;
 
     double lat;
     double sun_lat;
@@ -44,8 +43,10 @@ void sunup(double DEST_Lat, double *sunrise, double *sundown) {
 
     lat = DEST_Lat / RADIAN;
 
-    get_time();
-    total_days = time_ptr->tm_yday + 10; /* days after lower culmination
+    time_t now = get_time();
+    struct tm time_tm;
+    gmtime_r(&now, &time_tm);
+    total_days = time_tm.tm_yday + 10; /* days after lower culmination
 						   of the sun */
     if (total_days >= 365.25)
 	total_days -= 365.25;

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -64,20 +64,12 @@ void broadcast_lan(void) {
 
 
 /** update band, date and time */
-void update_line(char *timestr) {
-
-    extern struct tm *time_ptr;
-
-    char time_buf[40];
+void update_line(const char *timestr) {
 
     attron(COLOR_PAIR(C_WINDOW) | A_STANDOUT);
 
     mvaddstr(12, 0, band[bandinx]);
-
-    strncpy(time_buf, timestr, 8);
-    mvaddstr(12, 17, time_buf);
-    strftime(time_buf, 60, "%d-%b-%y", time_ptr);
-    mvaddstr(12, 7, time_buf);
+    mvaddstr(12, 7, timestr);
 }
 
 const char *FREQ_DISPLAY_FORMAT = " %s: %7.1f";
@@ -111,23 +103,17 @@ void show_freq(void) {
 
 void time_update(void) {
 
-    extern struct tm *time_ptr;
     extern char qsonrstr[];
     extern int bandinx;
-    extern int this_second;
-    extern int system_secs;
     extern int miniterm;
 
-    char time_buf[11];
-    int currentterm = 0;
     static int s = 0;
     static int bm_timeout = 0;
     static int oldsecs = -1;  	/* trigger immediate update */
 
-    get_time();
-    this_second = time_ptr->tm_sec;		/* seconds */
-    // used in background_process
-    system_secs = time_ptr->tm_min * 60 + time_ptr->tm_sec;
+    char time_buf[20];
+    time_t now = format_time(time_buf, sizeof(time_buf), DATE_TIME_FORMAT);
+    int this_second = now % 60;		/* seconds */
 
     // force frequency display if it has changed (don't wait until next second)
     static freq_t old_freq = 0;
@@ -172,9 +158,6 @@ void time_update(void) {
     s = (s + 1) % 2;
     if (s > 0) {		/* every 2 seconds */
 
-	strftime(time_buf, 10, "%H:%M:%S", time_ptr);
-	time_buf[5] = '\0';
-
 	static time_t prev_wwv_time = 0;
 	if (lastwwv_time > prev_wwv_time) { // is there a newer WWV message?
 	    prev_wwv_time = lastwwv_time;
@@ -183,7 +166,7 @@ void time_update(void) {
 	    wwv_show_footer();              // print WWV info
 	}
 
-	currentterm = miniterm;
+	int currentterm = miniterm;
 	miniterm = 0;
 
 	broadcast_lan();

--- a/src/time_update.h
+++ b/src/time_update.h
@@ -25,6 +25,7 @@
 
 extern bool force_show_freq;
 
+void update_line(const char *timebuf);
 void time_update(void);
 
 #endif /* TIME_UPDATE_H */

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -117,7 +117,6 @@ enum {
 #define  MAX_CALLS 5000      /*  max nr of calls in dupe array */
 #define  MAX_MULTS 1000        /* max nr of mults in mults array */
 #define	MAX_SPOTS 200		/* max nr. of spots in spotarray */
-#define MAX_CALLMASTER 50000 /* max number of calls in callmaster array */
 #define CQ_ZONES 40
 #define ITU_ZONES 90
 #define MAX_ZONES (ITU_ZONES + 1) /* size of zones array */

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -34,6 +34,7 @@
 #include <unistd.h>
 
 #include "getsummary.h"
+#include "get_time.h"
 #include "log_utils.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
@@ -94,8 +95,8 @@ struct qso_t *get_next_record(FILE *fp) {
 	    /* date & time */
 	    memset(&date_n_time, 0, sizeof(struct tm));
 
-	    strptime(strtok_r(NULL, " \t", &sp), "%d-%b-%y", &date_n_time);
-	    strptime(strtok_r(NULL, " \t", &sp), "%H:%M", &date_n_time);
+	    strptime(strtok_r(NULL, " \t", &sp), DATE_FORMAT, &date_n_time);
+	    strptime(strtok_r(NULL, " \t", &sp), TIME_FORMAT, &date_n_time);
 
 	    ptr->year = date_n_time.tm_year + 1900;	/* convert to
 							   1968..2067 */
@@ -200,8 +201,8 @@ struct qso_t *get_next_qtc_record(FILE *fp, int qtcdirection) {
 	/* date & time */
 	memset(&date_n_time, 0, sizeof(struct tm));
 
-	strptime(strtok_r(NULL, " \t", &sp), "%d-%b-%y", &date_n_time);
-	strptime(strtok_r(NULL, " \t", &sp), "%H:%M", &date_n_time);
+	strptime(strtok_r(NULL, " \t", &sp), DATE_FORMAT, &date_n_time);
+	strptime(strtok_r(NULL, " \t", &sp), TIME_FORMAT, &date_n_time);
 
 	ptr->qsots = timegm(&date_n_time);
 
@@ -681,23 +682,22 @@ int write_cabrillo(void) {
 
 
 /* write ADIF header to open file */
-void write_adif_header(FILE* fp) {
+void write_adif_header(FILE *fp) {
     extern char whichcontest[];
 
-    time_t now = time(0);
-    struct tm *time_ptr = gmtime(&now);
     char timebuf[100];
 
     fputs
     ("################################################################################\n",
      fp);
-    fputs ("#                     ADIF v3.10 data file exported by TLF\n", fp);
-    fputs ("#              according to specifications on http://www.adif.org\n", fp);
+    fputs("#                     ADIF v3.10 data file exported by TLF\n", fp);
+    fputs("#              according to specifications on http://www.adif.org\n",
+	  fp);
     fputs
     ("################################################################################\n",
      fp);
 
-    strftime(timebuf, sizeof(timebuf), "%d-%b-%y at %H:%Mz", time_ptr);
+    format_time(timebuf, sizeof(timebuf), "%d-%b-%y at %H:%Mz");
     fprintf(fp, "Created %s for %s\n", timebuf, call);
 
     /* Write contest name */

--- a/test/data.c
+++ b/test/data.c
@@ -132,6 +132,7 @@ char multsfile[80] = "";	/* name of file with a list of allowed
 				   multipliers */
 char exchange_list[40] = "";
 int timeoffset = 0;
+long timecorr = 0;  // from lancode.c
 int multi = 0;			/* 0 = SO , 1 = MOST, 2 = MM */
 int trxmode = CWMODE;
 /* RIG_MODE_NONE in hamlib/rig.h, but if hamlib not compiled, then no dependecy */
@@ -310,14 +311,6 @@ char rigportname[40];
 int rignumber = 0;
 int rig_comm_error = 0;
 int rig_comm_success = 0;
-
-/*---------------------------------simulator-------------------------------*/
-int simulator = 0;
-int simulator_mode = 0;
-int simulator_seed = 8327;
-int system_secs;
-char tonecpy[5];
-char simulator_tone[5];
 
 /*-------------------------------the log lines-----------------------------*/
 char qsos[MAX_QSOS][LOGLINELEN + 1];

--- a/test/test.h
+++ b/test/test.h
@@ -12,6 +12,8 @@
 #include <setjmp.h>
 #include <string.h>
 
+#include <glib.h>
+
 #include <cmocka.h>
 
 extern const char STRING_NOT_SET[];

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -41,12 +41,12 @@ int pacc_pa(void) {
     return 0;
 }
 
-long timecorr = 0;
-
 /* setups */
 int setup_default(void **state) {
     char filename[100];
 
+    nr_worked = 0;
+    memset(&worked, 0, sizeof(worked));
     bandinx = BANDINDEX_10;
     cqww = 1;   /* trigger zone evaluation */
     wpx = 0;
@@ -114,12 +114,16 @@ void test_addcall_nopfxnum(void **state) {
 void test_addcall_pfxnum_inList(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "LZ1AB");
+    time_t now = time(NULL);
 
     addcall();
     assert_int_equal(addcallarea, 1);
     assert_int_equal(pfxnummulti[1].qsos[1], BAND10);
     assert_int_equal(countryscore[BANDINDEX_10], 1);
     assert_int_equal(zonescore[BANDINDEX_10], 1);
+
+    assert_int_equal(nr_worked, 1);
+    assert_in_range(worked[0].qsotime[trxmode][BANDINDEX_10], now, now + 1);
 }
 
 
@@ -165,7 +169,7 @@ char logline[] =
     "160CW  08-Feb-11 17:06 0025  LZ1AB          599  599  20            LZ  20   1  ";
 
 char logline_HA[] =
-    "160CW  08-Feb-11 17:06 0025  HA1AB          599  599  19            LZ  20   1  ";
+    "160CW  08-Aug-11 17:06 0025  HA1AB          599  599  19            LZ  20   1  ";
 
 char logline_PY[] =
     "160CW  08-Feb-11 17:06 0025  PY1AB          599  599  19            PY  20   1  ";
@@ -177,6 +181,10 @@ void test_addcall2_nopfxnum(void **state) {
     strcpy(lan_logline, logline);
     addcall2();
     assert_int_equal(addcallarea, 0);
+
+    assert_int_equal(nr_worked, 1);
+    // 2011-02-08 17:06 UTC
+    assert_int_equal(worked[0].qsotime[trxmode][BANDINDEX_160], 1297184760);
 }
 
 int setup_addcall2_pfxnum_inList(void **state) {
@@ -203,6 +211,10 @@ void test_addcall2_pfxnum_notinList(void **state) {
     strcpy(lan_logline, logline_HA);
     addcall2();
     assert_int_equal(addcallarea, 0);
+
+    assert_int_equal(nr_worked, 1);
+    // 2011-08-08 17:06 UTC
+    assert_int_equal(worked[0].qsotime[trxmode][BANDINDEX_160], 1312823160);
 }
 
 

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -9,7 +9,6 @@
 
 /* test stubs and dummies */
 int do_cabrillo = 0;	/* actually converting cabrillo file to Tlf log */
-extern struct tm *time_ptr;
 struct tm time_ptr_cabrillo;
 
 int qsoflags_for_qtc[MAX_QSOS];
@@ -154,7 +153,7 @@ void test_cabToTlf_ParseQSO(void **state) {
     struct cabrillo_desc *desc;
     desc = read_cabrillo_format(formatfile, "UNIVERSAL");
     bandinx_spy = 0;
-    cab_qso_to_tlf("QSO:  7002 RY 2016-08-13 0033 HA2OS         589 0008   K6ND          599 044",
+    cab_qso_to_tlf("QSO:  7002 RY 2016-02-13 2033 HA2OS         589 0008   K6ND          599 044",
 		   desc);
     assert_int_equal(bandinx_spy, 3);
     assert_int_equal((int)freq, 7002000);
@@ -163,10 +162,10 @@ void test_cabToTlf_ParseQSO(void **state) {
     assert_string_equal(my_rst, "589");
     assert_string_equal(his_rst, "599");
     assert_string_equal(comment, "044");
-    assert_int_equal(time_ptr_cabrillo.tm_hour, 00);
+    assert_int_equal(time_ptr_cabrillo.tm_hour, 20);
     assert_int_equal(time_ptr_cabrillo.tm_min, 33);
     assert_int_equal(time_ptr_cabrillo.tm_year, 2016 - 1900); /* year-1900 */
-    assert_int_equal(time_ptr_cabrillo.tm_mon, 8 - 1);	  /* 0-11 */
+    assert_int_equal(time_ptr_cabrillo.tm_mon, 2 - 1);	  /* 0-11 */
     assert_int_equal(time_ptr_cabrillo.tm_mday, 13);
 }
 

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -16,6 +16,7 @@
 // OBJECT ../src/dxcc.o
 // OBJECT ../src/getctydata.o
 // OBJECT ../src/getpx.o
+// OBJECT ../src/get_time.o
 // OBJECT ../src/locator2longlat.o
 // OBJECT ../src/readcalls.o
 // OBJECT ../src/searchcallarray.o
@@ -31,7 +32,6 @@ extern int exclude_multilist_type;
 extern bool continentlist_only;
 
 // dummy functions
-void get_time(void) {}
 void readqtccalls() {}
 void shownr(char *msg, int x) {}
 void spaces(int n) {} /* needs more care */

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -9,6 +9,7 @@
 
 // OBJECT ../src/addmult.o
 // OBJECT ../src/bands.o
+// OBJECT ../src/get_time.o
 // OBJECT ../src/searchlog.o
 // OBJECT ../src/zone_nr.o
 // OBJECT ../src/searchcallarray.o
@@ -56,10 +57,6 @@ void clusterinfo() {
 
 // splitscreen.c
 void refresh_splitlayout() {
-}
-
-// get_time.c
-void get_time(void) {
 }
 
 // getpx.c

--- a/test/test_sendbuf.c
+++ b/test/test_sendbuf.c
@@ -5,6 +5,7 @@
 #include "../src/sendspcall.h"
 #include "../src/tlf.h"
 #include "../src/globalvars.h"
+#include "../src/cqww_simulator.h"
 
 // OBJECT ../src/sendbuf.o
 // OBJECT ../src/sendspcall.o
@@ -28,10 +29,14 @@ extern char buffer[];
 extern char wkeyerbuffer[400];
 extern int demode;
 char *SPcall;
-extern int sending_call, simulator, data_ready, shortqsonr;
+extern int sending_call, data_ready, shortqsonr;
 
 void keyer_append(const char *string) { }
 int play_file(char *file) { return 0; }
+
+bool simulator;
+void set_simulator_state(simstate_t s) { }
+simstate_t get_simulator_state() { return IDLE; }
 
 
 /* test helpers */
@@ -72,7 +77,7 @@ void check_ExpandMacro(const char *input, const char *exp) {
 int setup_default(void **state) {
     wkeyerbuffer[0] = '\0';
     data_ready = 0;
-    simulator = 0;
+    simulator = false;
     sending_call = 0;
     trxmode = CWMODE;
     cwkeyer = 1;

--- a/test/test_wwv.c
+++ b/test/test_wwv.c
@@ -4,6 +4,7 @@
 #include "../src/getwwv.h"
 
 // OBJECT ../src/getwwv.o
+// OBJECT ../src/get_time.o
 
 int setup_default(void **state) {
 


### PR DESCRIPTION
(sorry for the Big Bang-like commit, but time related code is scattered all around, not easy to make separate fixes.)

The motivation for the fix is that after DST switch I started sometimes see a time on call input line that was 1 hour off. Logging worked with the correct time, just the input line was showing sporadically wrong time. Even though I was not able to reproduce it but I do have possible suspects.

Number 1 is the ` gtime()` function that stores its result into a shared static structure. It's clearly not thread safe. Number 2 is `mktime()`: it updates the TZ and DST flag in the shared structure.

Consider this snippet:
``` 
    time_t now = time(0);

    struct tm * time_ptr = gmtime(&now);

    char buf[128];
    strftime(buf, sizeof(buf), "date1: %a, %d %b %Y %H:%M:%S %Z", time_ptr);
    puts(buf);

    time_t t1 = mktime(time_ptr);

    strftime(buf, sizeof(buf), "date2: %a, %d %b %Y %H:%M:%S %Z", time_ptr);
    puts(buf);

    time_t t2 = mktime(time_ptr);
    printf("now=%d  t1=%d   t2=%d\n", now, t1, t2);
```
One would expect the same date/time output twice with now=t1=t2.
What actually happens is something like
```
date1: Wed, 13 May 2020 06:36:39 GMT
date2: Wed, 13 May 2020 07:36:39 CEST
now=1589351799  t1=1589348199   t2=1589348199
```
This was executed on Wed 13 May 2020 08:36:39 AM CEST. `date2` has been messed up by 
`mktime`. I believe this was the reason for the wrong time I was seeing.

All time related operations (getting, formatting, parsing) were moved to `get_time.c` and are done in a thread safe way. Internally time is stored strictly in UTC epoch (seconds since 1970.01.01) instead of mktime's output, Tests were extended to check this.

(a good read on time in C: http://www.catb.org/esr/time-programming/)

As a byproduct of the time-related fixes I had to touch the simulator and figured out the it doesn't fully work as intended. The major issue was that repeating was triggered by looking for a `?` on the call line, but this we don't have since who knows when as `?` is caught already in `callinput.c` so `logit.c` won't get it.
The code was separated from `background_process` and moved into `cqww_simulator` as this is what it actually does. I kept the funny time-based "random" generators. The countries come in a  barely random order if callmaster file is sorted. It's no problem, one just has to shuffle the file for a different pattern. As a new feature I added a progressive slow down for repeat.
A note on repeat: it's triggered by any message (F-key) but upon completing the logging the state is overwritten to FINAL. I.e. there is no explicit check for F5/F8/F9/F10 that one would typically use for this purpose.

