### PR TITLE
Test logcfg parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -272,7 +272,7 @@
 2018-12-30  Thomas Beierlein <tomjbe@gentoo.org>
 
   * src/searchlog.c: Fix zone display for old behaviour  If multiplier is WAZ
-  or ITU zone the following algorithmus is used:  - First try to pick up the
+  or ITU zone the following algorithm is used:  - First try to pick up the
   zone from the comment string of the selected QSOs. Use the last one found. -
   If no QSO with zoneinfo is found use zone_export (set by getctydata()
   according to the country information.  - If there are a zoneinfo field, but
@@ -327,7 +327,7 @@
   places.  - Adapt checklogfile() for use with logedit() Do not exit program if
   file not found. Use ncurses for all text output.  - Use existing
   checklogfile() to check the log after editing Original code was a copy of
-  that funtion with small adaption wrt text output and errror handling.  Be
+  that funtion with small adaption wrt text output and error handling.  Be
   aware that the functionality is still broken as before.
 
 2018-12-05  zcsahok <ha5cqz@freemail.hu>
@@ -348,7 +348,7 @@
 
   * src/bandmap.c: Fix compiler warning from clang  Calculation the difference
   of two unsigned numbers gives an unsigned result. clang warns that doing an
-  abs() of it makes no sense. Thansk nate N0NB for reporting.
+  abs() of it makes no sense. Thanks Nate N0NB for reporting.
 
 2018-11-03  Nate Bargmann <n0nb@n0nb.us>
 
@@ -741,7 +741,7 @@
 2017-12-02  Thomas Beierlein <tomjbe@gentoo.org>
 
   * src/callinput.c, src/showzones.c, src/time_update.c: move zones display to
-  using panels  Old code blinks zone display in 2s intervall. Tnx for reporting
+  using panels  Old code blinks zone display in 2s interval. Tnx for reporting
   Fred DH5FS.
 
 2017-12-01  zcsahok <ha5cqz@freemail.hu>
@@ -774,7 +774,7 @@
   src/paccdx.c, src/score.c, src/searchlog.c, src/showscore.c, src/tlf.h: Add a
   special OOB out_of_band entry  
   * Tlf normally recognizes the band in use from
-  rigs frequency. If the rig is outside of any band there is a indetermined
+  rigs frequency. If the rig is outside of any band there is a indeterminate
   state resulting in irregular characters on display and possible wrong entries
   into the contest statistics. Tnx to Zoltan Csahok HA5CQZ for pointing out the
   problem. 
@@ -883,11 +883,11 @@
   * src/addcall.c, src/main.c, src/parse_logcfg.c, src/readcalls.c,
   src/searchlog.c, src/tlf.h, tlf.1.in: Added new feature: MINITEST keyword to
   support the Mini CW test  
-  Optional an argument may passed to MINITEST, instean of hardcoded value
+  Optional an argument may passed to MINITEST, instead of hardcoded value
 
 2017-01-30  Thomas Beierlein <tomjbe@gentoo.org>
 
-  * macros/ax_with_curses_extra.m4: Better regocnition of <panel.h>  
+  * macros/ax_with_curses_extra.m4: Better recognition of <panel.h>
   
   If ax_with_ncurses finds a ncursesw instance the former code checks only for
   <ncursesw/panelh>. If not there the search fails. That lead to problems at
@@ -930,7 +930,7 @@
   * src/getpx.c: better implementation of getpx()  
   
   - handles callsigns with only letters 
-  - correct handling of callsigns with long nummbers, e.g. DR2006Q or 9A800VZ
+  - correct handling of callsigns with long numbers, e.g. DR2006Q or 9A800VZ
 
 2017-01-06  Ervin Hegedus <airween@gmail.com>
 
@@ -1028,7 +1028,7 @@
   * src/fldigixmlrpc.c, src/fldigixmlrpc.h, src/stoptx.c: minor changes  
   - rename to 'fldigi_to_rx()' 
   - do not add to a string of unknown length. Send '^r' on separate call 
-    afterwars.
+    afterwards.
 
 2016-11-23  Thomas Beierlein <tomjbe@gentoo.org>
 
@@ -1096,7 +1096,7 @@
 2016-07-18  zcsahok <ha5cqz@freemail.hu>
 
   * src/netkeyer.c, src/netkeyer.h: netkeyer: streamlined (part 2)  - add
-  synthactic sugar - fix buffer overflow
+  syntactic sugar - fix buffer overflow
 
 2016-07-03  zcsahok <ha5cqz@freemail.hu>
 
@@ -1346,7 +1346,7 @@
 
   * src/addmult.c: Tests for empty strings are already handled in
   remember_multi().  Furthermore for-loops tests themself if endcondition is
-  already fullfilled when entered. So we can drop some needless tests.
+  already fulfilled when entered. So we can drop some needless tests.
 
 2015-12-19  Nate Bargmann <n0nb@n0nb.us>
 
@@ -1368,7 +1368,7 @@
   Define
   PACKAGE_DATA_DIR in src/Makefile.am  Automake provides the predefined
   'pkgdatadir' Makefile variable which is the same path as the previously
-  caclulated PACKAGE_DATA_DIR value in configure.ac.  Use it to set
+  calculated PACKAGE_DATA_DIR value in configure.ac.  Use it to set
   PACKAGE_DATA_DIR as a -D value to the preprocessor via AM_CPPFLAGS in
   src/Makefile.am which is passed to the source files during preprocessing. 
   This conforms with current Autotools convention.  As PACKAGE_DATA_DIR is
@@ -1527,7 +1527,7 @@
   WARC) and counting zones and countries for contest bands only. The handling
   can be simplified if we unify the handling and count zones and countries for
   ALL bands. We can then ignore the non WARC entries for contest scoring.
-  Furthermore it is more easy to add additionla bands later.
+  Furthermore it is more easy to add additional bands later.
 
 
 2015-11-28  Nate Bargmann <n0nb@n0nb.us>
@@ -1563,7 +1563,7 @@
 
   * src/bandmap.c: fix calculation of remaining time during bandmap read 
   Lastly spot->timeout got changed to unsigned. We must take care that we do
-  not get a wrap ariund if the diff between writing und reading the bandmap
+  not get a wrap around if the diff between writing und reading the bandmap
   data ist to big.
 
   * src/bandmap.c, src/bandmap.h, src/time_update.c: Fix saving of bandmap data
@@ -1612,7 +1612,7 @@
 
 2015-10-27  Ervin Hegedus <airween@gmail.com>
 
-  * src/callinput.c: Fixed immediated auto_cq bug: if Tlf sends CQ in auto
+  * src/callinput.c: Fixed immediate auto_cq bug: if Tlf sends CQ in auto
   mode, and op press the first letter of callsign, that will be lost
 
 2015-10-25  Thomas Beierlein <tomjbe@gentoo.org>
@@ -1629,7 +1629,7 @@
 2015-10-13  Thomas Beierlein <tomjbe@gentoo.org>
 
   * src/bandmap.c: Cleanup bmdata_read_file  - fix memory leak - close file
-  pointer - restructre parsing loop - simplify
+  pointer - restructure parsing loop - simplify
 
   * src/writecabrillo.c: Close opened file pointers in case of error
 
@@ -1772,7 +1772,7 @@
 
   * src/sendbuf.c, src/sendbuf.h: factor out conversion to short cw numbers
 
-  * src/sendbuf.c, src/setcontest.c: drop contradictionary setting of
+  * src/sendbuf.c, src/setcontest.c: drop contradictory setting of
   shortqsonr for ARLL_SS
 
 2015-05-31  dh5fs <dh5fs@users.noreply.github.com>
@@ -1992,7 +1992,7 @@
   * src/logit.c: Modified automatic cq zone nr copy to comment variable, if
   that's not empty  - If the user modified the exchange field, which was filled
   out by Tlf from cty.dat, then Tlf rewrite the original value if switching
-  bqack forth between call input and comemtn field.
+  back forth between call input and comment field.
 
   * src/getexchange.c, src/makelogline.c: Added extra check for exchange field
   for CQ-WW-RTTY
@@ -2058,7 +2058,7 @@
 2014-08-23  Thomas Beierlein <tomjbe@gentoo.org>
 
   * src/displayit.c, src/displayit.h, src/sendbuf.c, src/sendbuf.h: fix
-  displayit()  - functions relied on termbuf temrinated with newline. Dropped
+  displayit()  - functions relied on termbuf terminated with newline. Dropped
   last character in display if not present.
 
 2014-06-20  Thomas Beierlein <tb@forth-ev.de>
@@ -2586,7 +2586,7 @@
   - In case of errors ask if user want to continue without rig control. 
     Otherwise exit tlf. 
   - If get_frequency fails (maybe because rig is switched off) report
-    frequency as 0.0. Do not change band settings from tranceiver. 
+    frequency as 0.0. Do not change band settings from transceiver.
     (Show and log the actual frequency as 0, meaning no rig control available 
     at the moment)
   - writecabrillo() will insert start-of-band frequency in log calculated from
@@ -2623,7 +2623,7 @@
   included in the tlf directory, and all other documentation references the
   GPL, the reference to 'Library' is presumed to be incorrect.   With the
   concurrance of Tom and Rein, this patch set removes the word 'Library' from
-  the boilerplate in all .c and .h files where it occured.  Include minor Free
+  the boilerplate in all .c and .h files where it occurred.  Include minor Free
   Software Foundation mailing address correction with this patch set.
 
 2013-06-29  Thomas Beierlein <tomjbe@gentoo.org>
@@ -2773,7 +2773,7 @@
 
   * src/parse_logcfg.c: Fix parsing of CALL in logcfg.dat  - drop trailing
   whitespace - for now keep the trailing NL as a lot of code in other parts of
-  tlf rely on that NL cahracter
+  tlf rely on that NL character
 
 2013-01-05  Thomas Beierlein <tomjbe@gentoo.org>
 
@@ -2882,7 +2882,7 @@
     SOUNDCARD was se in logcfg.dat which switches to a soundcard for sidetone 
     output. 
   - Fix for recognition of SIDETONE_VOLUME value (drop trailing \n) 
-  - Allow volume setting independent of choosen sidetone device. 
+  - Allow volume setting independent of chosen sidetone device. 
   - Add information to man page.
 
   * src/callinput.c: Cleanup old code
@@ -3018,7 +3018,7 @@
 
 2012-09-10  Thomas Beierlein <tb@forth-ev.de>
 
-  * src/writecabrillo.c: Basic implemention of 'prepare_line' function  
+  * src/writecabrillo.c: Basic implementation of 'prepare_line' function  
   - format entries according to list of items from QSO: line definition 
   - add entry by entry to linebuffer 
   - !! atm not complete
@@ -3073,7 +3073,7 @@
   - 'read_cabrillo_format' lookup file with needed cabrillo format 
     description in local dir or datadir and parses some keys 
     (atm only 'QSO:') 
-  - QSO: key is splitted into separate items each describing one entry 
+  - QSO: key is split into separate items each describing one entry 
     in cabrillos QSO: line.
     Be aware !! Keywords have to be case sensitive
 
@@ -3142,7 +3142,7 @@
   * doc/Makefile.am, doc/README.cab, share/Makefile.am, share/cabrillo.fmt,
   tlf.1.in: add rudimental files with description of new cabrillo mechanism and
   format specification (needs to be completed). Document new CABRILLO=
-  statement for ruls file.
+  statement for rules file.
 
 2012-08-09  Thomas Beierlein <tb@forth-ev.de>
 
@@ -3194,7 +3194,7 @@
   New log line format in use! At the moment that is incompatible with old log
   files. Back them up before experimenting. Code to migrate old log to new
   format will follow in next days.  
-  - make logline 7 characters longer to accomodate the QRG with one decimal 
+  - make logline 7 characters longer to accommodate the QRG with one decimal
     precision. 
   - record QRG at end of logline if you have the rig online
 
@@ -3297,7 +3297,7 @@
 
 2012-02-28  Thomas Beierlein <tomjbe@gentoo.org>
 
-  * src/parse_logcfg.c: better regognition of unknown keywords in logcfg.dat
+  * src/parse_logcfg.c: better recognition of unknown keywords in logcfg.dat
   and rules file
 
 2012-02-27  Thomas Beierlein <tomjbe@gentoo.org>
@@ -3490,7 +3490,7 @@
 
 2011-11-06  Thomas Beierlein <tomjbe@gentoo.org>
 
-  * src/changefreq.c, src/changefreq.h: hide cursor during frequnecy change
+  * src/changefreq.c, src/changefreq.h: hide cursor during frequency change
 
   * src/callinput.c: Allow edit of old QSO's only if call field is empty
 
@@ -3959,7 +3959,7 @@
 	* fix bug in cty.dat and in the routine which reads in the file
 
 2011-01-08  thomas beierlein <tb@forth-ev.de>
-	* fix logfile read error. Last QSO got reead twice.
+	* fix logfile read error. Last QSO got read twice.
 	* Optimize searchlog() for speed and also optimize partial call
 	  lookup.
 
@@ -3996,7 +3996,7 @@
 2010-01-xx  thomas beierlein <tb@forth-ev.de>
 	* better recognition of hamlib install (tnx F8FCE)
 	* fix a lot of buffer overrun for string handling (as glibc and gcc
-	  use -D_FORTIFY_SOURCE for stricter checking of buffer overuns)
+	  use -D_FORTIFY_SOURCE for stricter checking of buffer overruns)
 	* rewrote handling of initial exchange file. It now allows empty 
 	  and comment lines (#) and spaces around the callsign. Leading 
 	  space before comment gets ignored.
@@ -4036,7 +4036,7 @@
 
 	* fixed bug in callinput.c allowing input of too many characters in call field
 
-	* added TIME_OFFSET to allow running PC on local time instaead of UTC
+	* added TIME_OFFSET to allow running PC on local time instead of UTC
 
 	* added arrl sweepstakes contest with flexible exchange input
 
@@ -4168,7 +4168,7 @@
 
 2002-07-14  Rein Couperus   <rein@couperus.com>
 
-	* edit_last.c:	added instert and delete
+	* edit_last.c:	added insert and delete
 
 	* removed call to tlf_deletelogline
 

--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@ Bug fixes and minor improvements.
 Changes:
     - From TLF-1.3.1 on we can use the CT9 cty.dat files with full call sign
       exceptions (marked by =<call>).
-      Starting from Jan2020 Jim reiser AD1C presents the CT9 format file as
+      Starting from Jan2020 Jim Reiser AD1C presents the CT9 format file as
       default file format for TLF. If you use TLF-1.3.0 or older you should
       look for the old format files.
     - Rework display of partials - more stations displayed, bugs fixed
@@ -111,7 +111,7 @@ Minor corrections:
     - Minor syntax cleanup in code and documentation
 
 Bug fixes:
-    - Fix segement violation if RIGPORT is undefined in logcfg.dat
+    - Fix segmentation violation if RIGPORT is undefined in logcfg.dat
     - Fixes some test programs
     - fix warnigns from clang about taking an abs() from an unsigned number
 
@@ -132,10 +132,10 @@ New features since tlf-1.3.0:
     - Use $SHELL environment setting when opening a shell using '!'
     - Tlf can now reread its own cabrillo files. Tnx HA2OS
     - Changed BMAUTOGRAB to work only in S&P mode 
-    - Most configuration files allow now DOS line endingss. Tnx HA5CQZ
+    - Most configuration files allow now DOS line endings. Tnx HA5CQZ
     - Added documentation for using winkeydaemon. Tnx N0NB
     - Clarify man page text. Tnx N0NB.
-    - Added a Xressource sample file to set colors for xterm. Tnx N0NB
+    - Added a Xresource sample file to set colors for xterm. Tnx N0NB
     - Using fldigi for DIGI mode allows you to pick up call and exchange from
       fldigi program - see doc/README.RTTY. Tnx HA2OS
     - Tlf supports nanoIO interface (https://github.com/w1hkj/nanoIO). Tnx
@@ -156,12 +156,12 @@ Bug fixes:
     - WAE: when QTC was set up as BOTH directions the CABRILLO file was
       created with wrong format
     - Fix parsing of QTC= keyword 
-    - Fix zones display. Old code blinks display in 2s intervalls. 
+    - Fix zones display. Old code blinks display in 2s intervals.
       Tnx Fred DH5FS.
     - Fix a bug during sending a longer series of unanswered CQ's. 
       The cursor sometimes jumped to the exchange field. Tnx Zoltan HA5CQZ
     - Fix bug in BMAUTOGRAB and BMAUTOADD
-    - Do not fallback to 'rxvt' TERM value if tmerinal setting is 
+    - Do not fallback to 'rxvt' TERM value if terminal setting is
       not recognized. xterm-256color should now work. TnX K6BSD
 
 
@@ -183,7 +183,7 @@ New features:
       but will be dropped in next versions).
     - New keyword MINITEST to support Minitest like contests, where you can
       operate the same station each time in one of two or more time
-      intervalls. Tnx HA2OS.
+      intervals. Tnx HA2OS.
     - New multi keyword UNIQUE_CALL_MULTI for Minitest or CWops CWT contest.
       Allows to count unique call signs as multi for all band or per band.
       Tnx HA2OS.
@@ -235,7 +235,7 @@ tlf-1.2.4.2
 Bugfix release.
 
 Bug fixes:
-    - fix some memory and ressource leaks in seldom used functions
+    - fix some memory and resource leaks in seldom used functions
 
 Enhancements:
     - Update and fix spelling errors in man page
@@ -257,7 +257,7 @@ Maintenance and bugfix release.
 
 New features since tlf-1.2.3:
     - Switch hardcoded keyboard handling which supported only xterm, linux 
-      terminal and rxvt to use of ncruses keypad(). That way other terminal
+      terminal and rxvt to use of ncurses keypad(). That way other terminal
       settings should be supported as well (Tnx to Nate N0NB for the work).
     - Extend bandmap functionality. See man page for details
       (tnx to Ervin HA2OS).
@@ -271,7 +271,7 @@ New features since tlf-1.2.3:
 	in S&P by pressing ENTER. 
 
 Bug fixes:
-    - Cleanup some valgrind warnng about possible memory leaks.
+    - Cleanup some valgrind warnings about possible memory leaks.
     - Fix autoconf settings for new lookup of ncurses include files
     - Fix a segmentation fault if we have unexpected long call sign prefixes
 
@@ -281,7 +281,7 @@ Maintenance and bugfix release.
 
 New features since tlf-1.2.2:
     - Support for ARRL 160m contest (tnx N0NB)
-    - Search MULT_LIST file not only in working direxctory but also in 
+    - Search MULT_LIST file not only in working directory but also in
       install directory, e.g. /wusr/local/share/tlf (tnx N0NB)
     - Better calculation of working QRG for RTTY qso's according to the used 
       rig modulations (USB/LSB/FSK) (tnx HA2OS)
@@ -338,7 +338,7 @@ New features:
     - allow a list of stations known to give QTC's (maybe from last year)
 	  QTC_CAP_CALLS=QTC_calls.txt
       If you use this option, then Tlf will put a "P" flag (means "previous") 
-      near known station ifrom the list on bandmap, and in worked window. 
+      near known station from the list on bandmap, and in worked window.
       Eg: 7001.0 * R9AA P
     - new QTC capable flags: 'L': 'later', 'N': 'NO' 
       You can mark a station on the bandmap for QTC "L"ater or "N"o QTC 
@@ -685,7 +685,7 @@ Minor maintenance release.
 
 New features:
     - New doc/README.ssb gives some good hints how to use TLF on SSB contest.
-      Thansk Andy, G4KNO for contributing.
+      Thanks Andy, G4KNO for contributing.
 
 Bug fixes:
     - Fix spelling of unmute command in scripts/play_vk. Tnx G4KNO
@@ -775,7 +775,7 @@ maintenance release
     * fixes some nasty racing condition between bandmap code and 
       checkwindow. In result prefix in lower line of checkwindow
       got displayed wrong, but country was right.
-      Thansk Martin OK1RR for reporting.
+      Thanks Martin OK1RR for reporting.
 
 tlf-1.0.4
 =========
@@ -835,12 +835,12 @@ Bugfixes:
  * make Backspace and Delete-Keys the same to allow some more terminal 
    input encodings
 
-tfl-0.9.31-2
+tlf-0.9.31-2
 ============
 
 'Possible calls' are now in top left corner, and share the space with 
 the keyer. The 'possible calls' routine first checks the own log 
-and then the callmasterdatabase.
+and then the callmaster database.
 Calls can now be up to 12 characters
 
 tlf-0.9.31
@@ -996,7 +996,7 @@ tlf-0.9.18
 ==========
 
 Version 0.9.18 only adds native support for the ten tec ORION, to bridge 
-the time until Hamlib has an approriate driver.
+the time until Hamlib has an appropriate driver.
 Use RIGMODEL=ORION if you have one. This works with or without Hamlib installed.
 Set RIGSPEED=57600.
 The driver uses the internal keyer of the ORION, so you don't need cwdaemon i
@@ -1074,7 +1074,7 @@ tlf-0.9.15
 	This will only work in DIG mode.
 
 - Added experimental :SCAnner function (an idea of OK1RR)
-	The SCAnner funtion combines the Frequency Control function of Hamlib
+	The SCAnner function combines the Frequency Control function of Hamlib
 	with a rudimentary Audio S-Meter/plotter via the sound card. Just 
 	connect the rx output to the soundcard input and you are o.k.
 	Two functions are supported by version 0.9.15:
@@ -1085,7 +1085,7 @@ tlf-0.9.15
 	values are plotted.
 
 	SWR scan function - with a simple noise bridge and a computer 
-	controlled rx as a frequenzy-stepped detector you can plot antenna 
+	controlled rx as a frequency-stepped detector you can plot antenna
 	swr or filter transfer characteristic.
 
 	New parameters for logcfg.dat:
@@ -1142,7 +1142,7 @@ tlf-0.9.8
 - Changed time-to-live default for DX spots to 30 minutes. This can be changed 
   at compile time with the MAXMINUTES constant in cluster_bg.h
 
-- Added station ID to log line when logging from differentl nodes in the 
+- Added station ID to log line when logging from different nodes in the
   network.
   This enables post-contest analysis and log massage after the contest.
   CQWW_M2 must be set in logcfg.dat for this.
@@ -1607,7 +1607,7 @@ Bug/unwanted feature fixes:
 - when call field is empty, is TAB suposed to give a zone?
 
 - when editing last QSO '@', if I go right (with -> key) till end of line,
-  I'm stuck on next line. Acutally, If you enter "ggggggggggggggggggggggggg"
+  I'm stuck on next line. Actually, If you enter "ggggggggggggggggggggggggg"
   past the end of line, it will overflow to the next line. And there's no
   solution to go back (ESC and :edit to fix it though) But the screen looks
   ugly in the mean time.
@@ -1795,7 +1795,7 @@ tlf-0.7.0 beta test version with hamlib-1.1.3 integration
 
  - mode switch :SSB now gives right side band (USB, LSB)
 
- - I need reports on tlf/rig compatability (see Hamlib on source forge for lists)      !!
+ - I need reports on tlf/rig compatibility (see Hamlib on source forge for lists)      !!
 
 
 tlf-0.6.1  beta test version of telnet / tnc support

--- a/doc/FAQ
+++ b/doc/FAQ
@@ -64,6 +64,6 @@ A: You can use 'adifmerg' from OH7BF for it. It allows to post process the
 Q: I am using TLF in an XTerm. How can I configure used colors, fonts and
    window size?
 
-A: You can  can use a .Xressources file in your home directory. See the
-   Xressources example file in the doc directory. Follow the instructions
+A: You can  can use a .Xresources file in your home directory. See the
+   Xresources example file in the doc directory. Follow the instructions
    given there to install it. You can use it also for URxvt terminals.

--- a/test/data.c
+++ b/test/data.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include "../src/globalvars.h"
 #include "../src/tlf.h"
+#include "../src/tlf_curses.h"
 
 #include "test.h"
 
@@ -38,15 +39,28 @@ int portnum = 0;
 
 int use_rxvt = 0;
 int use_xterm = 0;
+int tlfcolors[8][2] = { {COLOR_BLACK, COLOR_WHITE},
+    {COLOR_GREEN, COLOR_YELLOW},
+    {COLOR_WHITE, COLOR_RED},
+    {COLOR_CYAN, COLOR_WHITE},
+    {COLOR_WHITE, COLOR_BLACK},
+    {COLOR_WHITE, COLOR_MAGENTA},
+    {COLOR_BLUE, COLOR_YELLOW},
+    {COLOR_WHITE, COLOR_BLACK}
+};
+
 
 int debugflag = 0;
-char *editor_name = NULL;
+char *editor_cmd = NULL;
 char rttyoutput[120];
 int tune_val = 0;
 int use_bandoutput = 0;
 int no_arrows = 0;
 int bandindexarray[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 int cqwwm2 = 0;
+
+int cwkeyer = NO_KEYER;
+int digikeyer = NO_KEYER;
 
 /* predefined contests */
 int cqww = 0;
@@ -112,6 +126,8 @@ int noautocq = 0;
 int emptydir = 0;
 int verbose = 0;
 int no_rst = 0;			/* 1 - do not use RS/RST */
+int sprint_mode = 0;
+int qtc_recv_lazy = 0;
 
 int pacc_qsos[10][10];
 int ve_cty;
@@ -137,6 +153,7 @@ int multi = 0;			/* 0 = SO , 1 = MOST, 2 = MM */
 int trxmode = CWMODE;
 /* RIG_MODE_NONE in hamlib/rig.h, but if hamlib not compiled, then no dependecy */
 rmode_t rigmode = 0;
+rmode_t digi_mode = 0;
 int mixedmode = 0;
 char sent_rst[4] = "599";
 char recvd_rst[4] = "599";
@@ -162,6 +179,7 @@ char *cabrillo = NULL;		/*< Name of the cabrillo format definition */
 char synclogfile[120];
 char markerfile[120] = "";
 int xplanet = 0;
+char fldigi_url[50] = "http://localhost:7362/RPC2";
 
 char sp_return[80] = " \n";
 char cq_return[80] = " \n";
@@ -266,6 +284,7 @@ int cqdelay = 8;
 char wkeyerbuffer[400];
 int data_ready = 0;
 char keyer_device[10] = "";	// ttyS0, ttyS1, lp0-2
+int keyer_backspace = 0;
 int k_tune;
 int k_pin14;
 int k_ptt;
@@ -308,6 +327,7 @@ char rigportname[40];
 int rignumber = 0;
 int rig_comm_error = 0;
 int rig_comm_success = 0;
+unsigned char rigptt = 0;
 
 /*-------------------------------the log lines-----------------------------*/
 char qsos[MAX_QSOS][LOGLINELEN + 1];

--- a/test/test.h
+++ b/test/test.h
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <string.h>
+#include <stdbool.h>
 
 #include <glib.h>
 

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -1,0 +1,173 @@
+#include "test.h"
+#include <stdio.h>
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "../src/parse_logcfg.h"
+#include "../src/lancode.h"
+#include "../src/bandmap.h"
+#include "../src/qtcvars.h"
+#include "../src/tlf.h"
+#include "../src/globalvars.h"
+
+// OBJECT ../src/parse_logcfg.o
+// OBJECT ../src/get_time.o
+// OBJECT ../src/getpx.o
+// OBJECT ../src/getwwv.o
+// OBJECT ../src/locator2longlat.o
+// OBJECT ../src/score.o
+// OBJECT ../src/qrb.o
+
+extern char *editor_cmd;
+extern int weight;
+
+// lancode.c
+int nodes = 0;
+int node;
+struct sockaddr_in bc_address[MAXNODES];
+int lan_port = 6788;
+int landebug = 0;
+char thisnode = 'A';
+int time_master;
+char bc_hostaddress[MAXNODES][16];
+char bc_hostservice[MAXNODES][16] = {
+    [0 ... MAXNODES - 1] = { [0 ... 15] = 0 }
+};
+
+
+char netkeyer_hostaddress[16] = "127.0.0.1";
+int netkeyer_port = 6789;
+
+bm_config_t bm_config;
+
+extern rig_model_t myrig_model;
+
+char *callmaster_filename = NULL;
+
+int call_update = 0;
+
+t_qtc_ry_line qtc_ry_lines[QTC_RY_LINE_NR];
+
+extern char keyer_device[10];
+extern int partials;
+extern int use_part;
+
+void setcontest() {
+    // TBD
+}
+
+bool fldigi_isenabled(void) {
+    return false;   // TBD
+}
+
+void SetCWSpeed(unsigned int wpm) {
+    // TBD
+}
+
+void fldigi_toggle() {
+    // TBD
+}
+
+void rst_init(char *init_string) {
+    // TBD
+}
+
+int getctydata(char *checkcallptr) {
+    // TBD
+    return 0;
+}
+
+int getctynr(char *checkcall) {
+    // TBD
+    return 0;
+}
+
+int foc_score(char *a) {
+    // TBD
+    return 0;
+}
+
+/* setup/teardown */
+int setup_default(void **state) {
+    *keyer_device = 0;
+    partials = 0;
+    use_part = 0;
+
+    showmsg_spy = STRING_NOT_SET;
+
+    return 0;
+}
+
+int teardown_default(void **state) {
+    return 0;
+}
+
+/*
+    call parse_logcfg with a dynamically allocated string
+    as g_strstip() fails on a statically allocated one
+*/
+static int call_parse_logcfg(const char *input) {
+    char *line = g_strdup(input);
+    int rc = parse_logcfg(line);
+    g_free(line);
+    return rc;
+}
+
+void test_unknown_keyword(void **state) {
+    int rc = call_parse_logcfg("UNKNOWN\r\n");   // DOS line ending
+    assert_int_equal(rc, PARSE_CONFIRM);
+    assert_string_equal(showmsg_spy,
+			"Keyword 'UNKNOWN' not supported. See man page.\n");
+}
+
+void test_logfile(void **state) {
+    int rc = call_parse_logcfg("LOGFILE= mylog\r\n");   // space before arg, DOS line ending
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(logfile, "mylog");
+}
+
+void test_logfile_no_arg(void **state) {
+    int rc = call_parse_logcfg("LOGFILE\r\n");   // DOS line ending
+    assert_int_equal(rc, PARSE_CONFIRM);
+    assert_string_equal(showmsg_spy,
+			"Keyword 'LOGFILE' must be followed by an parameter ('=....'). See man page.\n");
+}
+
+void test_keyer_device(void **state) {
+    int rc = call_parse_logcfg("KEYER_DEVICE =/dev/tty0\r\n");   // space after keyword, DOS line ending
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(keyer_device, "/dev/tty0");
+}
+
+void test_editor(void **state) {
+    int rc = call_parse_logcfg("EDITOR= pico \n");   // space around argument
+    assert_int_equal(rc, 0);
+    assert_string_equal(editor_cmd, "pico");
+}
+
+void test_weight(void **state) {
+    int rc = call_parse_logcfg("WEIGHT=12");    // no line ending
+    assert_int_equal(rc, 0);
+    assert_int_equal(weight, 12);
+}
+
+void test_partials(void **state) {
+    int rc = call_parse_logcfg("  PARTIALS\n");  // leading space
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(partials, 1);
+}
+
+void test_usepartials(void **state) {
+    int rc = call_parse_logcfg("USEPARTIALS  \n");  // trailing space
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(use_part, 1);
+}
+
+void test_usepartials_with_arg(void **state) {
+    int rc = call_parse_logcfg("USEPARTIALS=no\n");
+    assert_int_equal(rc, 0); // FIXME: this should be 1
+}
+
+

--- a/test/test_sendbuf.c
+++ b/test/test_sendbuf.c
@@ -20,8 +20,8 @@ void replace_all(char *buf, int size, const char *what,
 
 
 /* break dependencies */
-int digikeyer = NO_KEYER;
-int cwkeyer = NO_KEYER;
+extern int digikeyer;
+extern int cwkeyer;
 
 extern char message[25][80];
 extern char buffer[];

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1405,7 +1405,7 @@ Show cluster bandmap on startup and set start values for filtering.
 .br
 	\(lqO\(rq - show only multiplier (CQWW only)
 .br
-<number> livetime for new spots in seconds (number >= 30)
+<number> lifetime for new spots in seconds (number >= 30)
 .
 .TP
 .B SCOREWINDOW
@@ -1933,7 +1933,7 @@ Bands not in list are weighted by 1.
 .
 .TP
 .B BANDWEIGHT_MULTIS
-Allow a weigthing factor for multipliers on different bands. E.g.
+Allow a weighting factor for multipliers on different bands. E.g.
 .br
 \fBBANDWEIGHT_MULTIS\fR=\fI80:4,40:3,20:2,15:2,10:2\fR
 .br
@@ -1954,7 +1954,7 @@ list the affected countries:
 \fBPFX_NUM_MULTIS\fR=\fIW,VE,VK,ZL,ZS,JA,PY,UA9\fR.  @PACKAGE_NAME@ will read
 these items, make a lookup in a countrylist for a country code, and that code
 will be used.  If you include the UA9 prefix and then make a QSO with a
-station from Asiatic Russia, the PFX number will evaulated with a new
+station from Asiatic Russia, the PFX number will evaluated with a new
 multiplier, but European Russia will not.
 .
 .TP
@@ -2022,7 +2022,7 @@ If you run Fldigi's xmlrpc server on an different port use
 .TP
 \fBMINITEST \fR[=\fINNN\fR]
 Use this option when the contest is a minitest like contest. In that contests
-the full contest intervall is divided into shorter sections (e.g. 6 * 10
+the full contest interval is divided into shorter sections (e.g. 6 * 10
 minute sections in an hour).  Any station can be worked once in each of the
 time sections without counting as dupe.  The default length of the sections is
 600 seconds (10 minutes), but you can pass another value (in seconds) after
@@ -2040,7 +2040,7 @@ Example:
 The argument tells @PACKAGE_NAME@, how to score the callsigns as multipliers:
 .br
 .B ALL
-means the callsign is a multiplier, independet of band.
+means the callsign is a multiplier, independent of band.
 .br
 .B BAND
 means the callsign counts as multiplier on different bands.
@@ -2105,7 +2105,7 @@ It will take precedence over the system installed
 .IR callmaster .
 .
 .P
-\fISection files\fR contain a flat ASCII database of multpliers like states,
+\fISection files\fR contain a flat ASCII database of multipliers like states,
 sections, provinces, districts, names, ages, etc.  They are invoked by
 including \fBMULT_LIST\fR=\fIsection_file_name\fR in the rules file.
 .


### PR DESCRIPTION
Added test for logfcg parsing function. The goal is to refactor the monolithic switch-case statement into a data driven solution. For this all configs shall be covered with tests. As there are 250+ of them this will take some time. The migration can be done gradually, i.e. the ones tested can be changed to the new approach. This way we can always be sure the all is stable during the process.

The second unrelated commit just fixes some typos caught by ispell.