### PR TITLE
Introduce table driven contest configuration

### DIFF
--- a/src/addcall.c
+++ b/src/addcall.c
@@ -113,7 +113,7 @@ int addcall(void) {
 	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
 	add_ok = 0;
 
-    if ((country_mult == 1) && (universal == 1))
+    if (country_mult == 1 && iscontest)
 	add_ok = 1;
 
     if ((dx_arrlsections == 1)
@@ -290,7 +290,7 @@ int addcall2(void) {
     /* 	     if ((arrldx_usa ==1) && ((j == w_cty) || (j == ve_cty)))
      	     	add_ok = 0;
     */
-    if ((country_mult == 1) && (universal == 1))
+    if ((country_mult == 1) && iscontest)
 	add_ok = 1;
 
     if (IS_CONTEST(PACC_PA))

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -120,7 +120,7 @@ int addcall(void) {
 	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
 	add_ok = 0;
 
-    if (pacc_pa_flg == 1)
+    if (IS_CONTEST(PACC_PA))
 	add_ok = pacc_pa();
 
     // if pfx number as multiplier
@@ -293,7 +293,7 @@ int addcall2(void) {
     if ((country_mult == 1) && (universal == 1))
 	add_ok = 1;
 
-    if (pacc_pa_flg == 1)
+    if (IS_CONTEST(PACC_PA))
 	/* FIXME: Does not work for LAN qso's as pacc_pa uses global variables
 	 * set from foreground task */
 	add_ok = pacc_pa();

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -95,7 +95,7 @@ int addcall(void) {
     if (strlen(comment) >= 1) {		/* remember last exchange */
 	strcpy(worked[i].exchange, comment);
 
-	if (IS_CONTEST(CQWW) || wazmult == 1 || itumult == 1) {
+	if (CONTEST_IS(CQWW) || wazmult == 1 || itumult == 1) {
 	    /*
 	    			if (strlen(zone_fix) > 1) {
 	    				z = zone_nr(zone_fix);
@@ -109,7 +109,7 @@ int addcall(void) {
 
     add_ok = 1;			/* look if certain calls are excluded */
 
-    if (IS_CONTEST(ARRLDX_USA)
+    if (CONTEST_IS(ARRLDX_USA)
 	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
 	add_ok = 0;
 
@@ -120,7 +120,7 @@ int addcall(void) {
 	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
 	add_ok = 0;
 
-    if (IS_CONTEST(PACC_PA))
+    if (CONTEST_IS(PACC_PA))
 	add_ok = pacc_pa();
 
     // if pfx number as multiplier
@@ -281,7 +281,7 @@ int addcall2(void) {
     if (strlen(comment) >= 1) {
 //              strcpy(worked[i].exchange,comment);
 
-	if (IS_CONTEST(CQWW) || wazmult == 1 || itumult == 1)
+	if (CONTEST_IS(CQWW) || wazmult == 1 || itumult == 1)
 	    z = zone_nr(comment);
     }
 
@@ -293,7 +293,7 @@ int addcall2(void) {
     if ((country_mult == 1) && iscontest)
 	add_ok = 1;
 
-    if (IS_CONTEST(PACC_PA))
+    if (CONTEST_IS(PACC_PA))
 	/* FIXME: Does not work for LAN qso's as pacc_pa uses global variables
 	 * set from foreground task */
 	add_ok = pacc_pa();
@@ -389,7 +389,7 @@ int addcall2(void) {
 	    }
 	}
     }
-    if (IS_CONTEST(WPX) || pfxmult == 1 || pfxmultab == 1) {
+    if (CONTEST_IS(WPX) || pfxmult == 1 || pfxmultab == 1) {
 
 	if (lan_logline[68] != ' ') {
 

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -48,6 +48,7 @@
 #include "paccdx.h"
 #include "score.h"
 #include "searchcallarray.h"
+#include "setcontest.h"
 #include "tlf.h"
 #include "zone_nr.h"
 
@@ -388,7 +389,7 @@ int addcall2(void) {
 	    }
 	}
     }
-    if (wpx == 1 || pfxmult == 1 || pfxmultab == 1) {
+    if (IS_CONTEST(WPX) || pfxmult == 1 || pfxmultab == 1) {
 
 	if (lan_logline[68] != ' ') {
 

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -109,7 +109,7 @@ int addcall(void) {
 
     add_ok = 1;			/* look if certain calls are excluded */
 
-    if ((arrldx_usa == 1)
+    if (IS_CONTEST(ARRLDX_USA)
 	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
 	add_ok = 0;
 

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -95,7 +95,7 @@ int addcall(void) {
     if (strlen(comment) >= 1) {		/* remember last exchange */
 	strcpy(worked[i].exchange, comment);
 
-	if ((cqww == 1) || (wazmult == 1) || (itumult == 1)) {
+	if (IS_CONTEST(CQWW) || wazmult == 1 || itumult == 1) {
 	    /*
 	    			if (strlen(zone_fix) > 1) {
 	    				z = zone_nr(zone_fix);
@@ -281,7 +281,7 @@ int addcall2(void) {
     if (strlen(comment) >= 1) {
 //              strcpy(worked[i].exchange,comment);
 
-	if ((cqww == 1) || (wazmult == 1) || (itumult == 1))
+	if (IS_CONTEST(CQWW) || wazmult == 1 || itumult == 1)
 	    z = zone_nr(comment);
     }
 

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -31,6 +31,7 @@
 
 #include "addmult.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "setcontest.h"
 #include "tlf_curses.h"
 #include "bands.h"
 
@@ -52,7 +53,7 @@ int addmult(void) {
     g_strchomp(stripped_comment);
 
     // --------------------------- arrlss ------------------------------------
-    if (arrlss == 1) {
+    if (IS_CONTEST(ARRL_SS)) {
 
 	/* check all possible mults for match and remember the longest one */
 	for (i = 0; i < mults_possible->len; i++) {
@@ -163,7 +164,7 @@ int addmult2(void) {
     shownewmult = -1;
 
     // --------------------------- arrlss ------------------------------------
-    if (arrlss == 1) {
+    if (IS_CONTEST(ARRL_SS)) {
 	g_strlcpy(ssexchange, lan_logline + 54, 21);
 
 	/* check all possible mults for match and remember the longest one */

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -53,7 +53,7 @@ int addmult(void) {
     g_strchomp(stripped_comment);
 
     // --------------------------- arrlss ------------------------------------
-    if (IS_CONTEST(ARRL_SS)) {
+    if (CONTEST_IS(ARRL_SS)) {
 
 	/* check all possible mults for match and remember the longest one */
 	for (i = 0; i < mults_possible->len; i++) {
@@ -164,7 +164,7 @@ int addmult2(void) {
     shownewmult = -1;
 
     // --------------------------- arrlss ------------------------------------
-    if (IS_CONTEST(ARRL_SS)) {
+    if (CONTEST_IS(ARRL_SS)) {
 	g_strlcpy(ssexchange, lan_logline + 54, 21);
 
 	/* check all possible mults for match and remember the longest one */

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -31,6 +31,7 @@
 #include "qtcvars.h"		// Includes globalvars.h
 #include "searchcallarray.h"
 #include "searchlog.h"
+#include "setcontest.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
 #include "getctydata.h"
@@ -343,7 +344,7 @@ void bandmap_addspot(char *call, freq_t freq, char node) {
 
 	lastexch = NULL;
 	dxccindex = getctynr(entry->call);
-	if (cqww == 1) {
+	if (IS_CONTEST(CQWW)) {
 	    // check if the callsign exists in worked list
 	    wi = searchcallarray(call);
 	    if (wi >= 0) {
@@ -448,7 +449,7 @@ bool bm_ismulti(char *call, spot *data, int band) {
 	return false;   // no data
     }
 
-    if (cqww == 1) {
+    if (IS_CONTEST(CQWW)) {
 	if ((zones[data->cqzone] & inxes[band]) == 0
 		|| (countries[data->ctynr] & inxes[band]) == 0) {
 	    return true;

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -344,7 +344,7 @@ void bandmap_addspot(char *call, freq_t freq, char node) {
 
 	lastexch = NULL;
 	dxccindex = getctynr(entry->call);
-	if (IS_CONTEST(CQWW)) {
+	if (CONTEST_IS(CQWW)) {
 	    // check if the callsign exists in worked list
 	    wi = searchcallarray(call);
 	    if (wi >= 0) {
@@ -449,7 +449,7 @@ bool bm_ismulti(char *call, spot *data, int band) {
 	return false;   // no data
     }
 
-    if (IS_CONTEST(CQWW)) {
+    if (CONTEST_IS(CQWW)) {
 	if ((zones[data->cqzone] & inxes[band]) == 0
 		|| (countries[data->ctynr] & inxes[band]) == 0) {
 	    return true;

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -66,6 +66,7 @@
 #include "searchlog.h"		// Includes glib.h
 #include "sendbuf.h"
 #include "sendspcall.h"
+#include "setcontest.h"
 #include "show_help.h"
 #include "showinfo.h"
 #include "showpxmap.h"
@@ -94,7 +95,6 @@ extern int no_arrows;
 extern char hiscall[];
 extern int bandinx;
 extern char band[NBANDS][4];
-extern int dxped;
 extern freq_t freq;
 extern int trx_control;
 extern freq_t bandfrequency[];
@@ -1316,7 +1316,7 @@ void handle_bandswitch(int direction) {
 
     next_band(direction);
 
-    if (iscontest && dxped == 0) {
+    if (iscontest && !IS_CONTEST(DXPED)) {
 	while (IsWarcIndex(bandinx)) {	/* loop till next contest band */
 	    next_band(direction);
 	}

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -124,7 +124,6 @@ int callinput(void) {
     extern int zonedisplay;
     extern int showscore_flag;
     extern int searchflg;
-    extern int cqww;
     extern char cqzone[];
     extern char ituzone[];
     extern int ctcomp;
@@ -307,7 +306,7 @@ int callinput(void) {
 		} else {
 
 		    if (strlen(hiscall) > 2) {
-			if (((cqww == 1) || (wazmult == 1))
+			if ((IS_CONTEST(CQWW) || (wazmult == 1))
 				&& (*comment == '\0'))
 			    strcpy(comment, cqzone);
 
@@ -792,7 +791,7 @@ int callinput(void) {
 
 	    // Alt-z (M-z), show zones worked.
 	    case ALT_Z: {
-		if (cqww == 1) {
+		if (IS_CONTEST(CQWW)) {
 		    if (zonedisplay == 0)
 			zonedisplay = 1;
 		    else {

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -306,7 +306,7 @@ int callinput(void) {
 		} else {
 
 		    if (strlen(hiscall) > 2) {
-			if ((IS_CONTEST(CQWW) || (wazmult == 1))
+			if ((CONTEST_IS(CQWW) || (wazmult == 1))
 				&& (*comment == '\0'))
 			    strcpy(comment, cqzone);
 
@@ -791,7 +791,7 @@ int callinput(void) {
 
 	    // Alt-z (M-z), show zones worked.
 	    case ALT_Z: {
-		if (IS_CONTEST(CQWW)) {
+		if (CONTEST_IS(CQWW)) {
 		    if (zonedisplay == 0)
 			zonedisplay = 1;
 		    else {
@@ -1315,7 +1315,7 @@ void handle_bandswitch(int direction) {
 
     next_band(direction);
 
-    if (iscontest && !IS_CONTEST(DXPED)) {
+    if (iscontest && !CONTEST_IS(DXPED)) {
 	while (IsWarcIndex(bandinx)) {	/* loop till next contest band */
 	    next_band(direction);
 	}

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -429,7 +429,7 @@ int changepars(void) {
 	    break;
 	}
 	case 34: {		/* SIMULATOR  */
-	    if (!IS_CONTEST(CQWW)) {
+	    if (!CONTEST_IS(CQWW)) {
 		TLF_LOG_INFO(
 		    "Simulator mode is only supported for CQWW contest!");
 		break;
@@ -788,7 +788,7 @@ void multiplierinfo(void) {
 
     wipe_display();
 
-    if (IS_CONTEST(ARRL_SS)) {
+    if (CONTEST_IS(ARRL_SS)) {
 	int attributes;
 	char chmult[6];
 	char ch2mult[6];
@@ -831,7 +831,7 @@ void multiplierinfo(void) {
     }
 
     if (serial_section_mult == 1 || sectn_mult_once
-	    || (sectn_mult == 1 && !IS_CONTEST(ARRL_SS))) {
+	    || (sectn_mult == 1 && !CONTEST_IS(ARRL_SS))) {
 	char *tmp;
 	int worked_at;
 

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -778,7 +778,6 @@ void networkinfo(void) {
 
 void multiplierinfo(void) {
 
-    extern int arrlss;
     extern int serial_section_mult;
     extern int sectn_mult;
     extern mults_t multis[MAX_MULTS];
@@ -789,7 +788,7 @@ void multiplierinfo(void) {
 
     wipe_display();
 
-    if (arrlss == 1) {
+    if (IS_CONTEST(ARRL_SS)) {
 	int attributes;
 	char chmult[6];
 	char ch2mult[6];
@@ -832,7 +831,7 @@ void multiplierinfo(void) {
     }
 
     if (serial_section_mult == 1 || sectn_mult_once
-	    || (sectn_mult == 1 && arrlss != 1)) {
+	    || (sectn_mult == 1 && !IS_CONTEST(ARRL_SS))) {
 	char *tmp;
 	int worked_at;
 

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -54,6 +54,7 @@
 #include "rules.h"
 #include "scroll_log.h"
 #include "searchlog.h"
+#include "setcontest.h"
 #include "sendbuf.h"
 #include "set_tone.h"
 #include "show_help.h"
@@ -428,7 +429,7 @@ int changepars(void) {
 	    break;
 	}
 	case 34: {		/* SIMULATOR  */
-	    if (cqww != 1) {
+	    if (!IS_CONTEST(CQWW)) {
 		TLF_LOG_INFO(
 		    "Simulator mode is only supported for CQWW contest!");
 		break;

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -144,12 +144,12 @@ void clear_display(void) {
 	mvaddstr(12, 49, recvd_rst);
     }
 
-    if (IS_CONTEST(CQWW)) {
+    if (CONTEST_IS(CQWW)) {
 	attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 	mvaddstr(12, 54, comment);
     }
 
-    if (IS_CONTEST(ARRLDX_USA)) {
+    if (CONTEST_IS(ARRLDX_USA)) {
 	attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 	mvaddstr(12, 54, comment);
     }

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -37,6 +37,7 @@
 #include "printcall.h"
 #include "qsonr_to_str.h"
 #include "searchlog.h"		// Includes glib.h
+#include "setcontest.h"
 #include "showscore.h"
 #include "time_update.h"
 #include "tlf_curses.h"
@@ -82,7 +83,6 @@ void clear_display(void) {
     extern int bandinx;
     extern int trxmode;
     extern char qsonrstr[];
-    extern int cqww;
     extern int arrldx_usa;
     extern char comment[];
     extern int searchflg;
@@ -145,7 +145,7 @@ void clear_display(void) {
 	mvaddstr(12, 49, recvd_rst);
     }
 
-    if (cqww == 1) {
+    if (IS_CONTEST(CQWW)) {
 	attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 	mvaddstr(12, 54, comment);
     }

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -83,7 +83,6 @@ void clear_display(void) {
     extern int bandinx;
     extern int trxmode;
     extern char qsonrstr[];
-    extern int arrldx_usa;
     extern char comment[];
     extern int searchflg;
     extern char whichcontest[];
@@ -150,7 +149,7 @@ void clear_display(void) {
 	mvaddstr(12, 54, comment);
     }
 
-    if (arrldx_usa == 1) {
+    if (IS_CONTEST(ARRLDX_USA)) {
 	attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 	mvaddstr(12, 54, comment);
     }

--- a/src/focm.c
+++ b/src/focm.c
@@ -31,7 +31,6 @@
 #include "bands.h"
 
 
-extern int focm;
 extern int showscore_flag;
 extern int searchflg;
 extern int total;
@@ -50,10 +49,11 @@ int cntry;
 int cont;
 
 
-/** Initialize settings for FOC contest */
-void foc_init(void) {
-    focm = 1;
-}
+/** FOC contest configuration */
+contest_config_t config_focm = {
+    .id = FOCMARATHON,
+    .name = "FOCMARATHON"
+};
 
 
 /** calculate score for last QSO

--- a/src/focm.h
+++ b/src/focm.h
@@ -21,7 +21,9 @@
 #ifndef _FOC_H
 #define _FOC_H
 
-extern int got_g4foc; 		/* did we got Gx4FOC on the air? */
+#include "tlf.h"
+
+extern contest_config_t config_focm;
 
 void foc_init(void);
 int foc_score(char *call);

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -31,6 +31,7 @@
 #include "dxcc.h"
 #include "getpx.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "setcontest.h"
 
 /* check for calls which have no assigned country and no assigned zone,
  * e.g. airborn mobile /AM or maritime mobile /MM
@@ -228,7 +229,7 @@ static int getctydata_internal(char *checkcallptr, bool get_country) {
 
     w = getpfxindex(checkcallptr, &normalized_call);
 
-    if (wpx == 1 || pfxmult == 1)
+    if (IS_CONTEST(WPX) || pfxmult == 1)
 	/* needed for wpx and other pfx contests */
 	getpx(normalized_call);
 

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -229,7 +229,7 @@ static int getctydata_internal(char *checkcallptr, bool get_country) {
 
     w = getpfxindex(checkcallptr, &normalized_call);
 
-    if (IS_CONTEST(WPX) || pfxmult == 1)
+    if (CONTEST_IS(WPX) || pfxmult == 1)
 	/* needed for wpx and other pfx contests */
 	getpx(normalized_call);
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -45,6 +45,7 @@
 #include "score.h"
 #include "searchlog.h"		// Includes glib.h
 #include "sendbuf.h"
+#include "setcontest.h"
 #include "speedupndown.h"
 #include "stoptx.h"
 #include "time_update.h"
@@ -72,7 +73,6 @@ int getexchange(void) {
     extern char hiscall[];
     extern char qsonrstr[];
     extern int cqww;
-    extern int wpx;
     extern int pacc_pa_flg;
     extern int stewperry_flg;
     extern int arrldx_usa;
@@ -396,7 +396,7 @@ int getexchange(void) {
 
 	    }
 
-	    if (wpx == 1) {	/* align serial nr. */
+	    if (IS_CONTEST(WPX)) {	/* align serial nr. */
 
 		if ((strlen(comment) == 1) || (comment[1] == ' ')) {
 		    strcpy(commentbuf, comment);

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -79,7 +79,6 @@ int getexchange(void) {
     extern int arrl_fd;
     extern int exchange_serial;
     extern int countrynr;
-    extern int sprint;
     extern int trxmode;
     extern int recall_mult;
     extern int arrlss;
@@ -414,7 +413,7 @@ int getexchange(void) {
 
 	    }
 
-	    if (sprint == 1) {
+	    if (IS_CONTEST(SPRINT)) {
 
 		if ((comment[1] == ' ') && (comment[0] != ' ')) {
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -74,7 +74,6 @@ int getexchange(void) {
     extern char qsonrstr[];
     extern int cqww;
     extern int pacc_pa_flg;
-    extern int stewperry_flg;
     extern int arrldx_usa;
     extern int arrl_fd;
     extern int exchange_serial;
@@ -135,7 +134,7 @@ int getexchange(void) {
 	strcpy(comment, continent);
     }
 
-    if (stewperry_flg == 1) {
+    if (IS_CONTEST(STEWPERRY)) {
 	recall_exchange();
     }
 
@@ -368,7 +367,7 @@ int getexchange(void) {
 		(sectn_mult_once == 1) ||
 		(arrlss == 1) ||
 		(cqww == 1) ||
-		(stewperry_flg == 1)) {
+		IS_CONTEST(STEWPERRY)) {
 
 	    x = checkexchange(x);
 	}
@@ -477,7 +476,7 @@ int getexchange(void) {
 		break;
 //                              x = 0; //##debug
 
-	    } else if (stewperry_flg == 1) {
+	    } else if (IS_CONTEST(STEWPERRY)) {
 		if (check_qra(comment) == 0) {
 		    mvprintw(13, 54, "locator?");
 		    mvprintw(12, 54, comment);
@@ -532,7 +531,6 @@ int checkexchange(int x) {
     extern char ssexchange[];
     extern int cqww;
     extern int arrlss;
-    extern int stewperry_flg;
     extern char section[];
     extern char callupdate[];
     extern char hiscall[];

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -72,7 +72,6 @@ int getexchange(void) {
     extern char ph_message[14][80];
     extern char hiscall[];
     extern char qsonrstr[];
-    extern int cqww;
     extern int pacc_pa_flg;
     extern int arrldx_usa;
     extern int arrl_fd;
@@ -122,7 +121,7 @@ int getexchange(void) {
     if (arrl_fd == 1)
 	recall_exchange();
 
-    if (((cqww == 1) || (wazmult == 1) || (itumult == 1))
+    if ((IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1))
 	    && (*comment == '\0') && (strlen(hiscall) != 0)) {
 	if (itumult == 1)
 	    strcpy(comment, ituzone);
@@ -366,7 +365,7 @@ int getexchange(void) {
 		(sectn_mult == 1) ||
 		(sectn_mult_once == 1) ||
 		(arrlss == 1) ||
-		(cqww == 1) ||
+		IS_CONTEST(CQWW) ||
 		IS_CONTEST(STEWPERRY)) {
 
 	    x = checkexchange(x);
@@ -484,7 +483,7 @@ int getexchange(void) {
 		}
 		refreshp();
 		break;
-	    } else if (cqww == 1 && trxmode == DIGIMODE && ((countrynr == w_cty)
+	    } else if (IS_CONTEST(CQWW) && trxmode == DIGIMODE && ((countrynr == w_cty)
 		       || (countrynr == ve_cty))) {
 		if (strlen(comment) < 5) {
 		    mvprintw(13, 54, "state/prov?");
@@ -529,7 +528,6 @@ int checkexchange(int x) {
 
     extern char comment[];
     extern char ssexchange[];
-    extern int cqww;
     extern int arrlss;
     extern char section[];
     extern char callupdate[];
@@ -666,7 +664,7 @@ int checkexchange(int x) {
     }
 
     // -----------------------------------cqww-----------------------
-    if (cqww == 1) {
+    if (IS_CONTEST(CQWW)) {
 
 	s = atoi(comment);
 	snprintf(zone, sizeof(zone), "%02d", s);

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -73,7 +73,6 @@ int getexchange(void) {
     extern char hiscall[];
     extern char qsonrstr[];
     extern int pacc_pa_flg;
-    extern int arrldx_usa;
     extern int arrl_fd;
     extern int exchange_serial;
     extern int countrynr;
@@ -115,7 +114,7 @@ int getexchange(void) {
     if (recall_mult == 1)
 	recall_exchange();
 
-    if ((arrldx_usa == 1) && (trxmode != CWMODE))
+    if (IS_CONTEST(ARRLDX_USA) && trxmode != CWMODE)
 	recall_exchange();
 
     if (arrl_fd == 1)

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -72,7 +72,6 @@ int getexchange(void) {
     extern char ph_message[14][80];
     extern char hiscall[];
     extern char qsonrstr[];
-    extern int pacc_pa_flg;
     extern int exchange_serial;
     extern int countrynr;
     extern int trxmode;
@@ -430,7 +429,7 @@ int getexchange(void) {
 
 	    }
 
-	    if ((pacc_pa_flg == 1) && (countrynr != my.countrynr)) {
+	    if (IS_CONTEST(PACC_PA) && (countrynr != my.countrynr)) {
 		if (strlen(comment) == 1) {
 		    strcpy(commentbuf, comment);
 		    comment[0] = '\0';

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -111,13 +111,13 @@ int getexchange(void) {
     if (recall_mult == 1)
 	recall_exchange();
 
-    if (IS_CONTEST(ARRLDX_USA) && trxmode != CWMODE)
+    if (CONTEST_IS(ARRLDX_USA) && trxmode != CWMODE)
 	recall_exchange();
 
-    if (IS_CONTEST(ARRL_FD))
+    if (CONTEST_IS(ARRL_FD))
 	recall_exchange();
 
-    if ((IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1))
+    if ((CONTEST_IS(CQWW) || (wazmult == 1) || (itumult == 1))
 	    && (*comment == '\0') && (strlen(hiscall) != 0)) {
 	if (itumult == 1)
 	    strcpy(comment, ituzone);
@@ -129,7 +129,7 @@ int getexchange(void) {
 	strcpy(comment, continent);
     }
 
-    if (IS_CONTEST(STEWPERRY)) {
+    if (CONTEST_IS(STEWPERRY)) {
 	recall_exchange();
     }
 
@@ -360,9 +360,9 @@ int getexchange(void) {
 		(dx_arrlsections == 1) ||
 		(sectn_mult == 1) ||
 		(sectn_mult_once == 1) ||
-		IS_CONTEST(ARRL_SS) ||
-		IS_CONTEST(CQWW) ||
-		IS_CONTEST(STEWPERRY)) {
+		CONTEST_IS(ARRL_SS) ||
+		CONTEST_IS(CQWW) ||
+		CONTEST_IS(STEWPERRY)) {
 
 	    x = checkexchange(x);
 	}
@@ -389,7 +389,7 @@ int getexchange(void) {
 
 	    }
 
-	    if (IS_CONTEST(WPX)) {	/* align serial nr. */
+	    if (CONTEST_IS(WPX)) {	/* align serial nr. */
 
 		if ((strlen(comment) == 1) || (comment[1] == ' ')) {
 		    strcpy(commentbuf, comment);
@@ -407,7 +407,7 @@ int getexchange(void) {
 
 	    }
 
-	    if (IS_CONTEST(SPRINT)) {
+	    if (CONTEST_IS(SPRINT)) {
 
 		if ((comment[1] == ' ') && (comment[0] != ' ')) {
 
@@ -429,7 +429,7 @@ int getexchange(void) {
 
 	    }
 
-	    if (IS_CONTEST(PACC_PA) && (countrynr != my.countrynr)) {
+	    if (CONTEST_IS(PACC_PA) && (countrynr != my.countrynr)) {
 		if (strlen(comment) == 1) {
 		    strcpy(commentbuf, comment);
 		    comment[0] = '\0';
@@ -446,7 +446,7 @@ int getexchange(void) {
 
 	    }
 
-	    if (IS_CONTEST(ARRL_SS) && (x != TAB) && (strlen(section) < 2)) {
+	    if (CONTEST_IS(ARRL_SS) && (x != TAB) && (strlen(section) < 2)) {
 		mvprintw(13, 54, "section?");
 		mvprintw(12, 54, comment);
 		x = 0;
@@ -471,7 +471,7 @@ int getexchange(void) {
 		break;
 //                              x = 0; //##debug
 
-	    } else if (IS_CONTEST(STEWPERRY)) {
+	    } else if (CONTEST_IS(STEWPERRY)) {
 		if (check_qra(comment) == 0) {
 		    mvprintw(13, 54, "locator?");
 		    mvprintw(12, 54, comment);
@@ -479,7 +479,7 @@ int getexchange(void) {
 		}
 		refreshp();
 		break;
-	    } else if (IS_CONTEST(CQWW) && trxmode == DIGIMODE && ((countrynr == w_cty)
+	    } else if (CONTEST_IS(CQWW) && trxmode == DIGIMODE && ((countrynr == w_cty)
 		       || (countrynr == ve_cty))) {
 		if (strlen(comment) < 5) {
 		    mvprintw(13, 54, "state/prov?");
@@ -659,7 +659,7 @@ int checkexchange(int x) {
     }
 
     // -----------------------------------cqww-----------------------
-    if (IS_CONTEST(CQWW)) {
+    if (CONTEST_IS(CQWW)) {
 
 	s = atoi(comment);
 	snprintf(zone, sizeof(zone), "%02d", s);
@@ -721,7 +721,7 @@ int checkexchange(int x) {
     }
 
     // ---------------------------arrls------------------------------
-    if (IS_CONTEST(ARRL_SS)) {
+    if (CONTEST_IS(ARRL_SS)) {
 
 	// get serial nr.
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -77,7 +77,6 @@ int getexchange(void) {
     extern int countrynr;
     extern int trxmode;
     extern int recall_mult;
-    extern int arrlss;
     extern int lan_active;
     extern char lastqsonr[];
     extern char qsonrstr[];
@@ -362,7 +361,7 @@ int getexchange(void) {
 		(dx_arrlsections == 1) ||
 		(sectn_mult == 1) ||
 		(sectn_mult_once == 1) ||
-		(arrlss == 1) ||
+		IS_CONTEST(ARRL_SS) ||
 		IS_CONTEST(CQWW) ||
 		IS_CONTEST(STEWPERRY)) {
 
@@ -448,7 +447,7 @@ int getexchange(void) {
 
 	    }
 
-	    if ((arrlss == 1) && (x != TAB) && (strlen(section) < 2)) {
+	    if (IS_CONTEST(ARRL_SS) && (x != TAB) && (strlen(section) < 2)) {
 		mvprintw(13, 54, "section?");
 		mvprintw(12, 54, comment);
 		x = 0;
@@ -526,7 +525,6 @@ int checkexchange(int x) {
 
     extern char comment[];
     extern char ssexchange[];
-    extern int arrlss;
     extern char section[];
     extern char callupdate[];
     extern char hiscall[];
@@ -724,7 +722,7 @@ int checkexchange(int x) {
     }
 
     // ---------------------------arrls------------------------------
-    if (arrlss == 1) {
+    if (IS_CONTEST(ARRL_SS)) {
 
 	// get serial nr.
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -73,7 +73,6 @@ int getexchange(void) {
     extern char hiscall[];
     extern char qsonrstr[];
     extern int pacc_pa_flg;
-    extern int arrl_fd;
     extern int exchange_serial;
     extern int countrynr;
     extern int trxmode;
@@ -117,7 +116,7 @@ int getexchange(void) {
     if (IS_CONTEST(ARRLDX_USA) && trxmode != CWMODE)
 	recall_exchange();
 
-    if (arrl_fd == 1)
+    if (IS_CONTEST(ARRL_FD))
 	recall_exchange();
 
     if ((IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1))

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -110,7 +110,6 @@ extern int addcallarea;
 extern int addcty;
 extern char zone_fix[];
 extern int universal;
-extern int arrl_fd;
 extern int one_point;
 extern int two_point;
 extern int three_point;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -44,7 +44,6 @@ extern char hiscall[20];
 extern int total;
 extern int band_score[NBANDS];		// QSO/band
 extern int zones[MAX_ZONES];
-extern int arrlss;
 extern int serial_section_mult;
 extern int serial_grid4_mult;
 extern int sectn_mult;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -107,7 +107,6 @@ extern int wazmult;
 extern int addcallarea;
 extern int addcty;
 extern char zone_fix[];
-extern int universal;
 extern int one_point;
 extern int two_point;
 extern int three_point;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -63,7 +63,6 @@ extern int ve_cty;
 extern int pfxmult;
 extern int pfxmultab;
 extern int minute_timer;
-extern int stewperry_flg;
 extern int unique_call_multi;
 
 extern char logline_edit[5][LOGLINELEN + 1];

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -116,7 +116,6 @@ extern int arrl_fd;
 extern int one_point;
 extern int two_point;
 extern int three_point;
-extern int dxped;
 extern int addzone;
 extern int do_cabrillo;
 extern rmode_t digi_mode;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -37,7 +37,7 @@ extern int bandinx;			// band we're currently working on
 
 extern char logfile[];
 extern bool iscontest;
-extern int cqww;
+
 extern int arrldx_usa;
 extern int pacc_pa_flg;
 extern int country_mult;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -6,6 +6,7 @@
 #include "tlf.h"
 
 extern mystation_t my;			// all about my station
+extern char whichcontest[];
 extern contest_config_t *contest;	// contest configuration
 
 extern char qsos[MAX_QSOS][LOGLINELEN + 1];

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -6,6 +6,7 @@
 #include "tlf.h"
 
 extern mystation_t my;			// all about my station
+extern contest_config_t *contest;	// contest configuration
 
 extern char qsos[MAX_QSOS][LOGLINELEN + 1];
 					// array of log lines of QSOs so far;
@@ -86,7 +87,7 @@ extern char ssexchange[];
 extern int shownewmult;
 extern char comment[];
 
-extern char  lan_logline[];
+extern char lan_logline[];
 extern char logfile[];
 extern char qsonrstr[];
 extern int lan_mutex;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -38,7 +38,6 @@ extern int bandinx;			// band we're currently working on
 extern char logfile[];
 extern bool iscontest;
 
-extern int arrldx_usa;
 extern int pacc_pa_flg;
 extern int country_mult;
 extern char hiscall[20];

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -38,7 +38,6 @@ extern int bandinx;			// band we're currently working on
 extern char logfile[];
 extern bool iscontest;
 
-extern int pacc_pa_flg;
 extern int country_mult;
 extern char hiscall[20];
 extern int total;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -45,7 +45,6 @@ extern char hiscall[20];
 extern int total;
 extern int band_score[NBANDS];		// QSO/band
 extern int zones[MAX_ZONES];
-extern int wpx;
 extern int arrlss;
 extern int serial_section_mult;
 extern int serial_grid4_mult;

--- a/src/logit.c
+++ b/src/logit.c
@@ -103,7 +103,7 @@ void logit(void) {
 
 	    if (callreturn == '\n' && strlen(hiscall) >= 3) {
 		if ((*comment == '\0') && iscontest
-			&& !ctcomp && !IS_CONTEST(DXPED))
+			&& !ctcomp && !CONTEST_IS(DXPED))
 		    defer_store = 0;
 
 		if ((cqmode == CQ) && iscontest
@@ -118,7 +118,7 @@ void logit(void) {
 
 		    set_simulator_state(FINAL);
 
-		    if (IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1)) {
+		    if (CONTEST_IS(CQWW) || (wazmult == 1) || (itumult == 1)) {
 
 			if (recall_exchange() == -1) {
 			    if (itumult == 1)
@@ -141,7 +141,7 @@ void logit(void) {
 		if ((cqmode == S_P) && iscontest
 			&& (defer_store == 0)) {	/* S&P mode */
 
-		    if (IS_CONTEST(CQWW)) {
+		    if (CONTEST_IS(CQWW)) {
 			if (strlen(comment) == 0 && recall_exchange() == -1)
 			    strcpy(comment, cqzone);	/* fill in the zone */
 

--- a/src/logit.c
+++ b/src/logit.c
@@ -38,6 +38,7 @@
 #include "printcall.h"
 #include "recall_exchange.h"
 #include "searchlog.h"		// Includes glib.h
+#include "setcontest.h"
 #include "sendbuf.h"
 #include "sendqrg.h"
 #include "sendspcall.h"
@@ -67,7 +68,6 @@ void logit(void) {
     extern int itumult;
     extern int qsonum;
     extern int exchange_serial;
-    extern int dxped;
     extern int sprint_mode;
 
     int callreturn = 0;
@@ -104,7 +104,7 @@ void logit(void) {
 
 	    if (callreturn == '\n' && strlen(hiscall) >= 3) {
 		if ((*comment == '\0') && iscontest
-			&& !ctcomp && !dxped)
+			&& !ctcomp && !IS_CONTEST(DXPED))
 		    defer_store = 0;
 
 		if ((cqmode == CQ) && iscontest

--- a/src/logit.c
+++ b/src/logit.c
@@ -58,7 +58,6 @@ void logit(void) {
     extern cqmode_t cqmode;
     extern char ph_message[14][80];
     extern char comment[];
-    extern int cqww;
     extern char cqzone[];
     extern char itustr[];
     extern int defer_store;
@@ -119,7 +118,7 @@ void logit(void) {
 
 		    set_simulator_state(FINAL);
 
-		    if ((cqww == 1) || (wazmult == 1) || (itumult == 1)) {
+		    if (IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1)) {
 
 			if (recall_exchange() == -1) {
 			    if (itumult == 1)
@@ -142,7 +141,7 @@ void logit(void) {
 		if ((cqmode == S_P) && iscontest
 			&& (defer_store == 0)) {	/* S&P mode */
 
-		    if (cqww == 1) {
+		    if (IS_CONTEST(CQWW)) {
 			if (strlen(comment) == 0 && recall_exchange() == -1)
 			    strcpy(comment, cqzone);	/* fill in the zone */
 

--- a/src/main.c
+++ b/src/main.c
@@ -100,7 +100,6 @@ bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest = &config_qso;	/* contest configuration */
 
 /* predefined contests */
-int pacc_pa_flg = 0;
 int sprint_mode = 0;
 int minitest = 0;	/**< if set, length of minitest period in seconds */
 int unique_call_multi = 0;          /* do we count calls as multiplier */

--- a/src/main.c
+++ b/src/main.c
@@ -101,7 +101,6 @@ contest_config_t *contest = &config_qso;	/* contest configuration */
 
 /* predefined contests */
 int cqww = 0;
-int wpx = 0;
 int dxped = 0;
 int sprint = 0;
 int arrldx_usa = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -100,7 +100,6 @@ bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest = &config_qso;	/* contest configuration */
 
 /* predefined contests */
-int arrl_fd = 0;
 int arrlss = 0;
 int pacc_pa_flg = 0;
 int sprint_mode = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -105,7 +105,6 @@ int arrldx_usa = 0;
 int arrl_fd = 0;
 int arrlss = 0;
 int pacc_pa_flg = 0;
-int stewperry_flg = 0;
 int focm = 0;
 int sprint_mode = 0;
 int minitest = 0;	/**< if set, length of minitest period in seconds */

--- a/src/main.c
+++ b/src/main.c
@@ -101,7 +101,6 @@ contest_config_t *contest = &config_qso;	/* contest configuration */
 
 /* predefined contests */
 int cqww = 0;
-int sprint = 0;
 int arrldx_usa = 0;
 int arrl_fd = 0;
 int arrlss = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -56,12 +56,13 @@
 #include "scroll_log.h"
 #include "searchlog.h"		// Includes glib.h
 #include "sendqrg.h"
+#include "setcontest.h"
 #include "set_tone.h"
 #include "splitscreen.h"
 #include "startmsg.h"
 #include "tlf_panel.h"
-#include "ui_utils.h"
 #include "readcabrillo.h"
+#include "ui_utils.h"
 
 #include <config.h>
 
@@ -93,6 +94,10 @@ int use_bandoutput = 0;
 int no_arrows = 0;
 int bandindexarray[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 int cqwwm2 = 0;
+
+char whichcontest[40] = "qso";
+bool iscontest = false;		/* false =  General,  true  = contest */
+contest_config_t *contest = &config_qso;	/* contest configuration */
 
 /* predefined contests */
 int cqww = 0;
@@ -199,11 +204,10 @@ int searchflg = 0;		/* 1  = display search  window */
 int show_time = 0;
 cqmode_t cqmode = CQ;
 int demode = 0;			/* 1 =  send DE  before s&p call  */
-bool iscontest = false;		/* false =  General,  true  = contest */
+
 int announcefilter = FILTER_ANN; /*  filter cluster  announcements */
 int showscore_flag = 0;		/* show  score window */
 char exchange[40];
-char whichcontest[40] = "qso";
 int defer_store = 0;
 mystation_t my;			/* all info about me */
 //char call[20];

--- a/src/main.c
+++ b/src/main.c
@@ -100,7 +100,6 @@ bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest = &config_qso;	/* contest configuration */
 
 /* predefined contests */
-int arrlss = 0;
 int pacc_pa_flg = 0;
 int sprint_mode = 0;
 int minitest = 0;	/**< if set, length of minitest period in seconds */

--- a/src/main.c
+++ b/src/main.c
@@ -104,7 +104,6 @@ int sprint_mode = 0;
 int minitest = 0;	/**< if set, length of minitest period in seconds */
 int unique_call_multi = 0;          /* do we count calls as multiplier */
 
-int universal = 0;
 
 int addcallarea;
 int pfxmult = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -100,7 +100,6 @@ bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest = &config_qso;	/* contest configuration */
 
 /* predefined contests */
-int cqww = 0;
 int arrldx_usa = 0;
 int arrl_fd = 0;
 int arrlss = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -100,7 +100,6 @@ bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest = &config_qso;	/* contest configuration */
 
 /* predefined contests */
-int arrldx_usa = 0;
 int arrl_fd = 0;
 int arrlss = 0;
 int pacc_pa_flg = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -101,7 +101,6 @@ contest_config_t *contest = &config_qso;	/* contest configuration */
 
 /* predefined contests */
 int cqww = 0;
-int dxped = 0;
 int sprint = 0;
 int arrldx_usa = 0;
 int arrl_fd = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -105,7 +105,6 @@ int arrldx_usa = 0;
 int arrl_fd = 0;
 int arrlss = 0;
 int pacc_pa_flg = 0;
-int focm = 0;
 int sprint_mode = 0;
 int minitest = 0;	/**< if set, length of minitest period in seconds */
 int unique_call_multi = 0;          /* do we count calls as multiplier */

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -240,7 +240,7 @@ void prepare_specific_part(void) {
     char grid[7] = "";
     int i;
 
-    if (arrlss == 1) {
+    if (IS_CONTEST(ARRL_SS)) {
 	// ----------------------------arrlss----------------
 	strncat(logline4, ssexchange, 22);
 	section[0] = '\0';

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -397,7 +397,7 @@ void prepare_specific_part(void) {
 
 	fillto(77);
 
-    } else if (pacc_pa_flg == 1 || pfxnummultinr > 0) {
+    } else if (IS_CONTEST(PACC_PA) || pfxnummultinr > 0) {
 
 	logline4[68] = '\0';
 

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -346,7 +346,7 @@ void prepare_specific_part(void) {
 
 	//----------------------------------end cqww-----------------
 
-    } else if (arrldx_usa == 1) {
+    } else if (IS_CONTEST(ARRLDX_USA)) {
 	logline4[68] = '\0';
 	if (addcty != 0) {
 	    strncat(logline4, dxcc_by_index(addcty) -> pfx, 9);

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -63,7 +63,7 @@ void makelogline(void) {
     int points;
 
     /* restart band timer if qso on new band */
-    if (IS_CONTEST(WPX)) {		// 10 minute timer
+    if (CONTEST_IS(WPX)) {		// 10 minute timer
 	if (lastbandinx != bandinx) {
 	    lastbandinx = bandinx;
 	    minute_timer = 600;	// 10 minutes
@@ -86,7 +86,7 @@ void makelogline(void) {
     points = score();			/* update qso's per band and score */
     total = total + points;
 
-    if (iscontest && !IS_CONTEST(DXPED)) {
+    if (iscontest && !CONTEST_IS(DXPED)) {
 	sprintf(logline4 + 76, "%2d", points);
     }
 
@@ -240,7 +240,7 @@ void prepare_specific_part(void) {
     char grid[7] = "";
     int i;
 
-    if (IS_CONTEST(ARRL_SS)) {
+    if (CONTEST_IS(ARRL_SS)) {
 	// ----------------------------arrlss----------------
 	strncat(logline4, ssexchange, 22);
 	section[0] = '\0';
@@ -269,7 +269,7 @@ void prepare_specific_part(void) {
 	strncat(logline4, comment, 22);
 	section[0] = '\0';
 
-    } else if (IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1)) {
+    } else if (CONTEST_IS(CQWW) || (wazmult == 1) || (itumult == 1)) {
 	//-------------------------cqww----------------
 	/*
 		if (strlen(zone_fix) > 1) {
@@ -277,7 +277,7 @@ void prepare_specific_part(void) {
 		} else
 			strcat (logline4, zone_export);
 	*/
-	if (trxmode == DIGIMODE && IS_CONTEST(CQWW) && strlen(comment) < 5) {
+	if (trxmode == DIGIMODE && CONTEST_IS(CQWW) && strlen(comment) < 5) {
 	    comment[2] = ' ';
 	    comment[3] = 'D';
 	    comment[4] = 'X';
@@ -300,7 +300,7 @@ void prepare_specific_part(void) {
 	new_pfx = (add_pfx(pxstr, bandinx) == 0);	/* add prefix, remember if new */
     }
 
-    if (IS_CONTEST(WPX) ||pfxmult == 1 || pfxmultab == 1) {	/* wpx */
+    if (CONTEST_IS(WPX) ||pfxmult == 1 || pfxmultab == 1) {	/* wpx */
 	if (new_pfx) {
 	    /** \todo FIXME: prefix can be longer than 5 char, e.g. LY1000 */
 	    strncat(logline4, pxstr, 5);
@@ -309,7 +309,7 @@ void prepare_specific_part(void) {
 	fillto(73);
     }
 
-    if (IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1)) {
+    if (CONTEST_IS(CQWW) || (wazmult == 1) || (itumult == 1)) {
 	/* ------------cqww --------------------- */
 	logline4[68] = '\0';
 
@@ -346,7 +346,7 @@ void prepare_specific_part(void) {
 
 	//----------------------------------end cqww-----------------
 
-    } else if (IS_CONTEST(ARRLDX_USA)) {
+    } else if (CONTEST_IS(ARRLDX_USA)) {
 	logline4[68] = '\0';
 	if (addcty != 0) {
 	    strncat(logline4, dxcc_by_index(addcty) -> pfx, 9);
@@ -397,7 +397,7 @@ void prepare_specific_part(void) {
 
 	fillto(77);
 
-    } else if (IS_CONTEST(PACC_PA) || pfxnummultinr > 0) {
+    } else if (CONTEST_IS(PACC_PA) || pfxnummultinr > 0) {
 
 	logline4[68] = '\0';
 

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -86,7 +86,7 @@ void makelogline(void) {
     points = score();			/* update qso's per band and score */
     total = total + points;
 
-    if (iscontest && (dxped == 0)) {
+    if (iscontest && !IS_CONTEST(DXPED)) {
 	sprintf(logline4 + 76, "%2d", points);
     }
 

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -34,6 +34,7 @@
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "qsonr_to_str.h"
 #include "score.h"
+#include "setcontest.h"
 
 
 void prepare_fixed_part(void);
@@ -62,7 +63,7 @@ void makelogline(void) {
     int points;
 
     /* restart band timer if qso on new band */
-    if (wpx == 1) {		// 10 minute timer
+    if (IS_CONTEST(WPX)) {		// 10 minute timer
 	if (lastbandinx != bandinx) {
 	    lastbandinx = bandinx;
 	    minute_timer = 600;	// 10 minutes
@@ -299,7 +300,7 @@ void prepare_specific_part(void) {
 	new_pfx = (add_pfx(pxstr, bandinx) == 0);	/* add prefix, remember if new */
     }
 
-    if (wpx == 1 || pfxmult == 1 || pfxmultab == 1) {			/* wpx */
+    if (IS_CONTEST(WPX) ||pfxmult == 1 || pfxmultab == 1) {	/* wpx */
 	if (new_pfx) {
 	    /** \todo FIXME: prefix can be longer than 5 char, e.g. LY1000 */
 	    strncat(logline4, pxstr, 5);

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -414,7 +414,7 @@ void prepare_specific_part(void) {
 
 	fillto(77);
 
-    } else if ((universal == 1)
+    } else if (iscontest
 	       && ((country_mult == 1) || (dx_arrlsections == 1))) {
 
 	logline4[68] = '\0';

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -269,7 +269,7 @@ void prepare_specific_part(void) {
 	strncat(logline4, comment, 22);
 	section[0] = '\0';
 
-    } else if ((cqww == 1) || (wazmult == 1) || (itumult == 1)) {
+    } else if (IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1)) {
 	//-------------------------cqww----------------
 	/*
 		if (strlen(zone_fix) > 1) {
@@ -277,7 +277,7 @@ void prepare_specific_part(void) {
 		} else
 			strcat (logline4, zone_export);
 	*/
-	if (trxmode == DIGIMODE && cqww == 1 && strlen(comment) < 5) {
+	if (trxmode == DIGIMODE && IS_CONTEST(CQWW) && strlen(comment) < 5) {
 	    comment[2] = ' ';
 	    comment[3] = 'D';
 	    comment[4] = 'X';
@@ -309,7 +309,7 @@ void prepare_specific_part(void) {
 	fillto(73);
     }
 
-    if ((cqww == 1) || (wazmult == 1) || (itumult == 1)) {
+    if (IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1)) {
 	/* ------------cqww --------------------- */
 	logline4[68] = '\0';
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -245,7 +245,6 @@ int parse_logcfg(char *inputbuffer) {
     extern int time_master;
     extern char multsfile[];
     extern int multlist;
-    extern int universal;
     extern int serial_section_mult;
     extern int serial_grid4_mult;
     extern int sectn_mult;
@@ -730,12 +729,10 @@ int parse_logcfg(char *inputbuffer) {
 	}
 	case 22: {
 	    one_point = 1;
-	    universal = 1;
 	    break;
 	}
 	case 23: {
 	    three_point = 1;
-	    universal = 1;
 	    break;
 	}
 	case 24: {
@@ -1090,14 +1087,12 @@ int parse_logcfg(char *inputbuffer) {
 	}
 	case 86: {
 	    two_point = 1;
-	    universal = 1;
 	    break;
 	}
 	case 87: {
 	    PARAMETER_NEEDED(teststring);
 	    g_strlcpy(multsfile, g_strchomp(fields[1]), 80);
 	    multlist = 1;
-	    universal = 1;
 	    break;
 	}
 	case 88: {

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "bandmap.h"
 #include "change_rst.h"
@@ -48,6 +49,13 @@
 #include <config.h>
 
 
+extern bool mixedmode;
+extern bool ignoredupe;
+extern bool continentlist_only;
+extern int continentlist_points;
+extern int lan_port;
+extern char rigconf[];
+extern char ph_message[14][80];
 extern int cwkeyer;
 extern int digikeyer;
 extern int keyer_backspace;
@@ -56,72 +64,118 @@ extern int use_part;
 extern int portnum;
 extern int packetinterface;
 extern int tncport;
+extern char tncportname[];
 extern int shortqsonr;
 extern char *cabrillo;
 extern rmode_t digi_mode;
 extern int ctcomp;
+extern int recall_mult;
+extern int trx_control;
+extern int rit;
+extern int showscore_flag;
+extern int searchflg;
+extern int demode;
+extern int portable_x2;
+extern int landebug;
+extern int call_update;
+extern int nob4;
+extern int time_master;
+extern int show_time;
+extern int use_rxvt;
+extern int exc_cont;
+extern int noautocq;
+extern int bmautoadd;
+extern int bmautograb;
+extern int logfrequency;
+extern int no_rst;
+extern int serial_or_section;
+extern int sprint_mode;
+extern int sc_sidetone;
+extern int no_arrows;
+extern int lowband_point_mult;
+extern int cluster;
+extern int clusterlog;
+extern char keyer_device[10];
+extern int timeoffset;
+extern int netkeyer_port;
+extern char netkeyer_hostaddress[];
+extern char *rigportname;
+extern int tnc_serial_rate;
+extern int serial_rate;
+extern char pr_hostaddress[];
+extern char *editor_cmd;
+extern int cqdelay;
+extern int ssbpoints;
+extern int cwpoints;
+extern int tlfcolors[8][2];
+extern char whichcontest[];
+extern int use_bandoutput;
+extern int bandindexarray[];
+extern int txdelay;
+extern char tonestr[];
+extern int weight;
+extern int nodes;
+extern char bc_hostaddress[MAXNODES][16];
+extern char bc_hostservice[MAXNODES][16];
+extern rig_model_t myrig_model;
+extern int multlist;
+extern char multsfile[];
+extern char markerfile[];
+extern int xplanet;
+extern char countrylist[][6];
+extern bool mult_side;
+extern int countrylist_points;
+extern bool countrylist_only;
+extern int my_country_points;
+extern int my_cont_points;
+extern int dx_cont_points;
+extern char synclogfile[];
+extern char sc_device[40];
+extern char sc_volume[];
+extern char controllerport[80];	// port for multi-mode controller
+extern char clusterlogin[];
+extern int cw_bandwidth;
+extern char exchange_list[40];
+extern char modem_mode[];
+extern char rttyoutput[];
+extern float fixedmult;
+extern char continent_multiplier_list[7][3];
+extern int bandweight_points[NBANDS];
+extern int bandweight_multis[NBANDS];
+extern pfxnummulti_t pfxnummulti[MAXPFXNUMMULT];
+extern int pfxnummultinr;
+extern int exclude_multilist_type;
+#ifdef HAVE_LIBXMLRPC
+extern char fldigi_url[50];
+#endif
+extern unsigned char rigptt;
 
 bool exist_in_country_list();
 
-void KeywordRepeated(char *keyword);
-void KeywordNotSupported(char *keyword);
-void ParameterNeeded(char *keyword);
-void WrongFormat(char *keyword);
+void KeywordNotSupported(const char *keyword);
+void ParameterNeeded(const char *keyword);
+void ParameterUnexpected(const char *keyword);
+void WrongFormat(const char *keyword);
+void WrongFormat_details(const char *keyword, const char *details);
 
-#define  MAX_COMMANDS (sizeof(commands) / sizeof(*commands))	/* commands in list */
+static char *error_details = NULL;
 
+#define LOGCFG_DAT_FILE    "logcfg.dat"
 
 int read_logcfg(void) {
 
-    extern int nodes;
-    extern int node;
     extern char *config_file;
 
-    char defltconf[80];
-
-    int status;
-    int i;
+    static char defltconf[] = PACKAGE_DATA_DIR "/" LOGCFG_DAT_FILE;
     FILE *fp;
 
-    iscontest = false;
-    partials = 0;
-    use_part = 0;
-    cwkeyer = NO_KEYER;
-    digikeyer = NO_KEYER;
-    portnum = 0;
-    packetinterface = 0;
-    tncport = 0;
-    nodes = 0;
-    node = 0;
-    shortqsonr = 0;
-
-    /* Disable CT Mode until CTCOMPATIBLE is defined. */
-    ctcomp = 0;
-
-    for (i = 0; i < 25; i++) {
-	if (digi_message[i] != NULL) {
-	    free(digi_message[i]);
-	    digi_message[i] = NULL;
-	}
-    }
-    if (cabrillo != NULL) {
-	free(cabrillo);
-	cabrillo = NULL;
-    }
-
-    strcpy(defltconf, PACKAGE_DATA_DIR);
-    strcat(defltconf, "/logcfg.dat");
-
     if (config_file == NULL)
-	config_file = g_strdup("logcfg.dat");
+	config_file = g_strdup(LOGCFG_DAT_FILE);
 
     if ((fp = fopen(config_file, "r")) == NULL) {
 	if ((fp = fopen(defltconf, "r")) == NULL) {
 	    showmsg("Error opening logcfg.dat file.");
-	    showmsg("Exiting...");
-	    sleep(5);
-	    endwin();
-	    exit(1);
+	    return PARSE_ERROR;
 	} else {
 	    showstring("Using default (Read Only) config file:", defltconf);
 	}
@@ -129,18 +183,14 @@ int read_logcfg(void) {
     } else
 	showstring("Reading config file:", config_file);
 
-    status = parse_configfile(fp);
+    int status = parse_configfile(fp);
     fclose(fp);
 
     return status;
 }
 
 static bool isCommentLine(char *buffer) {
-    if ((buffer[0] != '#') && (buffer[0] != ';') && (strlen(buffer) > 1)) {
-	return false;
-    } else {
-	return true;
-    }
+    return buffer[0] == 0 || buffer[0] == '#' || buffer[0] == ';';
 }
 
 int parse_configfile(FILE *fp) {
@@ -148,450 +198,1152 @@ int parse_configfile(FILE *fp) {
     char buffer[160];
 
     while (fgets(buffer, sizeof(buffer), fp) != NULL) {
-	/* skip comments and empty lines */
-	if (!isCommentLine(buffer)) {
-	    status |= parse_logcfg(buffer);
+	g_strchug(buffer);              // remove leading space
+	if (isCommentLine(buffer)) {    // skip comments and empty lines
+	    continue;
+	}
+
+	status = parse_logcfg(buffer);
+	if (status != PARSE_OK) {
+	    break;
 	}
     }
 
     return status;
 }
 
-/** convert band string into index number (0..NBANDS-1) */
+/** convert band string into index number (0..NBANDS-2) */
+// note: NBANDS-1 is the OOB
 int getidxbybandstr(char *confband) {
-    static char bands_strings[NBANDS][4] = {"160", "80", "60", "40", "30", "20", "17", "15", "12", "10"};
-    int i;
+    char buf[8];
 
     g_strchomp(confband);
 
-    for (i = 0; i < NBANDS; i++) {
-	if (strcmp(confband, g_strchomp(bands_strings[i])) == 0) {
+    for (int i = 0; i < NBANDS - 1; i++) {
+	strcpy(buf, band[i]);
+	if (strcmp(confband, g_strchug(buf)) == 0) {
 	    return i;
 	}
     }
     return -1;
 }
 
+////////////////////
+// global variables for matcher functions:
+GMatchInfo *match_info;
+const char *parameter;
 
-static int confirmation_needed;
+static int parse_int(const char *string, gint64 min, gint64 max, int *result) {
+
+    gchar *str = g_strdup(string);
+    g_strstrip(str);
+
+    if (str[0] == 0) {  // empty input
+	g_free(str);
+	return PARSE_INVALID_INTEGER;
+    }
+
+    gchar *end_ptr = NULL;
+    errno = 0;
+    gint64 value = g_ascii_strtoll(str, &end_ptr, 10);
+
+    if ((errno != 0 && errno != ERANGE)
+	    || end_ptr == NULL || *end_ptr != 0) {
+
+	g_free(str);
+	return PARSE_INVALID_INTEGER;
+    }
+
+    g_free(str);
+
+    if (errno == ERANGE || value < min || value > max) {
+	return PARSE_INTEGER_OUT_OF_RANGE;
+    }
+
+    *result = (int)value;
+    return PARSE_OK;
+}
+
+int cfg_bool_const(const cfg_arg_t arg) {
+    *arg.bool_p = arg.bool_value;
+    return PARSE_OK;
+}
+
+int cfg_int_const(const cfg_arg_t arg) {
+    *arg.int_p  = arg.int_value;
+    return PARSE_OK;
+}
+
+int cfg_integer(const cfg_arg_t arg) {
+    return parse_int(parameter, (gint64)arg.min, (gint64)arg.max, arg.int_p);
+}
+
+//
+// static: char_p, size > 0, base not used
+// dynamic: char_pp, size optional, base optional
+// message: msg, size > 0, base used
+//
+int cfg_string(const cfg_arg_t arg) {
+    gchar *index = g_match_info_fetch(match_info, 1);
+    int n = 0;
+    if (NULL != index) {
+	n = atoi(index);    // use provided index
+	g_free(index);
+    }
+
+    char *str = g_strdup(parameter);
+    // chomp/strip
+    if (arg.chomp) {
+	g_strchomp(str);
+    }
+    if (arg.strip) {
+	g_strstrip(str);
+    }
+    // check length
+    if (arg.size > 0 && strlen(str) >= arg.size) {
+	g_free(str);
+	return PARSE_STRING_TOO_LONG;
+    }
+    // replace trailing newline with a space
+    if (arg.nl_to_space) {
+	char *nl = strrchr(str, '\n');
+	if (nl) {
+	    *nl = ' ';
+	}
+    }
+
+    // store value
+    switch (arg.string_type) {
+	case STATIC:
+	    g_strlcpy(arg.char_p, str, arg.size);
+	    g_free(str);
+	    break;
+	case MESSAGE:
+	    g_strlcpy(arg.msg[arg.base + n], str, arg.size);
+	    g_free(str);
+	    break;
+	case DYNAMIC:
+	    if (arg.char_pp[arg.base + n] != NULL) {
+		g_free(arg.char_pp[arg.base + n]);
+	    }
+	    arg.char_pp[arg.base + n] = str;
+    }
+    return PARSE_OK;
+}
+
+static int cfg_telnetport(const cfg_arg_t arg) {
+    int rc = cfg_integer((cfg_arg_t) {.int_p = &portnum, .min = 1, .max = INT32_MAX});
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    packetinterface = TELNET_INTERFACE;
+    return PARSE_OK;
+}
+
+// define colors: GREEN (header), CYAN (windows), WHITE (log win),
+//  MAGENTA (marker / dupes), BLUE (input field) and YELLOW (window frames)
+static int cfg_tlfcolor(const cfg_arg_t arg) {
+    gchar *index = g_match_info_fetch(match_info, 1);
+    int n = atoi(index);    // get index (1..6)
+    g_free(index);
+
+    int rc = PARSE_OK;
+    char *str = g_strdup(parameter);
+    g_strstrip(str);
+
+    if (strlen(str) == 2 && isdigit(str[0]) && isdigit(str[1])) {
+	if (n >= 2) {
+	    ++n; // skip RED
+	}
+	tlfcolors[n][0] = str[0] - '0';
+	tlfcolors[n][1] = str[1] - '0';
+    } else {
+	error_details = g_strdup("must be a 2 digit octal number");
+	rc = PARSE_WRONG_PARAMETER;
+    }
+
+    g_free(str);
+
+    return rc;
+}
+
+static int cfg_call(const cfg_arg_t arg) {
+    int rc = cfg_string((cfg_arg_t) {
+	.char_p = my.call, .size = 20 - 1, // keep space for NL
+	.strip = true, .string_type = STATIC
+    });
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    if (strlen(my.call) <= 2) {
+	error_details = g_strdup("too short");
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    /* as other code parts rely on a trailing NL on the call
+     * we add it back for now */
+    strcat(my.call, "\n");
+
+    // TODO: look it up cty database and set lat/lon
+
+    return PARSE_OK;
+}
+
+static int cfg_contest(const cfg_arg_t arg) {
+    char contest[41];
+    int rc = cfg_string((cfg_arg_t) {
+	.char_p = contest, .size = 40, .strip = true, .string_type = STATIC
+    });
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    setcontest(contest);
+    return PARSE_OK;
+}
+
+static int cfg_bandoutput(const cfg_arg_t arg) {
+    char *str = g_strdup(parameter);
+    g_strstrip(str);
+
+    int rc = PARSE_OK;
+
+    if (g_regex_match_simple("^\\d{10}$", str, G_REGEX_CASELESS,
+			     (GRegexMatchFlags)0)) {
+	use_bandoutput = 1;
+	for (int i = 0; i <= 9; i++) {	// 10x
+	    bandindexarray[i] = str[i] - '0';
+	}
+    } else {
+	error_details = g_strdup_printf("must be %d digits", NBANDS);
+	rc = PARSE_WRONG_PARAMETER;
+    }
 
 
-#define PARAMETER_NEEDED(x) 			\
-    do {					\
-	if (fields[1] == NULL) { 		\
-	    ParameterNeeded(x); 		\
-    	    g_strfreev( fields );		\
-	    return( confirmation_needed ); 				\
-	}					\
-    } while(0)
+    g_free(str);
+
+    return rc;
+}
+
+static int cfg_n_points(const cfg_arg_t arg) {
+    gchar *keyword = g_match_info_fetch(match_info, 0);
+
+    if (g_str_has_prefix(keyword, "ONE")) {
+	one_point = 1;
+    } else if (g_str_has_prefix(keyword, "TWO")) {
+	two_point = 1;
+    } else if (g_str_has_prefix(keyword, "THREE")) {
+	three_point = 1;
+    }
+
+    g_free(keyword);
+
+    return PARSE_OK;
+}
+
+static int cfg_bandmap(const cfg_arg_t arg) {
+    cluster = MAP;
+
+    /* init bandmap filtering */
+    bm_config.allband = 1;
+    bm_config.allmode = 1;
+    bm_config.showdupes = 1;
+    bm_config.skipdupes = 0;
+    bm_config.livetime = 900;
+    bm_config.onlymults = 0;
+
+    /* Allow configuration of bandmap display if keyword
+     * is followed by a '='
+     * Parameter format is BANDMAP=<xxx>,<number>
+     * <xxx> - string parsed for the letters B, M, D and S
+     * <number> - spot livetime in seconds (>=30)
+     */
+    if (parameter != NULL) {
+	char **bm_fields = g_strsplit(parameter, ",", 2);
+	if (bm_fields[0] != NULL) {
+	    char *ptr = bm_fields[0];
+	    while (*ptr != '\0') {
+		switch (*ptr++) {
+		    case 'B': bm_config.allband = 0;
+			break;
+		    case 'M': bm_config.allmode = 0;
+			break;
+		    case 'D': bm_config.showdupes = 0;
+			break;
+		    case 'S': bm_config.skipdupes = 1;
+			break;
+		    case 'O': bm_config.onlymults = 1;
+			break;
+		    default:
+			break;
+		}
+	    }
+	}
+
+	if (bm_fields[1] != NULL) {
+	    int livetime;
+	    g_strstrip(bm_fields[1]);
+	    livetime = atoi(bm_fields[1]);
+	    if (livetime >= 30)
+		/* aging called each second */
+		bm_config.livetime = livetime;
+	}
+
+
+	g_strfreev(bm_fields);
+    }
+
+    return PARSE_OK;
+}
+
+static int cfg_cwspeed(const cfg_arg_t arg) {
+    int value;
+    int rc = cfg_integer((cfg_arg_t) {.int_p = &value, .min = 6, .max = 60});
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    SetCWSpeed(value);
+    return PARSE_OK;
+}
+
+static int cfg_cwtone(const cfg_arg_t arg) {
+    int value;
+    int rc = cfg_integer((cfg_arg_t) {.int_p = &value, .min = 0, .max = 999});
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    sprintf(tonestr, "%d", value);
+    return PARSE_OK;
+}
+
+static int cfg_sunspots(const cfg_arg_t arg) {
+    int value;
+    int rc = cfg_integer((cfg_arg_t) {.int_p = &value, .min = 0, .max = 1000});
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    wwv_set_r(value);
+    return PARSE_OK;
+}
+
+static int cfg_sfi(const cfg_arg_t arg) {
+    int value;
+    int rc = cfg_integer((cfg_arg_t) {.int_p = &value, .min = 0, .max = 1000});
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    wwv_set_sfi(value);
+    return PARSE_OK;
+}
+
+static int cfg_tncport(const cfg_arg_t arg) {
+    // FIXME remove tncport, keep tncportname only
+    if (strlen(parameter) > 2) {
+	strncpy(tncportname, parameter, 39);
+    } else
+	tncport = atoi(parameter) + 1;
+
+    packetinterface = TNC_INTERFACE;
+    return PARSE_OK;
+}
+
+static int cfg_addnode(const cfg_arg_t arg) {
+    if (nodes >= MAXNODES) {
+	error_details = g_strdup_printf("max %d nodes allowed", MAXNODES);
+	return PARSE_WRONG_PARAMETER;
+    }
+    /* split host name and port number, separated by colon */
+    char **an_fields;
+    an_fields = g_strsplit(parameter, ":", 2);
+    /* copy host name */
+    g_strlcpy(bc_hostaddress[nodes], g_strchomp(an_fields[0]),
+	      sizeof(bc_hostaddress[0]));
+    if (an_fields[1] != NULL) {
+	/* copy host port, if found */
+	g_strlcpy(bc_hostservice[nodes], g_strchomp(an_fields[1]),
+		  sizeof(bc_hostservice[0]));
+    }
+    g_strfreev(an_fields);
+
+    nodes++;
+    lan_active = 1;
+
+    return PARSE_OK;
+}
+
+static int cfg_thisnode(const cfg_arg_t arg) {
+    char *str = g_ascii_strup(parameter, -1);
+    g_strstrip(str);
+
+    if (strlen(str) != 1 || str[0] < 'A' || str[0] > 'A' + MAXNODES) {
+	g_free(str);
+	error_details = g_strdup_printf("name name is A..%c", 'A' + MAXNODES - 1);
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    thisnode = str[0];
+
+    g_free(str);
+    return PARSE_OK;
+}
+
+static int cfg_mult_list(const cfg_arg_t arg) {
+    int rc = cfg_string((cfg_arg_t) {
+	.char_p = multsfile, .size = 80, .strip = true, .string_type = STATIC
+    });
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    multlist = 1;
+    return PARSE_OK;
+}
+
+static int cfg_markers(const cfg_arg_t arg) {
+    int rc = cfg_string((cfg_arg_t) {
+	.char_p = markerfile, .size = 120, .strip = true, .string_type = STATIC
+    });
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+
+    gchar *type = g_match_info_fetch(match_info, 1);
+    if (strcmp(type, "") == 0) {
+	xplanet = 1;
+    } else if (strcmp(type, "DOT") == 0) {
+	xplanet = 2;
+    } else if (strcmp(type, "CALL") == 0) {
+	xplanet = 3;
+    }
+    g_free(type);
+    return PARSE_OK;
+}
+
+static int cfg_dx_n_sections(const cfg_arg_t arg) {
+    dx_arrlsections = 1;
+    setcontest(whichcontest);
+    return PARSE_OK;
+}
+
+static int cfg_countrylist(const cfg_arg_t arg) {
+    /* FIXME: why "use only first COUNTRY_LIST definition" ? */
+    /*static*/ char country_list_raw[50] = "";
+    char temp_buffer[255] = "";
+    char buffer[255] = "";
+    FILE *fp;
+
+    if (strlen(country_list_raw) == 0) {/* only if first definition */
+
+	/* First of all we are checking if the parameter <xxx> in
+	COUNTRY_LIST=<xxx> is a file name.  If it is we start
+	parsing the file. If we  find a line starting with our
+	case insensitive contest name, we copy the countries from
+	that line into country_list_raw.
+	If the input was not a file name we directly copy it into
+	country_list_raw (must not have a preceeding contest name). */
+
+	g_strlcpy(temp_buffer, parameter, sizeof(temp_buffer));
+	g_strchomp(temp_buffer);	/* drop trailing whitespace */
+
+	if ((fp = fopen(temp_buffer, "r")) != NULL) {
+
+	    while (fgets(buffer, sizeof(buffer), fp) != NULL) {
+
+		g_strchomp(buffer);   /* no trailing whitespace*/
+
+		/* accept only a line starting with the contest name
+		 * (CONTEST=) followed by ':' */
+		if (strncasecmp(buffer, whichcontest,
+				strlen(whichcontest) - 1) == 0) {
+
+		    strncpy(country_list_raw,
+			    buffer + strlen(whichcontest) + 1,
+			    strlen(buffer) - 1);
+		}
+	    }
+
+	    fclose(fp);
+	} else {	/* not a file */
+
+	    if (strlen(temp_buffer) > 0)
+		strcpy(country_list_raw, temp_buffer);
+	}
+    }
+
+    /* parse the country_list_raw string into an array
+     * (countrylist) for future use. */
+    char *tk_ptr = strtok(country_list_raw, ":,.- \t");
+    int counter = 0;
+
+    if (tk_ptr != NULL) {
+	while (tk_ptr) {
+	    strcpy(countrylist[counter], tk_ptr);
+	    tk_ptr = strtok(NULL, ":,.-_\t ");
+	    counter++;  //FIXME: check index and clean not touched records
+	}
+    }
+
+    /* on which multiplier side of the rules we are */
+    getpx(my.call);
+    mult_side = exist_in_country_list();
+    setcontest(whichcontest);
+
+    return PARSE_OK;
+}
+
+static int cfg_continentlist(const cfg_arg_t arg) {
+    /* based on LZ3NY code, by HA2OS
+       CONTINENT_LIST   (in file or listed in logcfg.dat),
+       First of all we are checking if inserted data in
+       CONTINENT_LIST= is a file name.  If it is we start
+       parsing the file. If we got our case insensitive contest name,
+       we copy the multipliers from it into multipliers_list.
+       If the input was not a file name we directly copy it into
+       cont_multiplier_list (must not have a preceeding contest name).
+       The last step is to parse the multipliers_list into an array
+       (continent_multiplier_list) for future use.
+     */
+
+    /* use only first CONTINENT_LIST definition */
+    /*static*/ char cont_multiplier_list[50] = "";
+    char temp_buffer[255] = "";
+    char buffer[255] = "";
+    FILE *fp;
+
+    if (strlen(cont_multiplier_list) == 0) {	/* if first definition */
+	g_strlcpy(temp_buffer, parameter, sizeof(temp_buffer));
+	g_strchomp(temp_buffer);	/* drop trailing whitespace */
+
+	if ((fp = fopen(temp_buffer, "r")) != NULL) {
+
+	    while (fgets(buffer, sizeof(buffer), fp) != NULL) {
+
+		g_strchomp(buffer);   /* no trailing whitespace*/
+
+		/* accept only a line starting with the contest name
+		 * (CONTEST=) followed by ':' */
+		if (strncasecmp(buffer, whichcontest,
+				strlen(whichcontest) - 1) == 0) {
+
+		    strncpy(cont_multiplier_list,
+			    buffer + strlen(whichcontest) + 1,
+			    strlen(buffer) - 1);
+		}
+	    }
+
+	    fclose(fp);
+	} else {	/* not a file */
+
+	    if (strlen(temp_buffer) > 0)
+		strcpy(cont_multiplier_list, temp_buffer);
+	}
+    }
+
+    /* creating the array */
+    char *tk_ptr = strtok(cont_multiplier_list, ":,.- \t");
+    int counter = 0;
+
+    if (tk_ptr != NULL) {
+	while (tk_ptr) {
+	    strncpy(continent_multiplier_list[counter], tk_ptr, 2);
+	    tk_ptr = strtok(NULL, ":,.-_\t ");
+	    counter++;  // FIXME check range + clean + value length check
+	}
+    }
+
+    setcontest(whichcontest);
+
+    return PARSE_OK;
+}
+
+static int cfg_country_list_only(const cfg_arg_t arg) {
+    countrylist_only = true;
+    if (mult_side) {
+	countrylist_only = false;
+    }
+    return PARSE_OK;
+}
+
+static int cfg_bandweight_points(const cfg_arg_t arg) {
+    static char bwp_params_list[50] = "";
+    int bandindex = -1;
+
+    if (strlen(bwp_params_list) == 0) {
+	g_strlcpy(bwp_params_list, parameter, sizeof(bwp_params_list));
+	g_strchomp(bwp_params_list);
+    }
+
+    char *tk_ptr = strtok(bwp_params_list, ";:,");
+    if (tk_ptr != NULL) {
+	while (tk_ptr) {
+
+	    bandindex = getidxbybandstr(g_strchomp(tk_ptr));
+	    tk_ptr = strtok(NULL, ";:,");
+	    if (tk_ptr != NULL && bandindex >= 0) {
+		bandweight_points[bandindex] = atoi(tk_ptr);
+	    }
+	    tk_ptr = strtok(NULL, ";:,");
+	}
+    }
+    return PARSE_OK;
+}
+
+static int cfg_bandweight_multis(const cfg_arg_t arg) {
+    static char bwm_params_list[50] = "";
+    int bandindex = -1;
+
+    if (strlen(bwm_params_list) == 0) {
+	g_strlcpy(bwm_params_list, parameter, sizeof(bwm_params_list));
+	g_strchomp(bwm_params_list);
+    }
+
+    char *tk_ptr = strtok(bwm_params_list, ";:,");
+    if (tk_ptr != NULL) {
+	while (tk_ptr) {
+
+	    bandindex = getidxbybandstr(g_strchomp(tk_ptr));
+	    tk_ptr = strtok(NULL, ";:,");
+	    if (tk_ptr != NULL && bandindex >= 0) {
+		bandweight_multis[bandindex] = atoi(tk_ptr);
+	    }
+	    tk_ptr = strtok(NULL, ";:,");
+	}
+    }
+    return PARSE_OK;
+}
+
+static int cfg_pfx_num_multis(const cfg_arg_t arg) {
+    /* based on LZ3NY code, by HA2OS
+       PFX_NUM_MULTIS   (in file or listed in logcfg.dat),
+       We directly copy it into pfxnummulti_str, then parse the prefixlist
+       and fill the pfxnummulti array.
+     */
+
+    int counter = 0;
+    int pfxnum;
+    static char pfxnummulti_str[50] = "";
+    char parsepfx[15] = "";
+
+    g_strlcpy(pfxnummulti_str, parameter, sizeof(pfxnummulti_str));
+    g_strchomp(pfxnummulti_str);
+
+    /* creating the array */
+    char *tk_ptr = strtok(pfxnummulti_str, ",");
+    counter = 0;
+
+    if (tk_ptr != NULL) {
+	while (tk_ptr) {
+	    parsepfx[0] = '\0';
+	    if (isdigit(tk_ptr[strlen(tk_ptr) - 1])) {
+		sprintf(parsepfx, "%sAA", tk_ptr);
+	    } else {
+		sprintf(parsepfx, "%s0AA", tk_ptr);
+	    }
+	    pfxnummulti[counter].countrynr = getctydata(parsepfx);
+	    for (pfxnum = 0; pfxnum < 10; pfxnum++) {
+		pfxnummulti[counter].qsos[pfxnum] = 0;
+	    }
+	    tk_ptr = strtok(NULL, ",");
+	    counter++;
+	}
+    }
+    pfxnummultinr = counter;
+    setcontest(whichcontest);
+    return PARSE_OK;
+}
+
+static int cfg_sc_volume(const cfg_arg_t arg) {
+    int value;
+    int rc = cfg_integer((cfg_arg_t) {.int_p = &value, .min = 0, .max = 100});
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    sprintf(sc_volume, "%d", value);
+    return PARSE_OK;
+}
+
+static int cfg_mfj1278_keyer(const cfg_arg_t arg) {
+    int rc = cfg_string((cfg_arg_t) {
+	.char_p = controllerport, .size = 80, .strip = true, .string_type = STATIC
+    });
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    cwkeyer = MFJ1278_KEYER;
+    digikeyer = MFJ1278_KEYER;
+    return PARSE_OK;
+}
+
+static int cfg_gmfsk(const cfg_arg_t arg) {
+    int rc = cfg_string((cfg_arg_t) {
+	.char_p = controllerport, .size = 80, .strip = true, .string_type = STATIC
+    });
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+    digikeyer = GMFSK;
+    return PARSE_OK;
+}
+
+static int cfg_change_rst(const cfg_arg_t arg) {
+    change_rst = true;
+    if (parameter == NULL) {
+	rst_init(NULL);
+	return PARSE_OK;
+    }
+    char *str = g_strdup(parameter);
+    g_strstrip(str);
+    /* comma separated list of RS(T) values 33..39, 43..39, 53..59 allowed.  */
+    if (!g_regex_match_simple("^([3-5][3-9]\\d?\\s*,\\s*)*[3-5][3-9]\\d?$",
+			      str, G_REGEX_CASELESS, (GRegexMatchFlags)0)) {
+	g_free(str);
+	error_details = g_strdup("must be a comma separated list of RS(T) values");
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    rst_init(str);
+
+    g_free(str);
+    return PARSE_OK;
+}
+
+static int cfg_rttymode(const cfg_arg_t arg) {
+    trxmode = DIGIMODE;
+    strcpy(modem_mode, "RTTY");
+    return PARSE_OK;
+}
+
+static int cfg_myqra(const cfg_arg_t arg) {
+    strcpy(my.qra, parameter);
+
+    if (check_qra(my.qra) == 0) {
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    return PARSE_OK;
+}
+
+static int cfg_powermult(const cfg_arg_t arg) {
+    if (fixedmult == 0.0 && atof(parameter) > 0.0) {
+	fixedmult = atof(parameter);
+    }
+
+    return PARSE_OK;
+}
+
+static int cfg_qtc(const cfg_arg_t arg) {
+    char *str = g_ascii_strup(parameter, -1);
+    g_strstrip(str);
+
+    int rc = PARSE_OK;
+
+    if (strcmp(str, "RECV") == 0) {
+	qtcdirection = RECV;
+    } else if (strcmp(str, "SEND") == 0) {
+	qtcdirection = SEND;
+    } else if (strcmp(str, "BOTH") == 0) {
+	qtcdirection = RECV | SEND;
+    } else {
+	error_details = g_strdup("must be RECV, SEND, or BOTH");
+	rc = PARSE_WRONG_PARAMETER;
+    }
+
+    g_free(str);
+    return rc;
+}
+
+static int cfg_qtcrec_record_command(const cfg_arg_t arg) {
+    int p, q = 0, i = 0, s = 0;
+    for (p = 0; p < strlen(parameter); p++) {
+	if (p > 0 && parameter[p] == ' ') {
+	    s = 1;
+	    qtcrec_record_command_shutdown[p] = '\0';
+	}
+	if (s == 0) {
+	    qtcrec_record_command_shutdown[p] = parameter[p];
+	}
+	if (parameter[p] == '$') {
+	    qtcrec_record_command[i][q] = '\0';
+	    i = 1;
+	    p++;
+	    q = 0;
+	}
+	if (parameter[p] != '\n') {
+	    qtcrec_record_command[i][q] = parameter[p];
+	}
+	q++;
+	qtcrec_record_command[i][q] = ' ';
+    }
+
+    if (qtcrec_record_command[i][q - 1] != '&') {
+	qtcrec_record_command[i][q++] = ' ';
+	qtcrec_record_command[i][q++] = '&';
+    }
+    qtcrec_record_command[i][q] = '\0';
+
+    return PARSE_OK;
+}
+
+static int cfg_exclude_multilist(const cfg_arg_t arg) {
+    char *str = g_ascii_strup(parameter, -1);
+    g_strstrip(str);
+
+    if (strcmp(str, "CONTINENTLIST") == 0) {
+	g_free(str);
+	if (strlen(continent_multiplier_list[0]) == 0) {
+	    error_details = g_strdup("need to set the CONTINENTLIST first");
+	    return PARSE_WRONG_PARAMETER;
+	}
+	exclude_multilist_type = EXCLUDE_CONTINENT;
+    } else if (strcmp(str, "COUNTRYLIST") == 0) {
+	g_free(str);
+	if (strlen(countrylist[0]) == 0) {
+	    error_details = g_strdup("need to set the COUNTRYLIST first");
+	    return PARSE_WRONG_PARAMETER;
+	}
+	exclude_multilist_type = EXCLUDE_COUNTRY;
+    } else {
+	g_free(str);
+	error_details = g_strdup("must be CONTINENTLIST or COUNTRYLIST");
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    return PARSE_OK;
+}
+
+static int cfg_fldigi(const cfg_arg_t arg) {
+#ifndef HAVE_LIBXMLRPC
+    showmsg("WARNING: XMLRPC not compiled - skipping setup.");
+    sleep(2);
+    digikeyer = NO_KEYER;
+#else
+    if (parameter != NULL) {
+	int rc = cfg_string((cfg_arg_t) {
+	    .char_p = fldigi_url, .size = sizeof(fldigi_url), .strip = true,
+	    .string_type = STATIC
+	});
+	if (rc != PARSE_OK) {
+	    return rc;
+	}
+    }
+
+    digikeyer = FLDIGI;
+    if (!fldigi_isenabled()) {
+	fldigi_toggle();
+    }
+#endif
+
+    return PARSE_OK;
+}
+
+static int cfg_rigptt(const cfg_arg_t arg) {
+    // FIXME: use enums
+    rigptt |= (1 << 0);		/* bit 0 set--CAT PTT wanted (RIGPTT) */
+    return PARSE_OK;
+}
+
+static int cfg_minitest(const cfg_arg_t arg) {
+    if (parameter == NULL) {
+	minitest = MINITEST_DEFAULT_PERIOD;
+	return PARSE_OK;
+    }
+
+    int value;
+    int rc = cfg_integer((cfg_arg_t) {.int_p = &value, .min = 60, .max = 1800});
+    if (rc != PARSE_OK) {
+	return rc;
+    }
+
+    if ((3600 % value) != 0) {
+	error_details = g_strdup("must be an integral divider of 3600 seconds");
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    minitest = value;
+
+    return PARSE_OK;
+}
+
+static int cfg_unique_call_multi(const cfg_arg_t arg) {
+    char *str = g_ascii_strup(parameter, -1);
+    g_strstrip(str);
+
+    if (strcmp(str, "ALL") == 0) {
+	unique_call_multi = UNIQUECALL_ALL;
+    } else if (strcmp(str, "BAND") == 0) {
+	unique_call_multi = UNIQUECALL_BAND;
+    } else {
+	g_free(str);
+	error_details = g_strdup("must be ALL or BAND");
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    g_free(str);
+    return PARSE_OK;
+}
+
+static int cfg_digi_rig_mode(const cfg_arg_t arg) {
+    char *str = g_ascii_strup(parameter, -1);
+    g_strstrip(str);
+
+    if (strcmp(str, "USB") == 0) {
+	digi_mode = RIG_MODE_USB;
+    } else if (strcmp(str, "LSB") == 0) {
+	digi_mode = RIG_MODE_LSB;
+    } else if (strcmp(str, "RTTY") == 0) {
+	digi_mode = RIG_MODE_RTTY;
+    } else if (strcmp(str, "RTTYR") == 0) {
+	digi_mode = RIG_MODE_RTTYR;
+    } else {
+	g_free(str);
+	error_details = g_strdup("must be USB, LSB, RTTY, or RTTYR");
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    g_free(str);
+    return PARSE_OK;
+}
+
+static config_t logcfg_configs[] = {
+    {"CONTEST_MODE",        CFG_BOOL_TRUE(iscontest)},
+    {"MIXED",               CFG_BOOL_TRUE(mixedmode)},
+    {"IGNOREDUPE",          CFG_BOOL_TRUE(ignoredupe)},
+    {"USE_CONTINENTLIST_ONLY",  CFG_BOOL_TRUE(continentlist_only)},
+
+    {"USEPARTIALS",     CFG_INT_ONE(use_part)},
+    {"PARTIALS",        CFG_INT_ONE(partials)},
+    {"RECALL_MULTS",    CFG_INT_ONE(recall_mult)},
+    {"WYSIWYG_MULTIBAND",   CFG_INT_ONE(wysiwyg_multi)},
+    {"WYSIWYG_ONCE",    CFG_INT_ONE(wysiwyg_once)},
+    {"RADIO_CONTROL",   CFG_INT_ONE(trx_control)},
+    {"RIT_CLEAR",       CFG_INT_ONE(rit)},
+    {"SHORT_SERIAL",    CFG_INT_ONE(shortqsonr)},
+    {"SCOREWINDOW",     CFG_INT_ONE(showscore_flag)},
+    {"CHECKWINDOW",     CFG_INT_ONE(searchflg)},
+    {"SEND_DE",         CFG_INT_ONE(demode)},
+    {"SERIAL_EXCHANGE", CFG_INT_ONE(exchange_serial)},
+    {"COUNTRY_MULT",    CFG_INT_ONE(country_mult)},
+    {"PORTABLE_MULT_2", CFG_INT_ONE(portable_x2)},
+    {"CQWW_M2",         CFG_INT_ONE(cqwwm2)},
+    {"LAN_DEBUG",       CFG_INT_ONE(landebug)},
+    {"CALLUPDATE",      CFG_INT_ONE(call_update)},
+    {"TIME_MASTER",     CFG_INT_ONE(time_master)},
+    {"CTCOMPATIBLE",    CFG_INT_ONE(ctcomp)},
+    {"SERIAL\\+SECTION",    CFG_INT_ONE(serial_section_mult)},
+    {"SECTION_MULT",    CFG_INT_ONE(sectn_mult)},
+    {"NOB4",            CFG_INT_ONE(nob4)},
+    {"SHOW_TIME",       CFG_INT_ONE(show_time)},
+    {"RXVT",            CFG_INT_ONE(use_rxvt)},
+    {"WAZMULT",         CFG_INT_ONE(wazmult)},
+    {"ITUMULT",         CFG_INT_ONE(itumult)},
+    {"CONTINENT_EXCHANGE",  CFG_INT_ONE(exc_cont)},
+    {"NOAUTOCQ",        CFG_INT_ONE(noautocq)},
+    {"NO_BANDSWITCH_ARROWKEYS", CFG_INT_ONE(no_arrows)},
+    {"SOUNDCARD",       CFG_INT_ONE(sc_sidetone)},
+    {"LOWBAND_DOUBLE",  CFG_INT_ONE(lowband_point_mult)},
+    {"CLUSTER_LOG",     CFG_INT_ONE(clusterlog)},
+    {"SERIAL\\+GRID4",  CFG_INT_ONE(serial_grid4_mult)},
+    {"LOGFREQUENCY",    CFG_INT_ONE(logfrequency)},
+    {"NO_RST",          CFG_INT_ONE(no_rst)},
+    {"SERIAL_OR_SECTION",   CFG_INT_ONE(serial_or_section)},
+    {"PFX_MULT",            CFG_INT_ONE(pfxmult)},
+    {"PFX_MULT_MULTIBAND",  CFG_INT_ONE(pfxmultab)},
+    {"QTCREC_RECORD",   CFG_INT_ONE(qtcrec_record)},
+    {"QTC_AUTO_FILLTIME",   CFG_INT_ONE(qtc_auto_filltime)},
+    {"BMAUTOGRAB",      CFG_INT_ONE(bmautograb)},
+    {"BMAUTOADD",       CFG_INT_ONE(bmautoadd)},
+    {"QTC_RECV_LAZY",   CFG_INT_ONE(qtc_recv_lazy)},
+    {"SPRINTMODE",      CFG_INT_ONE(sprint_mode)},
+    {"KEYER_BACKSPACE", CFG_INT_ONE(keyer_backspace)},
+    {"SECTION_MULT_ONCE",   CFG_INT_ONE(sectn_mult_once)},
+
+    {"F([1-9]|1[0-2])", CFG_MESSAGE(message, -1)},  // index is 1-based
+    {"S&P_TU_MSG",      CFG_MESSAGE(message, SP_TU_MSG)},
+    {"CQ_TU_MSG",       CFG_MESSAGE(message, CQ_TU_MSG)},
+    {"ALT_([0-9])",     CFG_MESSAGE(message, CQ_TU_MSG + 1)},
+    {"S&P_CALL_MSG",    CFG_MESSAGE(message, SP_CALL_MSG)},
+
+    {"VKM([1-9]|1[0-2])",   CFG_MESSAGE_CHOMP(ph_message, -1)},
+    {"VKCQM",               CFG_MESSAGE_CHOMP(ph_message, CQ_TU_MSG)},
+    {"VKSPM",               CFG_MESSAGE_CHOMP(ph_message, SP_TU_MSG)},
+
+    {"DKF([1-9]|1[0-2])",   CFG_MESSAGE_DYNAMIC(digi_message, -1)},
+    {"DKCQM",               CFG_MESSAGE_DYNAMIC(digi_message, CQ_TU_MSG)},
+    {"DKSPM",               CFG_MESSAGE_DYNAMIC(digi_message, SP_TU_MSG)},
+    {"DKSPC",               CFG_MESSAGE_DYNAMIC(digi_message, SP_CALL_MSG)},
+    {"ALT_DK([1-9]|10)",    CFG_MESSAGE_DYNAMIC(digi_message, CQ_TU_MSG)},
+
+    {"QR_F([1-9]|1[0-2])",      CFG_MESSAGE(qtc_recv_msgs, -1) },
+    {"QR_VKM([1-9]|1[0-2])",    CFG_MESSAGE_CHOMP(qtc_phrecv_message, -1) },
+    {"QR_VKCQM",                CFG_MESSAGE_CHOMP(qtc_phrecv_message, CQ_TU_MSG) },
+    {"QR_VKSPM",                CFG_MESSAGE_CHOMP(qtc_phrecv_message, SP_TU_MSG) },
+
+    {"QS_F([1-9]|1[0-2])",      CFG_MESSAGE(qtc_send_msgs, -1) },
+    {"QS_VKM([1-9]|1[0-2])",    CFG_MESSAGE_CHOMP(qtc_phsend_message, -1) },
+    {"QS_VKCQM",                CFG_MESSAGE_CHOMP(qtc_phsend_message, CQ_TU_MSG) },
+    {"QS_VKSPM",                CFG_MESSAGE_CHOMP(qtc_phsend_message, SP_TU_MSG) },
+
+    {"TLFCOLOR([1-6])",  NEED_PARAM, cfg_tlfcolor},
+
+    {"LAN_PORT",        CFG_INT(lan_port, 1000, INT32_MAX)},
+    {"TIME_OFFSET",     CFG_INT(timeoffset, -23, 23)},
+    {"NETKEYERPORT",    CFG_INT(netkeyer_port, 1, INT32_MAX)},
+    {"TNCSPEED",        CFG_INT(tnc_serial_rate, 0, INT32_MAX)},
+    {"RIGSPEED",        CFG_INT(serial_rate, 0, INT32_MAX)},
+    {"CQDELAY",         CFG_INT(cqdelay, 3, 60)},
+    {"SSBPOINTS",       CFG_INT(ssbpoints, 0, INT32_MAX)},
+    {"CWPOINTS",        CFG_INT(cwpoints, 0, INT32_MAX)},
+    {"WEIGHT",          CFG_INT(weight, -50, 50)},
+    {"TXDELAY",         CFG_INT(txdelay, 0, 50)},
+    {"RIGMODEL",        CFG_INT(myrig_model, 0, 9999)},
+    {"COUNTRY_LIST_POINTS", CFG_INT(countrylist_points, 0, INT32_MAX)},
+    {"MY_COUNTRY_POINTS",   CFG_INT(my_country_points, 0, INT32_MAX)},
+    {"MY_CONTINENT_POINTS", CFG_INT(my_cont_points, 0, INT32_MAX)},
+    {"DX_POINTS",           CFG_INT(dx_cont_points, 0, INT32_MAX)},
+    {"CWBANDWIDTH",         CFG_INT(cw_bandwidth, 0, INT32_MAX)},
+    {"CONTINENT_LIST_POINTS",   CFG_INT(continentlist_points, 0, INT32_MAX)},
+
+    {"NETKEYER",        CFG_INT_CONST(cwkeyer, NET_KEYER)},
+    {"FIFO_INTERFACE",  CFG_INT_CONST(packetinterface, FIFO_INTERFACE)},
+    {"LONG_SERIAL",     CFG_INT_CONST(shortqsonr, 0)},
+    {"CLUSTER",         CFG_INT_CONST(cluster, CLUSTER)},
+    {"SSBMODE",         CFG_INT_CONST(trxmode, SSBMODE)},
+
+    {"RIGCONF",         CFG_STRING_STATIC(rigconf, 80)},
+    {"LOGFILE",         CFG_STRING_STATIC(logfile, 120)},
+    {"KEYER_DEVICE",    CFG_STRING_STATIC(keyer_device, 10)},
+    {"NETKEYERHOST",    CFG_STRING_STATIC(netkeyer_hostaddress, 16)},
+    {"TELNETHOST",      CFG_STRING_STATIC(pr_hostaddress, 48)},
+    {"QTC_CAP_CALLS",   CFG_STRING_STATIC(qtc_cap_calls, 40)},
+    {"SYNCFILE",        CFG_STRING_STATIC(synclogfile, 120)},
+    {"SC_DEVICE",       CFG_STRING_STATIC(sc_device, 40)},
+    {"INITIAL_EXCHANGE",       CFG_STRING_STATIC(exchange_list, 40)},
+    {"DIGIMODEM",       CFG_STRING_STATIC(rttyoutput, 120)},
+
+    {"CABRILLO",    CFG_STRING(cabrillo)},
+    {"CALLMASTER",  CFG_STRING(callmaster_filename)},
+    {"EDITOR",      CFG_STRING(editor_cmd)},
+
+    {"RIGPORT",         CFG_STRING_NOCHOMP(rigportname)},
+    {"CLUSTERLOGIN",    CFG_STRING_STATIC_NOCHOMP(clusterlogin, 80)},
+
+    {"CALL",            NEED_PARAM, cfg_call},
+    {"(CONTEST|RULES)", NEED_PARAM, cfg_contest},
+    {"TELNETPORT",      NEED_PARAM, cfg_telnetport},
+    {"BANDOUTPUT",      NEED_PARAM, cfg_bandoutput},
+    {"(ONE_POINT|(TWO|THREE)_POINTS)",  NO_PARAM, cfg_n_points},
+    {"BANDMAP",         OPTIONAL_PARAM, cfg_bandmap},
+    {"CWSPEED",         NEED_PARAM, cfg_cwspeed},
+    {"CWTONE",          NEED_PARAM, cfg_cwtone},
+    {"SUNSPOTS",        NEED_PARAM, cfg_sunspots},
+    {"SFI",             NEED_PARAM, cfg_sfi},
+    {"TNCPORT",         NEED_PARAM, cfg_tncport},
+    {"ADDNODE",         NEED_PARAM, cfg_addnode},
+    {"THISNODE",        NEED_PARAM, cfg_thisnode},
+    {"MULT_LIST",       NEED_PARAM, cfg_mult_list},
+    {"MARKER(|DOT|CALL)S",  NEED_PARAM, cfg_markers},
+    {"DX_&_SECTIONS",   NO_PARAM, cfg_dx_n_sections},
+    {"COUNTRYLIST",     NEED_PARAM, cfg_countrylist},
+    {"CONTINENTLIST",   NEED_PARAM, cfg_continentlist},
+    {"USE_COUNTRYLIST_ONLY",    NO_PARAM, cfg_country_list_only},
+    {"SIDETONE_VOLUME", NEED_PARAM, cfg_sc_volume},
+    {"MFJ1278_KEYER",   NEED_PARAM, cfg_mfj1278_keyer},
+    {"CHANGE_RST",      OPTIONAL_PARAM, cfg_change_rst},
+    {"GMFSK",           NEED_PARAM, cfg_gmfsk},
+    {"RTTYMODE",        NO_PARAM, cfg_rttymode},
+    {"MYQRA",           NEED_PARAM, cfg_myqra},
+    {"POWERMULT",       NEED_PARAM, cfg_powermult},
+    {"QTC",             NEED_PARAM, cfg_qtc},
+    {"BANDWEIGHT_POINTS",   NEED_PARAM, cfg_bandweight_points},
+    {"BANDWEIGHT_MULTIS",   NEED_PARAM, cfg_bandweight_multis},
+    {"PFX_NUM_MULTIS",      NEED_PARAM, cfg_pfx_num_multis},
+    {"QTCREC_RECORD_COMMAND",   NEED_PARAM, cfg_qtcrec_record_command},
+    {"EXCLUDE_MULTILIST",   NEED_PARAM, cfg_exclude_multilist},
+    {"FLDIGI",              OPTIONAL_PARAM, cfg_fldigi},
+    {"RIGPTT",              NO_PARAM, cfg_rigptt},
+    {"MINITEST",            OPTIONAL_PARAM, cfg_minitest},
+    {"UNIQUE_CALL_MULTI",   NEED_PARAM, cfg_unique_call_multi},
+    {"DIGI_RIG_MODE",       NEED_PARAM, cfg_digi_rig_mode},
+
+    {NULL}  // end marker
+};
+
+
+static int check_match(const config_t *cfg, const char *keyword) {
+    gchar *pattern = g_strdup_printf("^%s$", cfg->regex);
+    GRegex *regex = g_regex_new(pattern, 0, 0, NULL);
+    g_free(pattern);
+
+    int result = PARSE_NO_MATCH;    // default: not found
+
+    g_regex_match(regex, keyword, 0, &match_info);
+    if (g_match_info_matches(match_info)) {
+
+	if (cfg->param_kind == NEED_PARAM && parameter == NULL) {
+	    result = PARSE_MISSING_PARAMETER;
+	} else if (cfg->param_kind == NO_PARAM && parameter != NULL) {
+	    result = PARSE_EXTRA_PARAMETER;
+	} else {
+	    result = cfg->func(cfg->arg);
+	}
+    }
+    g_match_info_free(match_info);
+    g_regex_unref(regex);
+
+    return result;
+}
+
+static int apply_config(const char *keyword, const char *param,
+			const config_t *configs) {
+
+    parameter = param;      // save for matcher functions
+
+    int result = PARSE_NO_MATCH;
+
+    for (const config_t *cfg = configs; cfg->regex ; ++cfg) {
+	result = check_match(cfg, keyword);
+	if (result != PARSE_NO_MATCH) {
+	    break;
+	}
+    }
+
+    switch (result) {
+	case PARSE_OK:
+	    return PARSE_OK;
+
+	case PARSE_NO_MATCH:
+	    KeywordNotSupported(keyword);
+	    break;
+
+	case PARSE_MISSING_PARAMETER:
+	    ParameterNeeded(keyword);
+	    break;
+
+	case PARSE_EXTRA_PARAMETER:
+	    ParameterUnexpected(keyword);
+	    break;
+
+	case PARSE_INVALID_INTEGER:
+	    WrongFormat_details(keyword, "invalid number");
+	    break;
+
+	case PARSE_INTEGER_OUT_OF_RANGE:
+	    WrongFormat_details(keyword, "value out of range");
+	    break;
+
+	default:
+	    if (error_details != NULL) {
+		WrongFormat_details(keyword, error_details);
+		g_free(error_details);
+	    } else {
+		WrongFormat(keyword);
+	    }
+    }
+
+    return PARSE_ERROR;
+}
+////////////////////
+
 
 int parse_logcfg(char *inputbuffer) {
-
-    extern int use_rxvt;
-    extern char message[][80];
-    extern char ph_message[14][80];
-    extern char whichcontest[];
-    extern char logfile[];
-    extern int recall_mult;
-    extern int one_point;
-    extern int two_point;
-    extern int three_point;
-    extern int exchange_serial;
-    extern int country_mult;
-    extern int wysiwyg_multi;
-    extern int wysiwyg_once;
-    extern float fixedmult;
-    extern int portable_x2;
-    extern int trx_control;
-    extern int rit;
-    extern int shortqsonr;
-    extern int cluster;
-    extern int clusterlog;
-    extern int showscore_flag;
-    extern int searchflg;
-    extern int demode;
-    extern bool iscontest;
-    extern int weight;
-    extern int txdelay;
-    extern char tonestr[];
-    extern char *editor_cmd;
-    extern int partials;
-    extern int use_part;
-    extern bool mixedmode;
-    extern char pr_hostaddress[];
-    extern int portnum;
-    extern int packetinterface;
-    extern int tncport;
-    extern int tnc_serial_rate;
-    extern int serial_rate;
-    extern rig_model_t myrig_model;
-    extern char *rigportname;
-    extern int rignumber;
-    extern char rigconf[];
-    extern char exchange_list[40];
-    extern char tncportname[];
-    extern int netkeyer_port;
-    extern char netkeyer_hostaddress[];
-    extern char bc_hostaddress[MAXNODES][16];
-    extern char bc_hostservice[MAXNODES][16];
-    extern int lan_active;
-    extern char thisnode;
-    extern int nodes;
-    extern int node;
-    extern int cqwwm2;
-    extern int landebug;
-    extern int call_update;
-    extern int timeoffset;
-    extern int time_master;
-    extern char multsfile[];
-    extern int multlist;
-    extern int serial_section_mult;
-    extern int serial_grid4_mult;
-    extern int sectn_mult;
-    extern int sectn_mult_once;
-    extern int dx_arrlsections;
-    extern int pfxmult;
-    extern int exc_cont;
-    extern char markerfile[];
-    extern int xplanet;
-    extern int nob4;
-    extern int noautocq;
-    extern int show_time;
-    extern char keyer_device[10];
-    extern int wazmult;
-    extern int itumult;
-    extern int cqdelay;
-    extern int trxmode;
-    extern int use_bandoutput;
-    extern int no_arrows;
-    extern int bandindexarray[];
-    extern int ssbpoints;
-    extern int cwpoints;
-    extern int lowband_point_mult;
-    extern int sc_sidetone;
-    extern char sc_volume[];
-    extern char modem_mode[];
-    extern int no_rst;
-    extern int serial_or_section;
-
-    /* LZ3NY mods */
-    extern int my_country_points;
-    extern int my_cont_points;
-    extern int dx_cont_points;
-    extern int countrylist_points;
-    extern bool countrylist_only;
-    extern int continentlist_points;
-    extern bool continentlist_only;
-    char c_temp[11];
-    extern bool mult_side;
-    extern char countrylist[][6];
-    extern char continent_multiplier_list[7][3];
-    extern int exclude_multilist_type;
-
-    /* end LZ3NY mods */
-    extern int tlfcolors[8][2];
-    extern char synclogfile[];
-    extern char sc_device[40];
-    extern char controllerport[80];	// port for multi-mode controller
-    extern char clusterlogin[];
-    extern int cw_bandwidth;
-    extern char rttyoutput[];
-    extern int logfrequency;
-    extern bool ignoredupe;
-    extern int bandweight_points[NBANDS];
-    extern int bandweight_multis[NBANDS];
-    extern pfxnummulti_t pfxnummulti[MAXPFXNUMMULT];
-    extern int pfxnummultinr;
-    extern int pfxmultab;
-    extern int bmautoadd;
-    extern int bmautograb;
-    extern int sprint_mode;
-#ifdef HAVE_LIBXMLRPC
-    extern char fldigi_url[50];
-#endif
-    extern unsigned char rigptt;
-    extern int minitest;
-    extern int unique_call_multi;
-    extern int lan_port;
-    extern int verbose;
-
-    char *commands[] = {
-	NULL,   //"enable",		/* 0 */		/* deprecated */
-	NULL,   //"disable",				/* deprecated */
-	"F1",
-	"F2",
-	"F3",
-	"F4",			/* 5 */
-	"F5",
-	"F6",
-	"F7",
-	"F8",
-	"F9",			/* 10 */
-	"F10",
-	"F11",
-	"F12",
-	"S&P_TU_MSG",
-	"CQ_TU_MSG",		/* 15 */
-	"CALL",
-	"CONTEST",
-	"LOGFILE",
-	"KEYER_DEVICE",
-	"BANDOUTPUT",		/* 20 */
-	"RECALL_MULTS",
-	"ONE_POINT",
-	"THREE_POINTS",
-	"WYSIWYG_MULTIBAND",
-	"WYSIWYG_ONCE",		/* 25 */
-	"RADIO_CONTROL",
-	"RIT_CLEAR",
-	"SHORT_SERIAL",
-	"LONG_SERIAL",
-	"CONTEST_MODE",		/* 30 */
-	"CLUSTER",
-	"BANDMAP",
-	NULL,   //"SPOTLIST",				/* deprecated */
-	"SCOREWINDOW",
-	"CHECKWINDOW",		/* 35 */
-	NULL,   //"FILTER",				/* deprecated */
-	"SEND_DE",
-	"CWSPEED",
-	"CWTONE",
-	"WEIGHT",		/* 40 */
-	"TXDELAY",
-	"SUNSPOTS",
-	"SFI",
-	NULL,   //"SHOW_FREQUENCY",                       /* deprecated */
-	"EDITOR",		/* 45 */
-	"PARTIALS",
-	"USEPARTIALS",
-	NULL,   //"POWERMULT_5",				/* deprecated */
-	NULL,   //"POWERMULT_2",				/* deprecated */
-	NULL,   //"POWERMULT_1",		/* 50 */	/* deprecated */
-	NULL,   //"MANY_CALLS",				/* deprecated */
-	"SERIAL_EXCHANGE",
-	"COUNTRY_MULT",
-	"2EU3DX_POINTS",
-	"PORTABLE_MULT_2",	/* 55 */
-	"MIXED",
-	"TELNETHOST",
-	"TELNETPORT",
-	"TNCPORT",
-	"FIFO_INTERFACE",	/* 60 */
-	"RIGMODEL",
-	"RIGSPEED",
-	"TNCSPEED",
-	"RIGPORT",
-	"NETKEYER",		/* 65 */
-	"NETKEYERPORT",
-	"NETKEYERHOST",
-	"ADDNODE",
-	"THISNODE",
-	"CQWW_M2",		/* 70 */
-	"LAN_DEBUG",
-	"ALT_0",
-	"ALT_1",
-	"ALT_2",
-	"ALT_3",		/* 75 */
-	"ALT_4",
-	"ALT_5",
-	"ALT_6",
-	"ALT_7",
-	"ALT_8",		/* 80 */
-	"ALT_9",
-	"CALLUPDATE",
-	"TIME_OFFSET",
-	"TIME_MASTER",
-	"CTCOMPATIBLE",		/*  85  */
-	"TWO_POINTS",
-	"MULT_LIST",
-	"SERIAL+SECTION",
-	"SECTION_MULT",
-	"MARKERS",		/* 90 */
-	"DX_&_SECTIONS",
-	"MARKERDOTS",
-	"MARKERCALLS",
-	"NOB4",
-	/*LZ3NY */
-	"COUNTRYLIST",		//by lz3ny      /* 95 */
-	"COUNTRY_LIST_POINTS",	//by lz3ny
-	"USE_COUNTRYLIST_ONLY",	//by lz3ny
-	"MY_COUNTRY_POINTS",	//by lz3ny
-	"MY_CONTINENT_POINTS",	//by lz3ny
-	"DX_POINTS",		//by lz3ny                 /* 100 */
-	"SHOW_TIME",
-	"RXVT",
-	"VKM1",
-	"VKM2",
-	"VKM3",		/* 105 */
-	"VKM4",
-	"VKM5",
-	"VKM6",
-	"VKM7",
-	"VKM8",		/* 110 */
-	"VKM9",
-	"VKM10",
-	"VKM11",
-	"VKM12",
-	"VKSPM",		/* 115 */
-	"VKCQM",
-	"WAZMULT",
-	"ITUMULT",
-	"CQDELAY",
-	"PFX_MULT",		/* 120 */
-	"CONTINENT_EXCHANGE",
-	"RULES",
-	"NOAUTOCQ",
-	"SSBMODE",
-	"NO_BANDSWITCH_ARROWKEYS",	/* 125 */
-	"RIGCONF",
-	"TLFCOLOR1",
-	"TLFCOLOR2",
-	"TLFCOLOR3",
-	"TLFCOLOR4",		/* 130 */
-	"TLFCOLOR5",
-	"TLFCOLOR6",
-	"SYNCFILE",
-	"SSBPOINTS",
-	"CWPOINTS",		/* 135 */
-	"SOUNDCARD",
-	"SIDETONE_VOLUME",
-	NULL,   //"S_METER",				/* deprecated */
-	"SC_DEVICE",
-	"MFJ1278_KEYER",	/* 140 */
-	"CLUSTERLOGIN",
-	"ORION_KEYER",
-	"INITIAL_EXCHANGE",
-	"CWBANDWIDTH",
-	"LOWBAND_DOUBLE",	/* 145 */
-	"CLUSTER_LOG",
-	"SERIAL+GRID4",
-	"CHANGE_RST",
-	"GMFSK",
-	"RTTYMODE",		/* 150 */
-	"DIGIMODEM",
-	"LOGFREQUENCY",
-	"IGNOREDUPE",
-	"CABRILLO",
-	NULL,   //"CW_TU_MSG",		/* 155 */	/* deprecated */
-	NULL,   //"VKCWR",				/* deprecated */
-	NULL,   //"VKSPR",				/* deprecated */
-	"NO_RST",
-	"MYQRA",
-	"POWERMULT",		/* 160 */
-	"SERIAL_OR_SECTION",
-	"QTC",
-	"CONTINENTLIST",
-	"CONTINENT_LIST_POINTS",
-	"USE_CONTINENTLIST_ONLY",  /* 165 */
-	"BANDWEIGHT_POINTS",
-	"BANDWEIGHT_MULTIS",
-	"PFX_NUM_MULTIS",
-	"PFX_MULT_MULTIBAND",
-	"QR_F1",		/* 170 */
-	"QR_F2",
-	"QR_F3",
-	"QR_F4",
-	"QR_F5",
-	"QR_F6",		/* 175 */
-	"QR_F7",
-	"QR_F8",
-	"QR_F9",
-	"QR_F10",
-	"QR_F11",		/* 180 */
-	"QR_F12",
-	"QS_F1",
-	"QS_F2",
-	"QS_F3",
-	"QS_F4",
-	"QS_F5",
-	"QS_F6",
-	"QS_F7",
-	"QS_F8",
-	"QS_F9",		/* 190 */
-	"QS_F10",
-	"QS_F11",
-	"QS_F12",
-	"QR_VKM1",
-	"QR_VKM2",
-	"QR_VKM3",
-	"QR_VKM4",
-	"QR_VKM5",
-	"QR_VKM6",
-	"QR_VKM7",			/* 200 */
-	"QR_VKM8",
-	"QR_VKM9",
-	"QR_VKM10",
-	"QR_VKM11",
-	"QR_VKM12",
-	"QR_VKSPM",
-	"QR_VKCQM",
-	"QS_VKM1",
-	"QS_VKM2",
-	"QS_VKM3",			/* 210 */
-	"QS_VKM4",
-	"QS_VKM5",
-	"QS_VKM6",
-	"QS_VKM7",
-	"QS_VKM8",
-	"QS_VKM9",
-	"QS_VKM10",
-	"QS_VKM11",
-	"QS_VKM12",
-	"QS_VKSPM",		/* 220 */
-	"QS_VKCQM",
-	"QTCREC_RECORD",
-	"QTCREC_RECORD_COMMAND",
-	"EXCLUDE_MULTILIST",
-	"S&P_CALL_MSG",		/* 225 */
-	"QTC_CAP_CALLS",
-	"QTC_AUTO_FILLTIME",
-	"BMAUTOGRAB",
-	"BMAUTOADD",
-	"QTC_RECV_LAZY",		/* 230 */
-	"SPRINTMODE",
-	"FLDIGI",
-	"RIGPTT",
-	"MINITEST",
-	"UNIQUE_CALL_MULTI",		/* 235 */
-	"KEYER_BACKSPACE",
-	"DIGI_RIG_MODE",
-	"DKF1",				/* 238 */
-	"DKF2",
-	"DKF3",
-	"DKF4",
-	"DKF5",
-	"DKF6",
-	"DKF7",
-	"DKF8",
-	"DKF9",
-	"DKF10",
-	"DKF11",
-	"DKF12",
-	"DKCQM",			/* 250 */
-	"DKSPM",
-	"DKSPC",
-	"ALT_DK1",			/* 253 */
-	"ALT_DK2",
-	"ALT_DK3",
-	"ALT_DK4",
-	"ALT_DK5",
-	"ALT_DK6",
-	"ALT_DK7",
-	"ALT_DK8",			/* 260 */
-	"ALT_DK9",
-	"ALT_DK10",
-	"CALLMASTER",
-	"LAN_PORT",                     /* 264 */
-	"SECTION_MULT_ONCE"
-    };
-
-    char **fields;
-    char teststring[80];
-    char buff[40];
-    int ii;
-    int jj, hh;
-    char *tk_ptr;
-
 
     /* split the inputline at '=' to max 2 elements
      *
@@ -608,9 +1360,8 @@ int parse_logcfg(char *inputbuffer) {
      * That allows plain keywords and also keywords with parameters (which
      * follows a '=' sign
      */
-    confirmation_needed = PARSE_OK;
 
-    fields = g_strsplit(inputbuffer, "=", 2);
+    char **fields = g_strsplit(inputbuffer, "=", 2);
     g_strstrip(fields[0]);
 
     if (*fields[0] == '\0') { 	/* only whitespace found? */
@@ -622,1383 +1373,10 @@ int parse_logcfg(char *inputbuffer) {
 	g_strchug(fields[1]);		/* from parameters */
     }
 
-    g_strlcpy(teststring, fields[0], sizeof(teststring));
-
-    for (ii = 0; ii < MAX_COMMANDS; ii++) {
-	if (g_strcmp0(teststring, commands[ii]) == 0) {
-	    break;
-	}
-    }
-
-    switch (ii) {
-
-	case 0: {
-	    KeywordNotSupported(teststring);
-	    break;
-	}
-	case 1: {
-	    KeywordNotSupported(teststring);
-	    break;
-	}
-	case 2 ... 10: {	/* messages */
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(message[ii - 2], fields[1]);
-	    break;
-	}
-	case 11 ... 13: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(message[ii - 2], fields[1]);
-	    break;
-	}
-	case 14: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(message[SP_TU_MSG], fields[1]);
-	    break;
-	}
-	case 15: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(message[CQ_TU_MSG], fields[1]);
-	    break;	/* end messages */
-	}
-	case 16: {
-	    char *tmpcall;
-	    PARAMETER_NEEDED(teststring);
-	    if (strlen(fields[1]) > 20) {
-		mvprintw(6, 0,
-			 "WARNING: Defined call sign too long! exiting...\n");
-		refreshp();
-		exit(1);
-	    }
-	    if (strlen(fields[1]) == 0) {
-		mvprintw(6, 0,
-			 "WARNING: No callsign defined in logcfg.dat! exiting...\n");
-		refreshp();
-		exit(1);
-	    }
-
-	    /* strip NL and trailing whitespace, convert to upper case */
-	    tmpcall = g_ascii_strup(g_strchomp(fields[1]), -1);
-	    g_strlcpy(my.call, tmpcall, 20);
-	    g_free(tmpcall);
-	    /* as other code parts rely on a trailing NL on the call
-	     * we add back such a NL for now */
-	    strcat(my.call, "\n");
-	    // check that call sign can be found in cty database !!
-	    break;
-	}
-	case 17:
-	case 122: {
-	    PARAMETER_NEEDED(teststring);
-	    if (strlen(g_strchomp(fields[1])) > 39) {
-		showmsg
-		    ("WARNING: contest name is too long! exiting...");
-		exit(1);
-	    }
-	    setcontest(fields[1]);
-	    break;
-	}
-	case 18: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(logfile, g_strchomp(fields[1]));
-	    break;
-	}
-	case 19: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(keyer_device, g_strchomp(fields[1]),
-		      sizeof(keyer_device));
-	    break;
-	}
-	case 20: {		// Use the bandswitch output on parport0
-	    /* \todo add message if parameter too short */
-	    use_bandoutput = 1;
-	    if ((fields[1] != NULL) && (strlen(fields[1]) >= 10)) {
-		for (jj = 0; jj <= 9; jj++) {	// 10x
-		    hh = ((int)(fields[1][jj])) - 48;
-
-		    if (hh >= 0 && hh <= 9)
-			bandindexarray[jj] = hh;
-		    else
-			bandindexarray[jj] = 0;
-		}
-	    }
-	    break;
-	}
-	case 21: {
-	    recall_mult = 1;
-	    break;
-	}
-	case 22: {
-	    one_point = 1;
-	    break;
-	}
-	case 23: {
-	    three_point = 1;
-	    break;
-	}
-	case 24: {
-	    wysiwyg_multi = 1;
-	    break;
-	}
-	case 25: {
-	    wysiwyg_once = 1;
-	    break;
-	}
-	case 26: {
-	    trx_control = 1;
-	    break;
-	}
-	case 27: {
-	    rit = 1;
-	    break;
-	}
-	case 28: {
-	    shortqsonr = 1;
-	    break;
-	}
-	case 29: {
-	    shortqsonr = 0;
-	    break;
-	}
-	case 30: {
-	    iscontest = true;
-	    break;
-	}
-	case 31: {
-	    cluster = CLUSTER;
-	    break;
-	}
-	case 32: {
-	    cluster = MAP;
-
-	    /* init bandmap filtering */
-	    bm_config.allband = 1;
-	    bm_config.allmode = 1;
-	    bm_config.showdupes = 1;
-	    bm_config.skipdupes = 0;
-	    bm_config.livetime = 900;
-	    bm_config.onlymults = 0;
-
-	    /* Allow configuration of bandmap display if keyword
-	     * is followed by a '='
-	     * Parameter format is BANDMAP=<xxx>,<number>
-	     * <xxx> - string parsed for the letters B, M, D and S
-	     * <number> - spot livetime in seconds (>=30)
-	     */
-	    if (fields[1] != NULL) {
-		char **bm_fields;
-		bm_fields = g_strsplit(fields[1], ",", 2);
-		if (bm_fields[0] != NULL) {
-		    char *ptr = bm_fields[0];
-		    while (*ptr != '\0') {
-			switch (*ptr++) {
-			    case 'B': bm_config.allband = 0;
-				break;
-			    case 'M': bm_config.allmode = 0;
-				break;
-			    case 'D': bm_config.showdupes = 0;
-				break;
-			    case 'S': bm_config.skipdupes = 1;
-				break;
-			    case 'O': bm_config.onlymults = 1;
-				break;
-			    default:
-				break;
-			}
-		    }
-		}
-
-		if (bm_fields[1] != NULL) {
-		    int livetime;
-		    g_strstrip(bm_fields[1]);
-		    livetime = atoi(bm_fields[1]);
-		    if (livetime >= 30)
-			/* aging called each second */
-			bm_config.livetime = livetime;
-		}
-
-
-		g_strfreev(bm_fields);
-	    }
-	    break;
-	}
-	case 33: {
-	    KeywordNotSupported(teststring);
-	    break;
-	}
-	case 34: {
-	    showscore_flag = 1;
-	    break;
-	}
-	case 35: {
-	    searchflg = 1;
-	    break;
-	}
-	case 36: {
-	    KeywordNotSupported(teststring);
-	    break;
-	}
-	case 37: {
-	    demode = 1;
-	    break;
-	}
-	case 38: {
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strncat(buff, fields[1], 2);
-	    SetCWSpeed(atoi(buff));
-	    break;
-	}
-	case 39: {
-	    int tone;
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strcat(buff, fields[1]);
-	    tone = atoi(buff);
-	    if ((tone > -1) && (tone < 1000)) {
-		sprintf(tonestr, "%d", tone);
-	    }
-	    break;
-	}
-	case 40: {
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strcat(buff, fields[1]);
-	    weight = atoi(buff);
-	    if (weight < -50)
-		weight = -50;
-	    if (weight > 50)
-		weight = 50;
-	    break;
-	}
-	case 41: {
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strcat(buff, fields[1]);
-	    txdelay = atoi(buff);
-	    if (txdelay > 50)
-		txdelay = 50;
-	    if (txdelay < 0)
-		txdelay = 0;
-	    break;
-	}
-	case 42: {
-	    PARAMETER_NEEDED(teststring);
-	    wwv_set_r(atoi(fields[1]));
-	    break;
-	}
-	case 43: {
-	    PARAMETER_NEEDED(teststring);
-	    wwv_set_sfi(atoi(fields[1]));
-	    break;
-	}
-	case 45: {
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    editor_cmd = g_strdup(g_strchomp(fields[1]));
-	}
-	case 46: {
-	    partials = 1;
-	    break;
-	}
-
-	case 47: {
-	    use_part = 1;
-	    break;
-	}
-	/*case 48:{
-	    fixedmult = 5;
-	    break;
-	}
-	case 49:{
-	    fixedmult = 2;
-	    break;
-	}
-	case 50:{
-	    fixedmult = 1;
-	    break;
-	} */
-	case 51: {
-	    KeywordNotSupported(teststring);
-	    break;
-	}
-	case 52: {
-	    exchange_serial = 1;
-	    break;
-	}
-	case 53: {
-	    country_mult = 1;
-	    break;
-	}
-	case 54: {
-	    KeywordNotSupported(teststring);
-	    break;
-	}
-	case 55: {
-	    portable_x2 = 1;
-	    break;
-	}
-	case 56: {
-	    mixedmode = true;
-	    break;
-	}
-	case 57: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(pr_hostaddress, g_strchomp(fields[1]), 48);
-	    break;
-	}
-	case 58: {
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strncat(buff, fields[1], 5);
-	    portnum = atoi(buff);
-	    packetinterface = TELNET_INTERFACE;
-	    break;
-	}
-	case 59: {
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strcat(buff, fields[1]);
-	    if (strlen(buff) > 2) {
-		strncpy(tncportname, buff, 39);
-	    } else
-		tncport = atoi(buff) + 1;
-
-	    packetinterface = TNC_INTERFACE;
-	    break;
-	}
-	case 60: {
-	    packetinterface = FIFO_INTERFACE;
-	    break;
-	}
-	case 61: {
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strcat(buff, fields[1]);
-
-	    if (strncmp(buff, "ORION", 5) == 0)
-		rignumber = 2000;
-	    else
-		rignumber = atoi(buff);
-
-	    myrig_model = (rig_model_t) rignumber;
-
-	    break;
-	}
-	case 62: {
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strcat(buff, fields[1]);
-	    serial_rate = atoi(buff);
-	    break;
-	}
-	case 63: {
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strcat(buff, fields[1]);
-	    tnc_serial_rate = atoi(buff);
-	    break;
-	}
-	case 64: {
-	    PARAMETER_NEEDED(teststring);
-	    rigportname = strdup(fields[1]);
-	    break;
-	}
-	case 65: {
-	    cwkeyer = NET_KEYER;
-	    break;
-	}
-	case 66: {
-	    PARAMETER_NEEDED(teststring);
-	    netkeyer_port = atoi(fields[1]);
-	    break;
-	}
-	case 67: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(netkeyer_hostaddress, g_strchomp(fields[1]), 16);
-	    break;
-	}
-	case 68: {
-	    PARAMETER_NEEDED(teststring);
-	    if (node < MAXNODES) {
-		/* split host name and port number, separated by colon */
-		char **an_fields;
-		an_fields = g_strsplit(fields[1], ":", 2);
-		/* copy host name */
-		g_strlcpy(bc_hostaddress[node], g_strchomp(an_fields[0]),
-			  sizeof(bc_hostaddress[0]));
-		if (an_fields[1] != NULL) {
-		    /* copy host port, if found */
-		    g_strlcpy(bc_hostservice[node], g_strchomp(an_fields[1]),
-			      sizeof(bc_hostservice[0]));
-		}
-		g_strfreev(an_fields);
-
-		if (node++ < MAXNODES)
-		    nodes++;
-	    }
-	    lan_active = 1;
-	    break;
-	}
-	case 69: {
-	    char c;
-	    PARAMETER_NEEDED(teststring);
-	    c = toupper(fields[1][0]);
-	    if (c >= 'A' && c <= 'H')
-		thisnode = c;
-	    else
-		WrongFormat(teststring);
-	    break;
-	}
-	case 70: {
-	    cqwwm2 = 1;
-	    break;
-	}
-	case 71: {
-	    landebug = 1;
-	    break;
-	}
-	case 72 ... 81: {	/* messages */
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(message[ii - 58], fields[1]);
-	    break;
-	}
-	case 82: {
-	    call_update = 1;
-	    break;
-	}
-	case 83: {
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strncat(buff, fields[1], 3);
-	    timeoffset = atoi(buff);
-	    if (timeoffset > 23)
-		timeoffset = 23;
-	    if (timeoffset < -23)
-		timeoffset = -23;
-	    break;
-	}
-	case 84: {
-	    time_master = 1;
-	    break;
-	}
-	case 85: {
-	    ctcomp = 1;
-	    break;
-	}
-	case 86: {
-	    two_point = 1;
-	    break;
-	}
-	case 87: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(multsfile, g_strchomp(fields[1]), 80);
-	    multlist = 1;
-	    break;
-	}
-	case 88: {
-	    serial_section_mult = 1;
-	    break;
-	}
-	case 89: {
-	    sectn_mult = 1;
-	    break;
-	}
-	case 90: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(markerfile, g_strchomp(fields[1]));
-	    xplanet = 1;
-	    break;
-	}
-	case 91: {
-	    dx_arrlsections = 1;
-	    setcontest(whichcontest);
-	    break;
-	}
-	case 92: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(markerfile, g_strchomp(fields[1]));
-	    xplanet = 2;
-	    break;
-	}
-	case 93: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(markerfile, g_strchomp(fields[1]));
-	    xplanet = 3;
-	    break;
-	}
-	case 94: {
-	    nob4 = 1;
-	    break;
-	}
-
-	case 95: {
-	    /* COUNTRYLIST   (in file or listed in logcfg.dat)     LZ3NY
-	     */
-
-	    int counter = 0;
-	    static char country_list_raw[50] = ""; 	/* use only first
-						   	COUNTRY_LIST
-						   	definition */
-	    char temp_buffer[255] = "";
-	    char buffer[255] = "";
-	    FILE *fp;
-
-	    PARAMETER_NEEDED(teststring);
-	    if (strlen(country_list_raw) == 0) {/* only if first definition */
-
-		/* First of all we are checking if the parameter <xxx> in
-		COUNTRY_LIST=<xxx> is a file name.  If it is we start
-		parsing the file. If we  find a line starting with our
-		case insensitive contest name, we copy the countries from
-		that line into country_list_raw.
-		If the input was not a file name we directly copy it into
-		country_list_raw (must not have a preceeding contest name). */
-
-		g_strlcpy(temp_buffer, fields[1], sizeof(temp_buffer));
-		g_strchomp(temp_buffer);	/* drop trailing whitespace */
-
-		if ((fp = fopen(temp_buffer, "r")) != NULL) {
-
-		    while (fgets(buffer, sizeof(buffer), fp) != NULL) {
-
-			g_strchomp(buffer);   /* no trailing whitespace*/
-
-			/* accept only a line starting with the contest name
-			 * (CONTEST=) followed by ':' */
-			if (strncasecmp(buffer, whichcontest,
-					strlen(whichcontest) - 1) == 0) {
-
-			    strncpy(country_list_raw,
-				    buffer + strlen(whichcontest) + 1,
-				    strlen(buffer) - 1);
-			}
-		    }
-
-		    fclose(fp);
-		} else {	/* not a file */
-
-		    if (strlen(temp_buffer) > 0)
-			strcpy(country_list_raw, temp_buffer);
-		}
-	    }
-
-	    /* parse the country_list_raw string into an array
-	     * (countrylist) for future use. */
-	    tk_ptr = strtok(country_list_raw, ":,.- \t");
-	    counter = 0;
-
-	    if (tk_ptr != NULL) {
-		while (tk_ptr) {
-		    strcpy(countrylist[counter], tk_ptr);
-		    tk_ptr = strtok(NULL, ":,.-_\t ");
-		    counter++;
-		}
-	    }
-
-	    /* on which multiplier side of the rules we are */
-	    getpx(my.call);
-	    mult_side = exist_in_country_list();
-	    setcontest(whichcontest);
-	    break;
-	}
-
-	case 96: {		// COUNTRY_LIST_POINTS
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(c_temp, fields[1], sizeof(c_temp));
-	    if (countrylist_points == -1)
-		countrylist_points = atoi(c_temp);
-
-	    break;
-	}
-	case 97: {		// COUNTRY_LIST_ONLY
-	    countrylist_only = true;
-	    if (mult_side == 1)
-		countrylist_only = false;
-
-	    break;
-	}
-	case 98: {		//HOW Many points scores my country  lz3ny
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(c_temp, fields[1], sizeof(c_temp));
-	    if (my_country_points == -1)
-		my_country_points = atoi(c_temp);
-
-	    break;
-	}
-	case 99: {		//MY_CONTINENT_POINTS       lz3ny
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(c_temp, fields[1], sizeof(c_temp));
-	    if (my_cont_points == -1)
-		my_cont_points = atoi(c_temp);
-
-	    break;
-	}
-	case 100: {		//DX_CONTINENT_POINTS       lz3ny
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(c_temp, fields[1], sizeof(c_temp));
-	    if (dx_cont_points == -1)
-		dx_cont_points = atoi(c_temp);
-
-	    break;
-	}
-	/* end LZ3NY mod */
-	case 101: {		// show time in searchlog window
-	    show_time = 1;
-	    break;
-	}
-	case 102: {		// use rxvt colours
-	    use_rxvt = 1;
-	    break;
-	}
-	case 103 ... 116: {	// get phone messages
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(ph_message[ii - 103], g_strchomp(fields[1]), 71);
-	    if (verbose) {
-		gchar *tmp;
-		tmp = g_strdup_printf("  Phone message #%d is %s", ii - 103,
-				      ph_message[ii - 103]);	// (W9WI)
-		showmsg(tmp);
-		g_free(tmp);
-	    }
-	    break;
-	}
-	case 117: {		// WAZ Zone is a Multiplier
-	    wazmult = 1;
-	    break;
-	}
-	case 118: {		// ITU Zone is a Multiplier
-	    itumult = 1;
-	    break;
-	}
-	case 119: {		// CQ Delay (0.5 sec)
-	    PARAMETER_NEEDED(teststring);
-	    buff[0] = '\0';
-	    strncpy(buff, fields[1], 3);
-	    cqdelay = atoi(buff);
-	    if ((cqdelay < 3) || (cqdelay > 60))
-		cqdelay = 20;
-
-	    break;
-	}
-	case 120: {		// wpx style prefixes mult
-	    pfxmult = 1;	// enable set points
-	    break;
-	}
-	case 121: {		// exchange continent abbrev
-	    exc_cont = 1;
-	    break;
-	}
-	case 123: {		// don't use auto_cq
-	    noautocq = 1;
-	    break;
-	}
-	case 124: {		// start in SSB mode
-	    trxmode = SSBMODE;
-	    break;
-	}
-	case 125: {		// arrow keys don't switch bands...
-	    no_arrows = 1;
-	    break;
-	}
-	case 126: {		// Hamlib rig conf parameters
-	    PARAMETER_NEEDED(teststring);
-	    if (strlen(fields[1]) >= 80) {
-		showmsg
-		("WARNING: rigconf parameters too long! exiting...");
-		sleep(5);
-		exit(1);
-	    }
-	    g_strlcpy(rigconf, g_strchomp(fields[1]), 80);	// RIGCONF=
-	    break;
-	}
-	case 127: {		// define color GREEN (header)
-	    PARAMETER_NEEDED(teststring);
-	    if (strlen(fields[1]) >= 2 && isdigit(fields[1][0]) &&
-		    isdigit(fields[1][1])) {
-		tlfcolors[1][0] = fields[1][0] - 48;
-		tlfcolors[1][1] = fields[1][1] - 48;
-	    } else {
-		WrongFormat(teststring);
-	    }
-	    break;
-	}
-	case 128 ... 132: {		// define color CYAN (windows), WHITE (log win)
-	    // MAGENTA (Marker / dupes), BLUE (input field)
-	    // and YELLOW (Window frames)
-	    PARAMETER_NEEDED(teststring);
-	    if (strlen(fields[1]) >= 2 && isdigit(fields[1][0]) &&
-		    isdigit(fields[1][1])) {
-		tlfcolors[ii - 128 + 3][0] = fields[1][0] - 48;
-		tlfcolors[ii - 128 + 3][1] = fields[1][1] - 48;
-	    } else {
-		WrongFormat(teststring);
-	    }
-	    break;
-	}
-	case 133: {		// define name of synclogfile
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(synclogfile, g_strchomp(fields[1]));
-	    break;
-	}
-	case 134: {		//SSBPOINTS=
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(buff, fields[1]);
-	    ssbpoints = atoi(buff);
-	    break;
-	}
-	case 135: {		//CWPOINTS=
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(buff, fields[1]);
-	    cwpoints = atoi(buff);
-	    break;
-	}
-	case 136: {		// SOUNDCARD, use soundcard for cw sidetone
-	    sc_sidetone = 1;
-	    break;
-	}
-	case 137: {		// sound card volume (default = 70)
-	    int volume;
-
-	    PARAMETER_NEEDED(teststring);
-	    volume = atoi(fields[1]);
-	    if (volume > -1 && volume < 101)
-		sprintf(sc_volume, "%d", volume);
-	    else
-		strcpy(sc_volume, "70");
-	    break;
-	}
-	case 139: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(sc_device, g_strchomp(fields[1]), sizeof(sc_device));
-	    break;
-	}
-	case 140: {
-	    PARAMETER_NEEDED(teststring);
-	    cwkeyer = MFJ1278_KEYER;
-	    digikeyer = MFJ1278_KEYER;
-	    g_strlcpy(controllerport, g_strchomp(fields[1]),
-		      sizeof(controllerport));
-	    break;
-	}
-	case 141: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(clusterlogin, fields[1]);
-	    break;
-	}
-	case 142: {
-	    KeywordNotSupported(teststring);
-	    break;
-	}
-	case 143: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(exchange_list, g_strchomp(fields[1]),
-		      sizeof(exchange_list));
-	    break;
-	}
-	case 144: {
-	    PARAMETER_NEEDED(teststring);
-	    cw_bandwidth = atoi(fields[1]);
-	    break;
-	}
-	case 145: {
-	    lowband_point_mult = 1;
-	    break;
-	}
-	case 146: {
-	    clusterlog = 1;
-	    break;
-	}
-	case 147: {
-	    serial_grid4_mult = 1;
-	    break;
-	}
-	case 148: {
-	    change_rst = true;
-	    if (g_strv_length(fields) == 2) {
-		/* comma separated list of RS(T) values 33..39, 43..39, 53..59
-		 * allowed.
-		 */
-		if (!g_regex_match_simple(
-			    "^([3-5][3-9]\\d?\\s*,\\s*)*[3-5][3-9]\\d?$",
-			    g_strstrip(fields[1]), G_REGEX_CASELESS,
-			    (GRegexMatchFlags)0)) {
-		    WrongFormat(teststring);
-		}
-		rst_init(fields[1]);
-	    } else {
-		rst_init(NULL);
-	    }
-	    break;
-	}
-	case 149: {
-	    PARAMETER_NEEDED(teststring);
-	    digikeyer = GMFSK;
-	    g_strlcpy(controllerport, g_strchomp(fields[1]),
-		      sizeof(controllerport));
-	    break;
-	}
-	case 150: {		// start in digital mode
-	    trxmode = DIGIMODE;
-	    strcpy(modem_mode, "RTTY");
-	    break;
-	}
-	case 151: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(rttyoutput, g_strchomp(fields[1]), 111);
-	    break;
-	}
-	case 152: {
-	    logfrequency = 1;
-	    break;
-	}
-	case 153: {
-	    ignoredupe = true;
-	    break;
-	}
-	case 154: {		/* read name of cabrillo format to use */
-
-	    if (cabrillo != NULL) {
-		free(cabrillo);	/* free old string if already set */
-		cabrillo = NULL;
-	    }
-	    cabrillo = strdup(g_strchomp(fields[1]));
-	    break;
-	}
-	case 155:
-	case 156:
-	case 157: {
-	    KeywordNotSupported(teststring);
-	    break;
-	}
-	case 158: {
-	    no_rst = 1;
-	    break;
-	}
-	case 159: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(my.qra, fields[1]);
-
-	    if (check_qra(my.qra) == 0) {
-		showmsg
-		("WARNING: Invalid MYQRA parameters! exiting...");
-		sleep(5);
-		exit(1);
-	    }
-	    break;
-	}
-	case 160: {
-	    PARAMETER_NEEDED(teststring);
-	    if (fixedmult == 0.0 && atof(fields[1]) > 0.0) {
-		fixedmult = atof(fields[1]);
-	    }
-	    break;
-	}
-	case 161: {
-	    serial_or_section = 1;
-	    break;
-	}
-
-	case 162: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strchomp(fields[1]);
-	    if (strncmp(fields[1], "RECV", 4) == 0) {
-		qtcdirection = RECV;
-	    }
-	    if (strncmp(fields[1], "SEND", 4) == 0) {
-		qtcdirection = SEND;
-	    } else if (strcmp(fields[1], "BOTH") == 0) {
-		qtcdirection = RECV | SEND;
-	    }
-	    if (qtcdirection == 0) {
-		KeywordNotSupported(teststring);
-	    } else {
-		int q;
-		for (q = 0; q < QTC_RY_LINE_NR; q++) {
-		    qtc_ry_lines[q].content[0] = '\0';
-		    qtc_ry_lines[q].attr = 0;
-		}
-	    }
-	    break;
-	}
-
-	case 163: {
-	    /* based on LZ3NY code, by HA2OS
-	       CONTINENT_LIST   (in file or listed in logcfg.dat),
-	       First of all we are checking if inserted data in
-	       CONTINENT_LIST= is a file name.  If it is we start
-	       parsing the file. If we got our case insensitive contest name,
-	       we copy the multipliers from it into multipliers_list.
-	       If the input was not a file name we directly copy it into
-	       cont_multiplier_list (must not have a preceeding contest name).
-	       The last step is to parse the multipliers_list into an array
-	       (continent_multiplier_list) for future use.
-	     */
-
-	    int counter = 0;
-	    static char cont_multiplier_list[50] = ""; 	/* use only first
-						   	CONTINENT_LIST
-						   	definition */
-	    char temp_buffer[255] = "";
-	    char buffer[255] = "";
-	    FILE *fp;
-
-	    PARAMETER_NEEDED(teststring);
-	    if (strlen(cont_multiplier_list) == 0) {	/* if first definition */
-		g_strlcpy(temp_buffer, fields[1], sizeof(temp_buffer));
-		g_strchomp(temp_buffer);	/* drop trailing whitespace */
-
-		if ((fp = fopen(temp_buffer, "r")) != NULL) {
-
-		    while (fgets(buffer, sizeof(buffer), fp) != NULL) {
-
-			g_strchomp(buffer);   /* no trailing whitespace*/
-
-			/* accept only a line starting with the contest name
-			 * (CONTEST=) followed by ':' */
-			if (strncasecmp(buffer, whichcontest,
-					strlen(whichcontest) - 1) == 0) {
-
-			    strncpy(cont_multiplier_list,
-				    buffer + strlen(whichcontest) + 1,
-				    strlen(buffer) - 1);
-			}
-		    }
-
-		    fclose(fp);
-		} else {	/* not a file */
-
-		    if (strlen(temp_buffer) > 0)
-			strcpy(cont_multiplier_list, temp_buffer);
-		}
-	    }
-
-	    /* creating the array */
-	    tk_ptr = strtok(cont_multiplier_list, ":,.- \t");
-	    counter = 0;
-
-	    if (tk_ptr != NULL) {
-		while (tk_ptr) {
-		    strncpy(continent_multiplier_list[counter], tk_ptr, 2);
-		    tk_ptr = strtok(NULL, ":,.-_\t ");
-		    counter++;
-		}
-	    }
-
-	    setcontest(whichcontest);
-	    break;
-	}
-
-
-	case 164: {		// CONTINENT_LIST_POINTS
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(c_temp, fields[1], sizeof(c_temp));
-	    if (continentlist_points == -1) {
-		continentlist_points = atoi(c_temp);
-	    }
-
-	    break;
-	}
-	case 165: {		// CONTINENT_LIST_ONLY
-	    continentlist_only = true;
-	    break;
-	}
-
-	case 166: {		// BANDWEIGHT_POINTS
-	    PARAMETER_NEEDED(teststring);
-	    static char bwp_params_list[50] = "";
-	    int bandindex = -1;
-
-	    if (strlen(bwp_params_list) == 0) {
-		g_strlcpy(bwp_params_list, fields[1], sizeof(bwp_params_list));
-		g_strchomp(bwp_params_list);
-	    }
-
-	    tk_ptr = strtok(bwp_params_list, ";:,");
-	    if (tk_ptr != NULL) {
-		while (tk_ptr) {
-
-		    bandindex = getidxbybandstr(g_strchomp(tk_ptr));
-		    tk_ptr = strtok(NULL, ";:,");
-		    if (tk_ptr != NULL && bandindex >= 0) {
-			bandweight_points[bandindex] = atoi(tk_ptr);
-		    }
-		    tk_ptr = strtok(NULL, ";:,");
-		}
-	    }
-	    break;
-	}
-
-	case 167: {		// BANDWEIGHT_MULTIS
-	    PARAMETER_NEEDED(teststring);
-	    static char bwm_params_list[50] = "";
-	    int bandindex = -1;
-
-	    if (strlen(bwm_params_list) == 0) {
-		g_strlcpy(bwm_params_list, fields[1], sizeof(bwm_params_list));
-		g_strchomp(bwm_params_list);
-	    }
-
-	    tk_ptr = strtok(bwm_params_list, ";:,");
-	    if (tk_ptr != NULL) {
-		while (tk_ptr) {
-
-		    bandindex = getidxbybandstr(g_strchomp(tk_ptr));
-		    tk_ptr = strtok(NULL, ";:,");
-		    if (tk_ptr != NULL && bandindex >= 0) {
-			bandweight_multis[bandindex] = atoi(tk_ptr);
-		    }
-		    tk_ptr = strtok(NULL, ";:,");
-		}
-	    }
-	    break;
-	}
-
-	case 168: {
-	    /* based on LZ3NY code, by HA2OS
-	       PFX_NUM_MULTIS   (in file or listed in logcfg.dat),
-	       We directly copy it into pfxnummulti_str, then parse the prefixlist
-	       and fill the pfxnummulti array.
-	     */
-
-	    int counter = 0;
-	    int pfxnum;
-	    static char pfxnummulti_str[50] = "";
-	    char parsepfx[15] = "";
-
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(pfxnummulti_str, fields[1], sizeof(pfxnummulti_str));
-	    g_strchomp(pfxnummulti_str);
-
-	    /* creating the array */
-	    tk_ptr = strtok(pfxnummulti_str, ",");
-	    counter = 0;
-
-	    if (tk_ptr != NULL) {
-		while (tk_ptr) {
-		    parsepfx[0] = '\0';
-		    if (isdigit(tk_ptr[strlen(tk_ptr) - 1])) {
-			sprintf(parsepfx, "%sAA", tk_ptr);
-		    } else {
-			sprintf(parsepfx, "%s0AA", tk_ptr);
-		    }
-		    pfxnummulti[counter].countrynr = getctydata(parsepfx);
-		    for (pfxnum = 0; pfxnum < 10; pfxnum++) {
-			pfxnummulti[counter].qsos[pfxnum] = 0;
-		    }
-		    tk_ptr = strtok(NULL, ",");
-		    counter++;
-		}
-	    }
-	    pfxnummultinr = counter;
-	    setcontest(whichcontest);
-	    break;
-	}
-	case 169: {		/* wpx style prefixes mult */
-	    pfxmultab = 1;	/* enable pfx on all band */
-	    break;
-	}
-
-	case 170 ... 181: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(qtc_recv_msgs[ii - 170], fields[1]);
-	    break;
-	}
-	case 182 ... 193: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(qtc_send_msgs[ii - 182], fields[1]);
-	    break;
-	}
-	case 194 ... 207: {	// get QTC recv phone messages
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(qtc_phrecv_message[ii - 194], g_strchomp(fields[1]), 71);
-	    if (verbose) {
-		gchar *tmp;
-		tmp = g_strdup_printf("  QTC RECV phone message #%d is %s",
-				      ii - 194, qtc_phrecv_message[ii - 194]);
-		showmsg(tmp);
-		g_free(tmp);
-	    }
-	    break;
-	}
-	case 208 ... 221: {	// get QTC send phone messages
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(qtc_phsend_message[ii - 208], g_strchomp(fields[1]), 71);
-	    if (verbose) {
-		gchar *tmp;
-		tmp = g_strdup_printf("  QTC SEND phone message #%d is %s",
-				      ii - 208, qtc_phrecv_message[ii - 208]);
-		showmsg(tmp);
-		g_free(tmp);
-	    }
-	    break;
-	}
-	case 222: {
-	    qtcrec_record = 1;
-	    break;
-	}
-	case 223: {
-	    PARAMETER_NEEDED(teststring);
-	    int p, q = 0, i = 0, s = 0;
-	    for (p = 0; p < strlen(fields[1]); p++) {
-		if (p > 0 && fields[1][p] == ' ') {
-		    s = 1;
-		    qtcrec_record_command_shutdown[p] = '\0';
-		}
-		if (s == 0) {
-		    qtcrec_record_command_shutdown[p] = fields[1][p];
-		}
-		if (fields[1][p] == '$') {
-		    qtcrec_record_command[i][q] = '\0';
-		    i = 1;
-		    p++;
-		    q = 0;
-		}
-		if (fields[1][p] != '\n') {
-		    qtcrec_record_command[i][q] = fields[1][p];
-		}
-		q++;
-		qtcrec_record_command[i][q] = ' ';
-	    }
-
-	    if (qtcrec_record_command[i][q - 1] != '&') {
-		qtcrec_record_command[i][q++] = ' ';
-		qtcrec_record_command[i][q++] = '&';
-	    }
-	    qtcrec_record_command[i][q] = '\0';
-	    break;
-	}
-	case 224: {
-	    PARAMETER_NEEDED(teststring);
-	    if (strcmp(g_strchomp(fields[1]), "CONTINENTLIST") == 0) {
-		if (strlen(continent_multiplier_list[0]) == 0) {
-		    showmsg
-		    ("WARNING: you need to set the CONTINENTLIST parameter...");
-		    sleep(5);
-		    exit(1);
-		}
-		exclude_multilist_type = EXCLUDE_CONTINENT;
-	    } else if (strcmp(g_strchomp(fields[1]), "COUNTRYLIST") == 0) {
-		if (strlen(countrylist[0]) == 0) {
-		    showmsg
-		    ("WARNING: you need to set the COUNTRYLIST parameter...");
-		    sleep(5);
-		    exit(1);
-		}
-		exclude_multilist_type = EXCLUDE_COUNTRY;
-	    } else {
-		showmsg
-		("WARNING: choose one of these for EXCLUDE_MULTILIST: CONTINENTLIST, COUNTRYLIST");
-		sleep(5);
-		exit(1);
-	    }
-	    break;
-	}
-	case 225: {
-	    PARAMETER_NEEDED(teststring);
-	    strcpy(message[SP_CALL_MSG], fields[1]);
-	    break;	/* end messages */
-	}
-	case 226: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strlcpy(qtc_cap_calls, g_strchomp(fields[1]),
-		      sizeof(exchange_list));
-	    break;
-	}
-	case 227: {
-	    qtc_auto_filltime = 1;
-	    break;
-	}
-	case 228: {
-	    bmautograb = 1;
-	    break;
-	}
-	case 229: {
-	    bmautoadd = 1;
-	    break;
-	}
-	case 230: {
-	    qtc_recv_lazy = 1;
-	    break;
-	}
-	case 231: {
-	    sprint_mode = 1;
-	    break;
-	}
-	case 232: {
-#ifndef HAVE_LIBXMLRPC
-	    showmsg("WARNING: XMLRPC not compiled - skipping setup.");
-	    sleep(2);
-	    digikeyer = NO_KEYER;
-#else
-	    if (fields[1] != NULL) {
-		g_strlcpy(fldigi_url, g_strchomp(fields[1]),
-			  sizeof(fldigi_url));
-	    }
-	    digikeyer = FLDIGI;
-	    if (!fldigi_isenabled())
-		fldigi_toggle();
-#endif
-	    break;
-	}
-	case 233: {
-	    rigptt |= (1 << 0);		/* bit 0 set--CAT PTT wanted (RIGPTT) */
-	    break;
-	}
-	case 234: {
-	    if (fields[1] != NULL) {
-		int minisec;
-		minisec = atoi(g_strchomp(fields[1]));
-		if ((3600 % minisec) != 0) {
-		    showmsg
-		    ("WARNING: invalid MINITEST value, must be an integral divider for 3600s!");
-		    sleep(5);
-		    exit(1);
-		} else {
-		    minitest = minisec;
-		}
-	    } else {
-		minitest = MINITEST_DEFAULT_PERIOD;
-	    }
-	    break;
-	}
-	case 235: {
-	    PARAMETER_NEEDED(teststring);
-	    if (strcmp(g_strchomp(fields[1]), "ALL") == 0) {
-		unique_call_multi = UNIQUECALL_ALL;
-	    } else if (strcmp(g_strchomp(fields[1]), "BAND") == 0) {
-		unique_call_multi = UNIQUECALL_BAND;
-	    } else {
-		showmsg
-		("WARNING: choose one of these for UNIQUE_CALL_MULTI: ALL, BAND");
-		sleep(5);
-		exit(1);
-	    }
-	    break;
-	}
-	case 236: { // KEYER_BACKSPACE
-	    keyer_backspace = 1;
-	    break;
-	}
-	case 237: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strchomp(fields[1]);
-	    if (strcmp(fields[1], "USB") == 0)
-		digi_mode = RIG_MODE_USB;
-	    else if (strcmp(fields[1], "LSB") == 0)
-		digi_mode = RIG_MODE_LSB;
-	    else if (strcmp(fields[1], "RTTY") == 0)
-		digi_mode = RIG_MODE_RTTY;
-	    else if (strcmp(fields[1], "RTTYR") == 0)
-		digi_mode = RIG_MODE_RTTYR;
-	    else {
-		showmsg
-		("WARNING: invalid DIGI_RIG_MODE value, must be \"USB\", \"LSB\", \"RTTY\", or \"RTTYR\"");
-		sleep(5);
-		exit(1);
-	    }
-	    break;
-	}
-	case 238 ... 249: {
-	    PARAMETER_NEEDED(teststring);
-	    if (digi_message[ii - 238]) {
-		KeywordRepeated(commands[ii]);
-		free(digi_message[ii - 238]);
-	    }
-	    digi_message[ii - 238] = strdup(fields[1]);
-	    if (digi_message[ii - 238]) {
-		/* Replace trailing newline with a space */
-		char *nl = strrchr(digi_message[ii - 238], '\n');
-		if (nl)
-		    *nl = ' ';
-	    }
-	    break;
-	}
-	case 250:
-	    PARAMETER_NEEDED(teststring);
-	    if (digi_message[CQ_TU_MSG]) {
-		KeywordRepeated(commands[ii]);
-		free(digi_message[CQ_TU_MSG]);
-	    }
-	    digi_message[CQ_TU_MSG] = strdup(fields[1]);
-	    if (digi_message[CQ_TU_MSG]) {
-		/* Replace trailing newline with a space */
-		char *nl = strrchr(digi_message[CQ_TU_MSG], '\n');
-		if (nl)
-		    *nl = ' ';
-	    }
-	    break;
-	case 251:
-	    PARAMETER_NEEDED(teststring);
-	    if (digi_message[SP_TU_MSG]) {
-		KeywordRepeated(commands[ii]);
-		free(digi_message[SP_TU_MSG]);
-	    }
-	    digi_message[SP_TU_MSG] = strdup(fields[1]);
-	    if (digi_message[SP_TU_MSG]) {
-		/* Replace trailing newline with a space */
-		char *nl = strrchr(digi_message[SP_TU_MSG], '\n');
-		if (nl)
-		    *nl = ' ';
-	    }
-	    break;
-	case 252:
-	    PARAMETER_NEEDED(teststring);
-	    if (digi_message[SP_CALL_MSG]) {
-		KeywordRepeated(commands[ii]);
-		free(digi_message[SP_CALL_MSG]);
-	    }
-	    digi_message[SP_CALL_MSG] = strdup(fields[1]);
-	    if (digi_message[SP_CALL_MSG]) {
-		/* Replace trailing newline with a space */
-		char *nl = strrchr(digi_message[SP_CALL_MSG], '\n');
-		if (nl)
-		    *nl = ' ';
-	    }
-	    break;
-	case 253 ... 262: {
-	    PARAMETER_NEEDED(teststring);
-	    if (digi_message[ii - 239]) {
-		KeywordRepeated(commands[ii]);
-		free(digi_message[ii - 239]);
-	    }
-	    digi_message[ii - 239] = strdup(fields[1]);
-	    if (digi_message[ii - 239]) {
-		/* Replace trailing newline with a space */
-		char *nl = strrchr(digi_message[ii - 239], '\n');
-		if (nl)
-		    *nl = ' ';
-	    }
-	    break;
-	}
-	case 263: {
-	    PARAMETER_NEEDED(teststring);
-	    g_strchomp(fields[1]);
-	    if (callmaster_filename != NULL) {
-		g_free(callmaster_filename);
-	    }
-	    callmaster_filename = g_strdup(fields[1]);
-
-	    break;
-	}
-	case 264: {
-	    PARAMETER_NEEDED(teststring);
-	    lan_port = atoi(fields[1]);
-	    break;
-	}
-	case 265: {
-	    sectn_mult_once = 1;
-	    break;
-	}
-	default: {
-	    KeywordNotSupported(teststring);
-	    break;
-	}
-    }
+    int result = apply_config(fields[0], fields[1], logcfg_configs);
 
     g_strfreev(fields);
-
-    return (confirmation_needed);
-
+    return result;
 }
 
 
@@ -2013,42 +1391,46 @@ void Complain(char *msg) {
     attron(A_STANDOUT);
     showmsg(msg);
     attroff(A_STANDOUT);
-    confirmation_needed = PARSE_CONFIRM;
     beep();
 }
 
-/** Complain about duplicate keyword */
-void KeywordRepeated(char *keyword) {
-    char msgbuffer[128];
-    sprintf(msgbuffer,
-	    "Keyword '%s' repeated more than once.\n",
-	    keyword);
-    Complain(msgbuffer);
-}
-
 /** Complain about not supported keyword */
-void KeywordNotSupported(char *keyword) {
+void KeywordNotSupported(const char *keyword) {
     char msgbuffer[192];
-    sprintf(msgbuffer,
-	    "Keyword '%s' not supported. See man page.\n",
-	    keyword);
+    sprintf(msgbuffer, "Keyword '%s' not supported. See man page.\n", keyword);
     Complain(msgbuffer);
 }
 
 /** Complain about missing parameter */
-void ParameterNeeded(char *keyword) {
+void ParameterNeeded(const char *keyword) {
     char msgbuffer[192];
     sprintf(msgbuffer,
-	    "Keyword '%s' must be followed by an parameter ('=....'). See man page.\n",
+	    "Keyword '%s' must be followed by a parameter ('=....'). See man page.\n",
+	    keyword);
+    Complain(msgbuffer);
+}
+
+void ParameterUnexpected(const char *keyword) {
+    char msgbuffer[192];
+    sprintf(msgbuffer,
+	    "Keyword '%s' can't have a parameter. See man page.\n",
 	    keyword);
     Complain(msgbuffer);
 }
 
 /** Complain about wrong parameter format */
-void WrongFormat(char *keyword) {
+void WrongFormat(const char *keyword) {
     char msgbuffer[192];
     sprintf(msgbuffer,
 	    "Wrong parameter format for keyword '%s'. See man page.\n",
 	    keyword);
+    Complain(msgbuffer);
+}
+
+void WrongFormat_details(const char *keyword, const char *details) {
+    char msgbuffer[192];
+    sprintf(msgbuffer,
+	    "Wrong parameter for keyword '%s': %s.\n",
+	    keyword, details);
     Complain(msgbuffer);
 }

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -690,13 +690,12 @@ int parse_logcfg(char *inputbuffer) {
 	case 17:
 	case 122: {
 	    PARAMETER_NEEDED(teststring);
-	    strcpy(whichcontest, g_strchomp(fields[1]));
-	    if (strlen(whichcontest) > 40) {
+	    if (strlen(g_strchomp(fields[1])) > 39) {
 		showmsg
-		("WARNING: contest name is too long! exiting...");
+		    ("WARNING: contest name is too long! exiting...");
 		exit(1);
 	    }
-	    setcontest();
+	    setcontest(fields[1]);
 	    break;
 	}
 	case 18: {
@@ -1117,7 +1116,7 @@ int parse_logcfg(char *inputbuffer) {
 	}
 	case 91: {
 	    dx_arrlsections = 1;
-	    setcontest();
+	    setcontest(whichcontest);
 	    break;
 	}
 	case 92: {
@@ -1204,7 +1203,7 @@ int parse_logcfg(char *inputbuffer) {
 	    /* on which multiplier side of the rules we are */
 	    getpx(my.call);
 	    mult_side = exist_in_country_list();
-	    setcontest();
+	    setcontest(whichcontest);
 	    break;
 	}
 
@@ -1590,7 +1589,7 @@ int parse_logcfg(char *inputbuffer) {
 		}
 	    }
 
-	    setcontest();
+	    setcontest(whichcontest);
 	    break;
 	}
 
@@ -1696,7 +1695,7 @@ int parse_logcfg(char *inputbuffer) {
 		}
 	    }
 	    pfxnummultinr = counter;
-	    setcontest();
+	    setcontest(whichcontest);
 	    break;
 	}
 	case 169: {		/* wpx style prefixes mult */

--- a/src/parse_logcfg.h
+++ b/src/parse_logcfg.h
@@ -21,14 +21,107 @@
 #ifndef PARSE_LOGCFG_H
 #define PARSE_LOGCFG_H
 
+#include <stdbool.h>
+
 enum {
     PARSE_OK,
     PARSE_ERROR,
-    PARSE_CONFIRM
+    PARSE_NO_MATCH,
+    PARSE_MISSING_PARAMETER,
+    PARSE_EXTRA_PARAMETER,
+    PARSE_WRONG_PARAMETER,
+    PARSE_INVALID_INTEGER,
+    PARSE_INTEGER_OUT_OF_RANGE,
+    PARSE_STRING_TOO_LONG,
 };
 
 int read_logcfg(void);
 int parse_configfile(FILE *fp);
 int parse_logcfg(char *inputbuffer);
+
+////////////////////////////////////
+// config parsing definitions
+
+enum {
+    NO_PARAM,
+    NEED_PARAM,
+    OPTIONAL_PARAM,
+};
+
+enum {
+    DYNAMIC,
+    STATIC,
+    MESSAGE,
+};
+
+typedef struct {
+    union {     // targets
+	int *int_p;
+	bool *bool_p;
+	char *char_p;
+	char **char_pp;
+	char (*msg)[80];
+    };
+    union {     // extra info
+	int int_value;
+	bool bool_value;
+	struct {
+	    int string_type;
+	    int base, size;
+	    bool chomp, strip, nl_to_space;
+	};
+	struct {
+	    int min, max;
+	};
+    };
+} cfg_arg_t;
+
+typedef struct {
+    char *regex;
+    int param_kind;
+    int (*func)(const cfg_arg_t arg);
+    cfg_arg_t arg;
+} config_t;
+
+#define CFG_BOOL_TRUE(var)  NO_PARAM, cfg_bool_const, \
+        (cfg_arg_t){.bool_p=&var, .bool_value=true}
+
+#define CFG_INT_CONST(var,n)    NO_PARAM, cfg_int_const, \
+        (cfg_arg_t){.int_p=&var, .int_value=n}
+
+#define CFG_INT_ONE(var)    CFG_INT_CONST(var, 1)
+
+#define CFG_INT(var,minval,maxval)  NEED_PARAM, cfg_integer, \
+        (cfg_arg_t){.int_p=&var, .min=minval, .max=maxval}
+
+#define CFG_STRING_STATIC(var,bufsize)  NEED_PARAM, cfg_string, \
+        (cfg_arg_t){.char_p=var, .size=bufsize, .chomp=true, \
+                    .string_type=STATIC}
+
+#define CFG_STRING(var)         NEED_PARAM, cfg_string, \
+        (cfg_arg_t){.char_pp=&var, .chomp=true, \
+                    .string_type=DYNAMIC}
+
+#define CFG_MESSAGE(var, i)     NEED_PARAM, cfg_string, \
+        (cfg_arg_t){.msg=var, .base=i, .size=80, \
+                    .string_type=MESSAGE}
+
+#define CFG_MESSAGE_CHOMP(var, i)   NEED_PARAM, cfg_string, \
+        (cfg_arg_t){.msg=var, .base=i, .size=80, .chomp=true, \
+                    .string_type=MESSAGE}
+
+#define CFG_MESSAGE_DYNAMIC(var, i) NEED_PARAM, cfg_string, \
+        (cfg_arg_t){.char_pp=var, .base=i, .size=80, .nl_to_space=true, \
+                    .string_type=DYNAMIC}
+
+// FIXME: remove NOCHOMPs
+#define CFG_STRING_STATIC_NOCHOMP(var,bufsize) NEED_PARAM, cfg_string, \
+        (cfg_arg_t){.char_p=var, .size=bufsize, \
+                    .string_type=STATIC}
+
+#define CFG_STRING_NOCHOMP(var) NEED_PARAM, cfg_string, \
+        (cfg_arg_t){.char_pp=&var, \
+                    .string_type=DYNAMIC}
+
 
 #endif // PARSE_LOGCFG_H

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -46,6 +46,7 @@
 #include "readqtccalls.h"
 #include "score.h"
 #include "searchcallarray.h"
+#include "setcontest.h"
 #include "startmsg.h"
 #include "tlf_curses.h"
 #include "zone_nr.h"
@@ -390,7 +391,7 @@ int readcalls(void) {
     fclose(fp);
 
     /* all lines red, now build other statistics */
-    if (wpx == 1 || pfxmult == 1) {
+    if (IS_CONTEST(WPX) || pfxmult == 1) {
 
 	/* build prefixes_worked array from list of worked stations */
 	InitPfx();

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -281,7 +281,7 @@ int readcalls(void) {
 	    // get points
 	    total = total + log_get_points(inputbuffer);
 
-	    if ((cqww == 1) || (itumult == 1) || (wazmult == 1)) {
+	    if (IS_CONTEST(CQWW) || (itumult == 1) || (wazmult == 1)) {
 		// get the zone
 		z = zone_nr(inputbuffer + 54);
 	    }
@@ -375,7 +375,7 @@ int readcalls(void) {
 
 	    band_score[bandindex]++;	/*  qso counter  per band */
 
-	    if ((cqww == 1) || (itumult == 1) || (wazmult == 1))
+	    if (IS_CONTEST(CQWW) || (itumult == 1) || (wazmult == 1))
 		zones[z] |= inxes[bandindex];
 
 	    if (pfxnumcntidx < 0) {
@@ -410,13 +410,13 @@ int readcalls(void) {
 	}
     }
 
-    if ((cqww == 1) || (itumult == 1) || (wazmult == 1)) {
+    if (IS_CONTEST(CQWW) || (itumult == 1) || (wazmult == 1)) {
 	for (int n = 1; n < MAX_ZONES; n++) {
 	    count_contest_bands(zones[n], zonescore);
 	}
     }
 
-    if (cqww == 1) {
+    if (IS_CONTEST(CQWW)) {
 	for (int n = 1; n <= MAX_DATALINES - 1; n++) {
 	    count_contest_bands(countries[n], countryscore);
 	}

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -339,7 +339,7 @@ int readcalls(void) {
 	/* look if calls are excluded */
 	add_ok = true;
 
-	if ((arrldx_usa == 1)
+	if (IS_CONTEST(ARRLDX_USA)
 		&& ((countrynr == w_cty) || (countrynr == ve_cty)))
 	    add_ok = false;
 
@@ -430,7 +430,7 @@ int readcalls(void) {
 	}
     }
 
-    if (arrldx_usa == 1) {
+    if (IS_CONTEST(ARRLDX_USA)) {
 	for (int cntr = 1; cntr < MAX_DATALINES; cntr++) {
 	    if (cntr != w_cty && cntr != ve_cty) {	// W and VE don't count here...
 		count_contest_bands(countries[cntr], countryscore);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -155,7 +155,7 @@ bool check_veto() {
 char *get_multi_from_line(char *logline) {
     char *multbuffer = g_malloc(20);
 
-    if (IS_CONTEST(ARRL_SS)) {
+    if (CONTEST_IS(ARRL_SS)) {
 
 	if (logline[63] == ' ')
 	    g_strlcpy(multbuffer, logline + 64, 4);
@@ -281,7 +281,7 @@ int readcalls(void) {
 	    // get points
 	    total = total + log_get_points(inputbuffer);
 
-	    if (IS_CONTEST(CQWW) || (itumult == 1) || (wazmult == 1)) {
+	    if (CONTEST_IS(CQWW) || (itumult == 1) || (wazmult == 1)) {
 		// get the zone
 		z = zone_nr(inputbuffer + 54);
 	    }
@@ -289,7 +289,7 @@ int readcalls(void) {
 	    if (wysiwyg_once == 1 ||
 		    wysiwyg_multi == 1 ||
 		    unique_call_multi != 0 ||
-		    IS_CONTEST(ARRL_SS) ||
+		    CONTEST_IS(ARRL_SS) ||
 		    serial_section_mult == 1 ||
 		    serial_grid4_mult == 1 ||
 		    sectn_mult == 1 ||
@@ -339,11 +339,11 @@ int readcalls(void) {
 	/* look if calls are excluded */
 	add_ok = true;
 
-	if (IS_CONTEST(ARRLDX_USA)
+	if (CONTEST_IS(ARRLDX_USA)
 		&& ((countrynr == w_cty) || (countrynr == ve_cty)))
 	    add_ok = false;
 
-	if (IS_CONTEST(PACC_PA)) {
+	if (CONTEST_IS(PACC_PA)) {
 
 	    strcpy(hiscall, presentcall);
 
@@ -375,7 +375,7 @@ int readcalls(void) {
 
 	    band_score[bandindex]++;	/*  qso counter  per band */
 
-	    if (IS_CONTEST(CQWW) || (itumult == 1) || (wazmult == 1))
+	    if (CONTEST_IS(CQWW) || (itumult == 1) || (wazmult == 1))
 		zones[z] |= inxes[bandindex];
 
 	    if (pfxnumcntidx < 0) {
@@ -391,7 +391,7 @@ int readcalls(void) {
     fclose(fp);
 
     /* all lines red, now build other statistics */
-    if (IS_CONTEST(WPX) || pfxmult == 1) {
+    if (CONTEST_IS(WPX) || pfxmult == 1) {
 
 	/* build prefixes_worked array from list of worked stations */
 	InitPfx();
@@ -410,13 +410,13 @@ int readcalls(void) {
 	}
     }
 
-    if (IS_CONTEST(CQWW) || (itumult == 1) || (wazmult == 1)) {
+    if (CONTEST_IS(CQWW) || (itumult == 1) || (wazmult == 1)) {
 	for (int n = 1; n < MAX_ZONES; n++) {
 	    count_contest_bands(zones[n], zonescore);
 	}
     }
 
-    if (IS_CONTEST(CQWW)) {
+    if (CONTEST_IS(CQWW)) {
 	for (int n = 1; n <= MAX_DATALINES - 1; n++) {
 	    count_contest_bands(countries[n], countryscore);
 	}
@@ -430,7 +430,7 @@ int readcalls(void) {
 	}
     }
 
-    if (IS_CONTEST(ARRLDX_USA)) {
+    if (CONTEST_IS(ARRLDX_USA)) {
 	for (int cntr = 1; cntr < MAX_DATALINES; cntr++) {
 	    if (cntr != w_cty && cntr != ve_cty) {	// W and VE don't count here...
 		count_contest_bands(countries[cntr], countryscore);
@@ -438,7 +438,7 @@ int readcalls(void) {
 	}
     }
 
-    if (IS_CONTEST(PACC_PA)) {
+    if (CONTEST_IS(PACC_PA)) {
 	for (int n = 1; n < MAX_DATALINES; n++) {
 	    count_contest_bands(countries[n], countryscore);
 	}

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -343,7 +343,7 @@ int readcalls(void) {
 		&& ((countrynr == w_cty) || (countrynr == ve_cty)))
 	    add_ok = false;
 
-	if (pacc_pa_flg == 1) {
+	if (IS_CONTEST(PACC_PA)) {
 
 	    strcpy(hiscall, presentcall);
 
@@ -438,7 +438,7 @@ int readcalls(void) {
 	}
     }
 
-    if (pacc_pa_flg == 1) {
+    if (IS_CONTEST(PACC_PA)) {
 	for (int n = 1; n < MAX_DATALINES; n++) {
 	    count_contest_bands(countries[n], countryscore);
 	}

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -155,7 +155,7 @@ bool check_veto() {
 char *get_multi_from_line(char *logline) {
     char *multbuffer = g_malloc(20);
 
-    if (arrlss == 1) {
+    if (IS_CONTEST(ARRL_SS)) {
 
 	if (logline[63] == ' ')
 	    g_strlcpy(multbuffer, logline + 64, 4);
@@ -289,7 +289,7 @@ int readcalls(void) {
 	    if (wysiwyg_once == 1 ||
 		    wysiwyg_multi == 1 ||
 		    unique_call_multi != 0 ||
-		    arrlss == 1 ||
+		    IS_CONTEST(ARRL_SS) ||
 		    serial_section_mult == 1 ||
 		    serial_grid4_mult == 1 ||
 		    sectn_mult == 1 ||

--- a/src/rules.c
+++ b/src/rules.c
@@ -86,7 +86,7 @@ int read_rules() {
     } else {
 	showstring("There is no contest rules file:", contest_conf);
 	showmsg("Assuming regular QSO operation. Logfile is qso.log");
-	setcontest("qso");		 /* default use general qso mode...
+	setcontest(QSO_MODE);		 /* default use general qso mode...
 					   (PA0R, 24 Sept. 2003) */
 	strcpy(logfile, "qso.log");
     }

--- a/src/rules.c
+++ b/src/rules.c
@@ -86,9 +86,8 @@ int read_rules() {
     } else {
 	showstring("There is no contest rules file:", contest_conf);
 	showmsg("Assuming regular QSO operation. Logfile is qso.log");
-	strcpy(whichcontest, "qso");	/* default use general qso mode...
+	setcontest("qso");		 /* default use general qso mode...
 					   (PA0R, 24 Sept. 2003) */
-	setcontest();
 	strcpy(logfile, "qso.log");
     }
 

--- a/src/score.c
+++ b/src/score.c
@@ -281,7 +281,6 @@ int score() {
     extern int dupe;
     extern int band_score[NBANDS];
     extern int bandinx;
-    extern int focm;
     extern int countrynr;
     extern char continent[];
     extern char comment[];
@@ -308,7 +307,7 @@ int score() {
 	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
 	band_score[bandinx]--;
 
-    if (focm == 1) {
+    if (IS_CONTEST(FOCMARATHON)) {
 	points = foc_score(hiscall);
 
 	return points;

--- a/src/score.c
+++ b/src/score.c
@@ -37,6 +37,7 @@
 #include "getctydata.h"
 #include "locator2longlat.h"
 #include "qrb.h"
+#include "setcontest.h"
 #include "tlf.h"
 
 extern char countrylist[][6];
@@ -281,7 +282,6 @@ int score() {
     extern int band_score[NBANDS];
     extern int bandinx;
     extern int focm;
-    extern int wpx;
     extern int countrynr;
     extern char continent[];
     extern char comment[];
@@ -315,7 +315,7 @@ int score() {
 	return points;
     }
 
-    if (wpx == 1) {
+    if (IS_CONTEST(WPX)) {
 	if (countrynr == my.countrynr) {
 	    points = 1;
 

--- a/src/score.c
+++ b/src/score.c
@@ -284,7 +284,6 @@ int score() {
     extern int countrynr;
     extern char continent[];
     extern char comment[];
-    extern int arrl_fd;
     extern int w_cty;
     extern int ve_cty;
     extern int trxmode;
@@ -382,7 +381,7 @@ int score() {
     }
 
     /* end cqww */
-    if (arrl_fd == 1) {
+    if (IS_CONTEST(ARRL_FD)) {
 
 	if (trxmode == SSBMODE) {
 	    points = 1;

--- a/src/score.c
+++ b/src/score.c
@@ -292,7 +292,6 @@ int score() {
     extern int ve_cty;
     extern int trxmode;
     extern char hiscall[];
-    extern int stewperry_flg;
 
     int points;
     int zone;
@@ -410,7 +409,7 @@ int score() {
 	return points;
     }
 
-    if (stewperry_flg == 1) {
+    if (IS_CONTEST(STEWPERRY)) {
 
 	double s1long, s1lat, s2long, s2lat, distance, azimuth;
 

--- a/src/score.c
+++ b/src/score.c
@@ -284,7 +284,6 @@ int score() {
     extern int countrynr;
     extern char continent[];
     extern char comment[];
-    extern int cqww;
     extern int arrl_fd;
     extern int arrldx_usa;
     extern int w_cty;
@@ -354,7 +353,7 @@ int score() {
 	}
     }				// end wpx
 
-    if (cqww == 1) {
+    if (IS_CONTEST(CQWW)) {
 
 	if (countrynr == 0) {
 	    zone = atoi(comment);

--- a/src/score.c
+++ b/src/score.c
@@ -285,7 +285,6 @@ int score() {
     extern char continent[];
     extern char comment[];
     extern int arrl_fd;
-    extern int arrldx_usa;
     extern int w_cty;
     extern int ve_cty;
     extern int trxmode;
@@ -302,7 +301,7 @@ int score() {
 
     band_score[bandinx]++;	/* qso's per band  */
 
-    if ((arrldx_usa == 1)
+    if (IS_CONTEST(ARRLDX_USA)
 	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
 	band_score[bandinx]--;
 
@@ -395,7 +394,7 @@ int score() {
 
     }				// end arrl_fd
 
-    if (arrldx_usa == 1) {
+    if (IS_CONTEST(ARRLDX_USA)) {
 
 	if ((countrynr == w_cty) || (countrynr == ve_cty)) {
 	    points = 0;

--- a/src/score.c
+++ b/src/score.c
@@ -300,17 +300,17 @@ int score() {
 
     band_score[bandinx]++;	/* qso's per band  */
 
-    if (IS_CONTEST(ARRLDX_USA)
+    if (CONTEST_IS(ARRLDX_USA)
 	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
 	band_score[bandinx]--;
 
-    if (IS_CONTEST(FOCMARATHON)) {
+    if (CONTEST_IS(FOCMARATHON)) {
 	points = foc_score(hiscall);
 
 	return points;
     }
 
-    if (IS_CONTEST(WPX)) {
+    if (CONTEST_IS(WPX)) {
 	if (countrynr == my.countrynr) {
 	    points = 1;
 
@@ -351,7 +351,7 @@ int score() {
 	}
     }				// end wpx
 
-    if (IS_CONTEST(CQWW)) {
+    if (CONTEST_IS(CQWW)) {
 
 	if (countrynr == 0) {
 	    zone = atoi(comment);
@@ -381,7 +381,7 @@ int score() {
     }
 
     /* end cqww */
-    if (IS_CONTEST(ARRL_FD)) {
+    if (CONTEST_IS(ARRL_FD)) {
 
 	if (trxmode == SSBMODE) {
 	    points = 1;
@@ -393,7 +393,7 @@ int score() {
 
     }				// end arrl_fd
 
-    if (IS_CONTEST(ARRLDX_USA)) {
+    if (CONTEST_IS(ARRLDX_USA)) {
 
 	if ((countrynr == w_cty) || (countrynr == ve_cty)) {
 	    points = 0;
@@ -405,7 +405,7 @@ int score() {
 	return points;
     }
 
-    if (IS_CONTEST(STEWPERRY)) {
+    if (CONTEST_IS(STEWPERRY)) {
 
 	double s1long, s1lat, s2long, s2lat, distance, azimuth;
 

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -563,7 +563,7 @@ void displayWorkedZonesCountries(int z) {
 	}
     }
 
-    if (IS_CONTEST(CQWW) || !iscontest || pacc_pa_flg == 1) {
+    if (IS_CONTEST(CQWW) || !iscontest || IS_CONTEST(PACC_PA)) {
 
 	if ((countries[countrynr] & BAND10) != 0) {
 	    mvwprintw(search_win, 1, 36, "C");
@@ -625,7 +625,7 @@ void displayWorkedZonesCountries(int z) {
 	}
     }
 
-    if (pacc_pa_flg == 1) {
+    if (IS_CONTEST(PACC_PA)) {
 
 	getpx(hiscall);
 

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -504,7 +504,7 @@ int getZone() {
     if (strlen(hiscall) == 2)
 	z1 = 0;
 
-    if ((cqww == 1) || (wazmult == 1) || (itumult == 1)) {
+    if (IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1)) {
 	for (int i = 0; i < srch_index; i++) {
 
 	    /* get zone nr from previous QSO */
@@ -563,7 +563,7 @@ void displayWorkedZonesCountries(int z) {
 	}
     }
 
-    if (cqww == 1 || !iscontest || pacc_pa_flg == 1) {
+    if (IS_CONTEST(CQWW) || !iscontest || pacc_pa_flg == 1) {
 
 	if ((countries[countrynr] & BAND10) != 0) {
 	    mvwprintw(search_win, 1, 36, "C");
@@ -604,7 +604,7 @@ void displayWorkedZonesCountries(int z) {
 	    }
 	}
     }
-    if ((cqww == 1) || (wazmult == 1) || (itumult == 1)) {
+    if (IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1)) {
 	if ((zones[z] & BAND10) != 0) {
 	    mvwprintw(search_win, 1, 37, "Z");
 	}
@@ -713,7 +713,6 @@ void searchlog() {
     extern int searchflg;
     extern int dupe;
     extern int partials;
-    extern int cqww;
     extern int countrynr;
     extern int arrlss;
     extern char pxstr[];

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -76,7 +76,7 @@ void show_needed_sections(void);
  * \return - true if also WARC bands
  */
 int IsAllBand() {
-    return ((dxped != 0) || !iscontest);
+    return (IS_CONTEST(DXPED) || !iscontest);
 }
 
 

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -714,7 +714,6 @@ void searchlog() {
     extern int dupe;
     extern int partials;
     extern int countrynr;
-    extern int arrlss;
     extern char pxstr[];
     extern char hiscall[];
     extern char zone_export[];
@@ -754,7 +753,7 @@ void searchlog() {
 	}
 
 	/* show needed sections for ARRL_Sweep Stake*/
-	if (dupe == NODUPE && arrlss == 1)
+	if (dupe == NODUPE && IS_CONTEST(ARRL_SS))
 	    show_needed_sections();
 
 	if (dupe == ISDUPE) {
@@ -821,7 +820,7 @@ int load_callmaster(void) {
 
 	char *call = g_ascii_strup(s_inputbuffer, 11);
 
-	if (arrlss) {
+	if (IS_CONTEST(ARRL_SS)) {
 	    /* keep only NA stations */
 	    if (strchr("AKWVCN", call[0]) == NULL) {
 		g_free(call);
@@ -848,14 +847,13 @@ int load_callmaster(void) {
 
 /*  --------------------------------------------------------------  */
 void show_needed_sections(void) {
-    extern int arrlss;
     extern int nr_multis;
     extern mults_t multis[MAX_MULTS];
 
     int j, vert, hor, cnt, found;
     char mprint[50];
 
-    if (arrlss == 1) {
+    if (IS_CONTEST(ARRL_SS)) {
 	cnt = 0;
 
 	wattron(search_win, modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -76,7 +76,7 @@ void show_needed_sections(void);
  * \return - true if also WARC bands
  */
 int IsAllBand() {
-    return (IS_CONTEST(DXPED) || !iscontest);
+    return (CONTEST_IS(DXPED) || !iscontest);
 }
 
 
@@ -146,7 +146,7 @@ void displayCallInfo(dxcc_data *dx, int z, char *pxstr) {
     else
 	mvwprintw(search_win, nr_bands + 1, 28, "ITU:%02d", z);
 
-    if (IS_CONTEST(WPX) || pfxmult == 1) {
+    if (CONTEST_IS(WPX) || pfxmult == 1) {
 	i = strlen(dx->countryname);
 	mvwprintw(search_win, nr_bands + 1, 2 + i + 3, pxstr);
     }
@@ -504,7 +504,7 @@ int getZone() {
     if (strlen(hiscall) == 2)
 	z1 = 0;
 
-    if (IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1)) {
+    if (CONTEST_IS(CQWW) || (wazmult == 1) || (itumult == 1)) {
 	for (int i = 0; i < srch_index; i++) {
 
 	    /* get zone nr from previous QSO */
@@ -563,7 +563,7 @@ void displayWorkedZonesCountries(int z) {
 	}
     }
 
-    if (IS_CONTEST(CQWW) || !iscontest || IS_CONTEST(PACC_PA)) {
+    if (CONTEST_IS(CQWW) || !iscontest || CONTEST_IS(PACC_PA)) {
 
 	if ((countries[countrynr] & BAND10) != 0) {
 	    mvwprintw(search_win, 1, 36, "C");
@@ -604,7 +604,7 @@ void displayWorkedZonesCountries(int z) {
 	    }
 	}
     }
-    if (IS_CONTEST(CQWW) || (wazmult == 1) || (itumult == 1)) {
+    if (CONTEST_IS(CQWW) || (wazmult == 1) || (itumult == 1)) {
 	if ((zones[z] & BAND10) != 0) {
 	    mvwprintw(search_win, 1, 37, "Z");
 	}
@@ -625,7 +625,7 @@ void displayWorkedZonesCountries(int z) {
 	}
     }
 
-    if (IS_CONTEST(PACC_PA)) {
+    if (CONTEST_IS(PACC_PA)) {
 
 	getpx(hiscall);
 
@@ -753,7 +753,7 @@ void searchlog() {
 	}
 
 	/* show needed sections for ARRL_Sweep Stake*/
-	if (dupe == NODUPE && IS_CONTEST(ARRL_SS))
+	if (dupe == NODUPE && CONTEST_IS(ARRL_SS))
 	    show_needed_sections();
 
 	if (dupe == ISDUPE) {
@@ -820,7 +820,7 @@ int load_callmaster(void) {
 
 	char *call = g_ascii_strup(s_inputbuffer, 11);
 
-	if (IS_CONTEST(ARRL_SS)) {
+	if (CONTEST_IS(ARRL_SS)) {
 	    /* keep only NA stations */
 	    if (strchr("AKWVCN", call[0]) == NULL) {
 		g_free(call);
@@ -853,7 +853,7 @@ void show_needed_sections(void) {
     int j, vert, hor, cnt, found;
     char mprint[50];
 
-    if (IS_CONTEST(ARRL_SS)) {
+    if (CONTEST_IS(ARRL_SS)) {
 	cnt = 0;
 
 	wattron(search_win, modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -48,6 +48,7 @@
 #include "ui_utils.h"
 #include "zone_nr.h"
 #include "searchcallarray.h"
+#include "setcontest.h"
 #include "get_time.h"
 #include "addmult.h"
 
@@ -145,7 +146,7 @@ void displayCallInfo(dxcc_data *dx, int z, char *pxstr) {
     else
 	mvwprintw(search_win, nr_bands + 1, 28, "ITU:%02d", z);
 
-    if (wpx == 1 || pfxmult == 1) {
+    if (IS_CONTEST(WPX) || pfxmult == 1) {
 	i = strlen(dx->countryname);
 	mvwprintw(search_win, nr_bands + 1, 2 + i + 3, pxstr);
     }
@@ -714,7 +715,6 @@ void searchlog() {
     extern int partials;
     extern int cqww;
     extern int countrynr;
-    extern int wpx;
     extern int arrlss;
     extern char pxstr[];
     extern char hiscall[];

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -33,15 +33,45 @@
 #include "tlf.h"
 
 /* configurations for supported contest */
+contest_config_t config_unknown = {
+    .id = UNKNOWN,
+    .name = "Unknown"
+};
+
 contest_config_t config_qso = {
     .id = QSO,
     .name = "QSO"
 };
 
+contest_config_t config_cqww = {
+    .id = CQWW,
+    .name = "CQWW"
+};
+
+contest_config_t config_wpx = {
+    .id = WPX,
+    .name = "WPX"
+};
+
+
 /* table with pointers to all supported contests */
 contest_config_t *contest_configs[] = {
     &config_qso,
+    &config_cqww,
 };
+
+#define NR_CONTESTS (sizeof(contest_configs)/sizeof(contest_config_t*))
+
+/* lookup contest config by name in config table */
+contest_config_t *lookup_contest(char *name) {
+    for (int i = 0; i < NR_CONTESTS; i++) {
+	if (strcasecmp(contest_configs[i]->name, name) == 0) {
+	    return contest_configs[i];
+	}
+    }
+    return &config_unknown;
+}
+
 
 void setcontest(void) {
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -58,6 +58,11 @@ contest_config_t config_cqww = {
     .name = "CQWW"
 };
 
+contest_config_t config_sprint = {
+    .id = SPRINT,
+    .name = "SPRINT"
+};
+
 
 /* table with pointers to all supported contests */
 contest_config_t *contest_configs[] = {
@@ -65,6 +70,7 @@ contest_config_t *contest_configs[] = {
     &config_dxped,
     &config_wpx,
     &config_cqww,
+    &config_sprint,
 };
 
 #define NR_CONTESTS (sizeof(contest_configs)/sizeof(contest_config_t*))
@@ -86,7 +92,6 @@ void setcontest(char *name) {
 
     extern int focm;
     extern int cqww;
-    extern int sprint;
     extern int arrldx_usa;
     extern int dx_arrlsections;
     extern int arrl_fd;
@@ -131,7 +136,6 @@ void setcontest(char *name) {
     char ua9call[] = "UA9AA";
 
     cqww = 0;
-    sprint = 0;
     arrldx_usa = 0;
     arrl_fd = 0;
     pacc_pa_flg = 0;
@@ -164,8 +168,7 @@ void setcontest(char *name) {
 	recall_mult = 1;
     }
 
-    if (strcmp(whichcontest, "sprint") == 0) {
-	sprint = 1;
+    if (IS_CONTEST(SPRINT)) {
 	one_point = 1;
     }
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -58,6 +58,7 @@ contest_config_t config_wpx = {
 contest_config_t *contest_configs[] = {
     &config_qso,
     &config_cqww,
+    &config_wpx,
 };
 
 #define NR_CONTESTS (sizeof(contest_configs)/sizeof(contest_config_t*))
@@ -78,7 +79,6 @@ contest_config_t *lookup_contest(char *name) {
 void setcontest(char *name) {
 
     extern int focm;
-    extern int wpx;
     extern int cqww;
     extern int dxped;
     extern int sprint;
@@ -125,11 +125,11 @@ void setcontest(char *name) {
     char zscall[] = "ZS6AA";
     char ua9call[] = "UA9AA";
 
-    wpx = 0;
     cqww = 0;
     dxped = 0;
     sprint = 0;
     arrldx_usa = 0;
+    arrl_fd = 0;
     pacc_pa_flg = 0;
     focm = 0;
     universal = 0;
@@ -148,9 +148,8 @@ void setcontest(char *name) {
 
     strcpy(whichcontest, name);
 
-    if (strcmp(whichcontest, "wpx") == 0) {
-	wpx = 1;
-    }
+    contest = lookup_contest(name);
+
 
     if (strcmp(whichcontest, "cqww") == 0) {
 	cqww = 1;

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -65,15 +65,17 @@ contest_config_t *contest_configs[] = {
 /* lookup contest config by name in config table */
 contest_config_t *lookup_contest(char *name) {
     for (int i = 0; i < NR_CONTESTS; i++) {
-	if (strcasecmp(contest_configs[i]->name, name) == 0) {
-	    return contest_configs[i];
+	if (contest_configs[i]->name != NULL) {
+	    if (strcasecmp(contest_configs[i]->name, name) == 0) {
+		return contest_configs[i];
+	    }
 	}
     }
     return &config_unknown;
 }
 
-
-void setcontest(void) {
+/* setup standard configuration for contest 'name' */
+void setcontest(char *name) {
 
     extern int focm;
     extern int wpx;
@@ -143,6 +145,8 @@ void setcontest(void) {
 
     w_cty = getctynr(wcall);
     ve_cty = getctynr(vecall);
+
+    strcpy(whichcontest, name);
 
     if (strcmp(whichcontest, "wpx") == 0) {
 	wpx = 1;

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -43,9 +43,9 @@ contest_config_t config_qso = {
     .name = "QSO"
 };
 
-contest_config_t config_cqww = {
-    .id = CQWW,
-    .name = "CQWW"
+contest_config_t config_dxped = {
+    .id = DXPED,
+    .name = "DXPED"
 };
 
 contest_config_t config_wpx = {
@@ -53,12 +53,18 @@ contest_config_t config_wpx = {
     .name = "WPX"
 };
 
+contest_config_t config_cqww = {
+    .id = CQWW,
+    .name = "CQWW"
+};
+
 
 /* table with pointers to all supported contests */
 contest_config_t *contest_configs[] = {
     &config_qso,
-    &config_cqww,
+    &config_dxped,
     &config_wpx,
+    &config_cqww,
 };
 
 #define NR_CONTESTS (sizeof(contest_configs)/sizeof(contest_config_t*))
@@ -80,7 +86,6 @@ void setcontest(char *name) {
 
     extern int focm;
     extern int cqww;
-    extern int dxped;
     extern int sprint;
     extern int arrldx_usa;
     extern int dx_arrlsections;
@@ -126,7 +131,6 @@ void setcontest(char *name) {
     char ua9call[] = "UA9AA";
 
     cqww = 0;
-    dxped = 0;
     sprint = 0;
     arrldx_usa = 0;
     arrl_fd = 0;
@@ -156,8 +160,7 @@ void setcontest(char *name) {
 	recall_mult = 1;
     }
 
-    if (strcmp(whichcontest, "dxped") == 0) {
-	dxped = 1;
+    if (IS_CONTEST(DXPED)) {
 	recall_mult = 1;
     }
 
@@ -189,6 +192,7 @@ void setcontest(char *name) {
     }
 
     if (strcmp(whichcontest, "arrl_fd") == 0) {
+
 	arrl_fd = 1;
 	recall_mult = 1;
     }

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -132,7 +132,6 @@ void setcontest(char *name) {
 
     extern int dx_arrlsections;
     extern int multlist;
-    extern int universal;
     extern int exchange_serial;
     extern int w_cty;
     extern int ve_cty;
@@ -167,7 +166,6 @@ void setcontest(char *name) {
     char zscall[] = "ZS6AA";
     char ua9call[] = "UA9AA";
 
-    universal = 0;
     iscontest = true;
     showscore_flag = 1;
     searchflg = 1;
@@ -241,7 +239,5 @@ void setcontest(char *name) {
     if (IS_CONTEST(QSO)) {
 	iscontest = false;
 	showscore_flag = 0;
-    } else {		    //dxpedition
-	universal = 1;
     }
 }

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -83,6 +83,11 @@ contest_config_t config_arrl_fd = {
     .name = "ARRL_FD"
 };
 
+contest_config_t config_pacc_pa = {
+    .id = PACC_PA,
+    .name = "PACC_PA"
+};
+
 contest_config_t config_stewperry = {
     .id = STEWPERRY,
     .name = "STEWPERRY"
@@ -100,7 +105,7 @@ contest_config_t *contest_configs[] = {
     &config_arrldx_dx,
     &config_arrl_ss,
     &config_arrl_fd,
-
+    &config_pacc_pa,
     &config_stewperry,
     &config_focm,
 };
@@ -127,7 +132,6 @@ void setcontest(char *name) {
 
     extern int dx_arrlsections;
     extern int multlist;
-    extern int pacc_pa_flg;
     extern int universal;
     extern int exchange_serial;
     extern int wysiwyg_multi;
@@ -164,7 +168,6 @@ void setcontest(char *name) {
     char zscall[] = "ZS6AA";
     char ua9call[] = "UA9AA";
 
-    pacc_pa_flg = 0;
     universal = 0;
     iscontest = true;
     showscore_flag = 1;
@@ -219,8 +222,7 @@ void setcontest(char *name) {
 	recall_mult = 1;
     }
 
-    if (strcmp(whichcontest, "pacc_pa") == 0) {
-	pacc_pa_flg = 1;
+    if (IS_CONTEST(PACC_PA)) {
 	one_point = 1;
 
 	zl_cty = getctynr(zlcall);

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -40,7 +40,7 @@ contest_config_t config_unknown = {
 
 contest_config_t config_qso = {
     .id = QSO,
-    .name = "QSO"
+    .name = QSO_MODE
 };
 
 contest_config_t config_dxped = {

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -68,6 +68,11 @@ contest_config_t config_arrldx_usa = {
     .name = "ARRLDX_USA"
 };
 
+contest_config_t config_arrldx_dx = {
+    .id = ARRLDX_DX,
+    .name = "ARRLDX_DX"
+};
+
 contest_config_t config_arrl_ss = {
     .id = ARRL_SS,
     .name = "ARRL_SS"
@@ -92,8 +97,10 @@ contest_config_t *contest_configs[] = {
     &config_cqww,
     &config_sprint,
     &config_arrldx_usa,
+    &config_arrldx_dx,
     &config_arrl_ss,
     &config_arrl_fd,
+
     &config_stewperry,
     &config_focm,
 };
@@ -193,7 +200,7 @@ void setcontest(char *name) {
 	recall_mult = 1;
     }
 
-    if (strcmp(whichcontest, "arrldx_dx") == 0) {
+    if (IS_CONTEST(ARRLDX_DX)) {
 	three_point = 1;
 	recall_mult = 1;
 	sectn_mult = 1;

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -63,6 +63,11 @@ contest_config_t config_sprint = {
     .name = "SPRINT"
 };
 
+contest_config_t config_stewperry = {
+    .id = STEWPERRY,
+    .name = "STEWPERRY"
+};
+
 
 /* table with pointers to all supported contests */
 contest_config_t *contest_configs[] = {
@@ -71,6 +76,7 @@ contest_config_t *contest_configs[] = {
     &config_wpx,
     &config_cqww,
     &config_sprint,
+    &config_stewperry,
 };
 
 #define NR_CONTESTS (sizeof(contest_configs)/sizeof(contest_config_t*))
@@ -98,7 +104,6 @@ void setcontest(char *name) {
     extern int arrlss;
     extern int multlist;
     extern int pacc_pa_flg;
-    extern int stewperry_flg;
     extern int universal;
     extern int exchange_serial;
     extern int wysiwyg_multi;
@@ -212,10 +217,6 @@ void setcontest(char *name) {
 	vk_cty = getctynr(vkcall);
 	zs_cty = getctynr(zscall);
 	ua9_cty = getctynr(ua9call);
-    }
-
-    if (strcmp(whichcontest, "stewperry") == 0) {
-	stewperry_flg = 1;
     }
 
     if (strcmp(whichcontest, "focmarathon") == 0) {

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -68,6 +68,11 @@ contest_config_t config_arrldx_usa = {
     .name = "ARRLDX_USA"
 };
 
+contest_config_t config_arrl_fd = {
+    .id = ARRL_FD,
+    .name = "ARRL_FD"
+};
+
 contest_config_t config_stewperry = {
     .id = STEWPERRY,
     .name = "STEWPERRY"
@@ -82,6 +87,7 @@ contest_config_t *contest_configs[] = {
     &config_cqww,
     &config_sprint,
     &config_arrldx_usa,
+    &config_arrl_fd,
     &config_stewperry,
     &config_focm,
 };
@@ -107,7 +113,6 @@ contest_config_t *lookup_contest(char *name) {
 void setcontest(char *name) {
 
     extern int dx_arrlsections;
-    extern int arrl_fd;
     extern int arrlss;
     extern int multlist;
     extern int pacc_pa_flg;
@@ -147,7 +152,6 @@ void setcontest(char *name) {
     char zscall[] = "ZS6AA";
     char ua9call[] = "UA9AA";
 
-    arrl_fd = 0;
     pacc_pa_flg = 0;
     universal = 0;
     iscontest = true;
@@ -201,9 +205,7 @@ void setcontest(char *name) {
 	noleadingzeros = 1;
     }
 
-    if (strcmp(whichcontest, "arrl_fd") == 0) {
-
-	arrl_fd = 1;
+    if (IS_CONTEST(ARRL_FD)) {
 	recall_mult = 1;
     }
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -77,6 +77,7 @@ contest_config_t *contest_configs[] = {
     &config_cqww,
     &config_sprint,
     &config_stewperry,
+    &config_focm,
 };
 
 #define NR_CONTESTS (sizeof(contest_configs)/sizeof(contest_config_t*))
@@ -96,7 +97,6 @@ contest_config_t *lookup_contest(char *name) {
 /* setup standard configuration for contest 'name' */
 void setcontest(char *name) {
 
-    extern int focm;
     extern int cqww;
     extern int arrldx_usa;
     extern int dx_arrlsections;
@@ -144,7 +144,6 @@ void setcontest(char *name) {
     arrldx_usa = 0;
     arrl_fd = 0;
     pacc_pa_flg = 0;
-    focm = 0;
     universal = 0;
     iscontest = true;
     showscore_flag = 1;
@@ -217,10 +216,6 @@ void setcontest(char *name) {
 	vk_cty = getctynr(vkcall);
 	zs_cty = getctynr(zscall);
 	ua9_cty = getctynr(ua9call);
-    }
-
-    if (strcmp(whichcontest, "focmarathon") == 0) {
-	foc_init();
     }
 
     if (strcmp(whichcontest, "other") == 0) {

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -134,7 +134,6 @@ void setcontest(char *name) {
     extern int multlist;
     extern int universal;
     extern int exchange_serial;
-    extern int wysiwyg_multi;
     extern int w_cty;
     extern int ve_cty;
     extern int zl_cty;
@@ -235,21 +234,11 @@ void setcontest(char *name) {
 	ua9_cty = getctynr(ua9call);
     }
 
-    if (strcmp(whichcontest, "other") == 0) {
-	one_point = 1;
-	recall_mult = 1;
-	wysiwyg_multi = 1;
-    }
-
-    if (strcmp(whichcontest, "universal") == 0) {
-	/* nothing special to do */
-    }
-
     if (dx_arrlsections == 1) {
 	/* same here */
     }
 
-    if (strcmp(whichcontest, "qso") == 0) {
+    if (IS_CONTEST(QSO)) {
 	iscontest = false;
 	showscore_flag = 0;
     } else {		    //dxpedition

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -184,29 +184,29 @@ void setcontest(char *name) {
     contest = lookup_contest(name);
 
 
-    if (IS_CONTEST(CQWW)) {
+    if (CONTEST_IS(CQWW)) {
 	recall_mult = 1;
     }
 
-    if (IS_CONTEST(DXPED)) {
+    if (CONTEST_IS(DXPED)) {
 	recall_mult = 1;
     }
 
-    if (IS_CONTEST(SPRINT)) {
+    if (CONTEST_IS(SPRINT)) {
 	one_point = 1;
     }
 
-    if (IS_CONTEST(ARRLDX_USA)) {
+    if (CONTEST_IS(ARRLDX_USA)) {
 	recall_mult = 1;
     }
 
-    if (IS_CONTEST(ARRLDX_DX)) {
+    if (CONTEST_IS(ARRLDX_DX)) {
 	three_point = 1;
 	recall_mult = 1;
 	sectn_mult = 1;
     }
 
-    if (IS_CONTEST(ARRL_SS)) {
+    if (CONTEST_IS(ARRL_SS)) {
 	two_point = 1;
 	qso_once = true;
 	exchange_serial = 1;
@@ -215,11 +215,11 @@ void setcontest(char *name) {
 	noleadingzeros = 1;
     }
 
-    if (IS_CONTEST(ARRL_FD)) {
+    if (CONTEST_IS(ARRL_FD)) {
 	recall_mult = 1;
     }
 
-    if (IS_CONTEST(PACC_PA)) {
+    if (CONTEST_IS(PACC_PA)) {
 	one_point = 1;
 
 	zl_cty = getctynr(zlcall);
@@ -236,7 +236,7 @@ void setcontest(char *name) {
 	/* same here */
     }
 
-    if (IS_CONTEST(QSO)) {
+    if (CONTEST_IS(QSO)) {
 	iscontest = false;
 	showscore_flag = 0;
     }

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -63,6 +63,11 @@ contest_config_t config_sprint = {
     .name = "SPRINT"
 };
 
+contest_config_t config_arrldx_usa = {
+    .id = ARRLDX_USA,
+    .name = "ARRLDX_USA"
+};
+
 contest_config_t config_stewperry = {
     .id = STEWPERRY,
     .name = "STEWPERRY"
@@ -76,6 +81,7 @@ contest_config_t *contest_configs[] = {
     &config_wpx,
     &config_cqww,
     &config_sprint,
+    &config_arrldx_usa,
     &config_stewperry,
     &config_focm,
 };
@@ -100,7 +106,6 @@ contest_config_t *lookup_contest(char *name) {
 /** setup standard configuration for contest 'name' */
 void setcontest(char *name) {
 
-    extern int arrldx_usa;
     extern int dx_arrlsections;
     extern int arrl_fd;
     extern int arrlss;
@@ -142,7 +147,6 @@ void setcontest(char *name) {
     char zscall[] = "ZS6AA";
     char ua9call[] = "UA9AA";
 
-    arrldx_usa = 0;
     arrl_fd = 0;
     pacc_pa_flg = 0;
     universal = 0;
@@ -176,8 +180,7 @@ void setcontest(char *name) {
 	one_point = 1;
     }
 
-    if (strcmp(whichcontest, "arrldx_usa") == 0) {
-	arrldx_usa = 1;
+    if (IS_CONTEST(ARRLDX_USA)) {
 	recall_mult = 1;
     }
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -32,6 +32,16 @@
 #include "setcontest.h"
 #include "tlf.h"
 
+/* configurations for supported contest */
+contest_config_t config_qso = {
+    .id = QSO,
+    .name = "QSO"
+};
+
+/* table with pointers to all supported contests */
+contest_config_t *contest_configs[] = {
+    &config_qso,
+};
 
 void setcontest(void) {
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -82,7 +82,10 @@ contest_config_t *contest_configs[] = {
 
 #define NR_CONTESTS (sizeof(contest_configs)/sizeof(contest_config_t*))
 
-/* lookup contest config by name in config table */
+/** lookup contest config by name in config table
+ *
+ * ignore configs where .name is not set
+ */
 contest_config_t *lookup_contest(char *name) {
     for (int i = 0; i < NR_CONTESTS; i++) {
 	if (contest_configs[i]->name != NULL) {
@@ -94,10 +97,9 @@ contest_config_t *lookup_contest(char *name) {
     return &config_unknown;
 }
 
-/* setup standard configuration for contest 'name' */
+/** setup standard configuration for contest 'name' */
 void setcontest(char *name) {
 
-    extern int cqww;
     extern int arrldx_usa;
     extern int dx_arrlsections;
     extern int arrl_fd;
@@ -140,7 +142,6 @@ void setcontest(char *name) {
     char zscall[] = "ZS6AA";
     char ua9call[] = "UA9AA";
 
-    cqww = 0;
     arrldx_usa = 0;
     arrl_fd = 0;
     pacc_pa_flg = 0;
@@ -163,8 +164,7 @@ void setcontest(char *name) {
     contest = lookup_contest(name);
 
 
-    if (strcmp(whichcontest, "cqww") == 0) {
-	cqww = 1;
+    if (IS_CONTEST(CQWW)) {
 	recall_mult = 1;
     }
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -68,6 +68,11 @@ contest_config_t config_arrldx_usa = {
     .name = "ARRLDX_USA"
 };
 
+contest_config_t config_arrl_ss = {
+    .id = ARRL_SS,
+    .name = "ARRL_SS"
+};
+
 contest_config_t config_arrl_fd = {
     .id = ARRL_FD,
     .name = "ARRL_FD"
@@ -87,6 +92,7 @@ contest_config_t *contest_configs[] = {
     &config_cqww,
     &config_sprint,
     &config_arrldx_usa,
+    &config_arrl_ss,
     &config_arrl_fd,
     &config_stewperry,
     &config_focm,
@@ -113,7 +119,6 @@ contest_config_t *lookup_contest(char *name) {
 void setcontest(char *name) {
 
     extern int dx_arrlsections;
-    extern int arrlss;
     extern int multlist;
     extern int pacc_pa_flg;
     extern int universal;
@@ -194,13 +199,11 @@ void setcontest(char *name) {
 	sectn_mult = 1;
     }
 
-    if (strcmp(whichcontest, "arrl_ss") == 0) {
-	arrlss = 1;
+    if (IS_CONTEST(ARRL_SS)) {
 	two_point = 1;
 	qso_once = true;
 	exchange_serial = 1;
 	multlist = 1;
-	recall_mult = 0;
 //      sectn_mult = 1;
 	noleadingzeros = 1;
     }

--- a/src/setcontest.h
+++ b/src/setcontest.h
@@ -26,6 +26,6 @@
 extern contest_config_t config_qso;
 
 contest_config_t *lookup_contest(char *name);
-void setcontest(void);
+void setcontest(char *name);
 
 #endif /* SETCONTEST_H */

--- a/src/setcontest.h
+++ b/src/setcontest.h
@@ -21,6 +21,8 @@
 #ifndef SETCONTEST_H
 #define SETCONTEST_H
 
+extern contest_config_t config_qso;
+
 void setcontest(void);
 
 #endif /* SETCONTEST_H */

--- a/src/setcontest.h
+++ b/src/setcontest.h
@@ -21,8 +21,11 @@
 #ifndef SETCONTEST_H
 #define SETCONTEST_H
 
+#include "globalvars.h"
+
 extern contest_config_t config_qso;
 
+contest_config_t *lookup_contest(char *name);
 void setcontest(void);
 
 #endif /* SETCONTEST_H */

--- a/src/setcontest.h
+++ b/src/setcontest.h
@@ -23,7 +23,7 @@
 
 #include "globalvars.h"
 
-#define IS_CONTEST(cid) (contest->id == cid)
+#define CONTEST_IS(cid) (contest->id == cid)
 
 extern contest_config_t config_qso;
 

--- a/src/setcontest.h
+++ b/src/setcontest.h
@@ -23,6 +23,8 @@
 
 #include "globalvars.h"
 
+#define IS_CONTEST(cid) (contest->id == cid)
+
 extern contest_config_t config_qso;
 
 contest_config_t *lookup_contest(char *name);

--- a/src/setparameters.c
+++ b/src/setparameters.c
@@ -140,7 +140,7 @@ int setparameters(void) {
 		return EXIT_FAILURE;
 	    }
 
-	    setcontest();	/* set contest parameters */
+	    setcontest(whichcontest);	/* set contest parameters */
 
 	    scroll_log();	/* read the last 5  log lines and set the qso number */
 				/* read the logfile for score and dupe */
@@ -184,7 +184,7 @@ int setparameters(void) {
 	    getnstr(whichcontest, 20);
 	    noecho();
 
-	    setcontest();
+	    setcontest(whichcontest);
 
 	}
 

--- a/src/showpxmap.c
+++ b/src/showpxmap.c
@@ -40,7 +40,6 @@ void show_mults(void) {
 
     extern int countries[MAX_DATALINES];
     extern int bandinx;
-    extern int cqww;
 
     int i, j, k, l, bandmask = 0;
     static char prefix[5];
@@ -54,7 +53,7 @@ void show_mults(void) {
 	return;
     }
 
-    if (cqww == 1) {
+    if (IS_CONTEST(CQWW)) {
 
 	mvprintw(12, 29, "E,A,F,N,S,O");
 

--- a/src/showpxmap.c
+++ b/src/showpxmap.c
@@ -29,6 +29,7 @@
 #include "focm.h"
 #include "changepars.h"
 #include "keystroke_names.h"
+#include "setcontest.h"
 #include "tlf.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
@@ -41,8 +42,6 @@ void show_mults(void) {
     extern int bandinx;
     extern int cqww;
 
-    extern int focm;
-
     int i, j, k, l, bandmask = 0;
     static char prefix[5];
     static char zonecmp[3] = "";
@@ -50,7 +49,7 @@ void show_mults(void) {
 
     int iMax = dxcc_count();
 
-    if (focm == 1) {
+    if (IS_CONTEST(FOCMARATHON)) {
 	foc_show_cty();
 	return;
     }

--- a/src/showpxmap.c
+++ b/src/showpxmap.c
@@ -48,12 +48,12 @@ void show_mults(void) {
 
     int iMax = dxcc_count();
 
-    if (IS_CONTEST(FOCMARATHON)) {
+    if (CONTEST_IS(FOCMARATHON)) {
 	foc_show_cty();
 	return;
     }
 
-    if (IS_CONTEST(CQWW)) {
+    if (CONTEST_IS(CQWW)) {
 
 	mvprintw(12, 29, "E,A,F,N,S,O");
 

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -131,7 +131,6 @@ int get_nr_of_points() {
 /* get total number of multis */
 int get_nr_of_mults() {
     extern float fixedmult;
-    extern int sprint;
     extern int multlist;
     extern int multscore[];
     extern int bandweight_multis[NBANDS];
@@ -156,7 +155,7 @@ int get_nr_of_mults() {
 		       bandweight_multis[bi_normal[n]]);
     }
 
-    if (sprint == 1) {
+    if (IS_CONTEST(SPRINT)) {
 	/* no multis used */
 	return 1;
     } else if (arrlss == 1) {
@@ -245,7 +244,6 @@ void showscore(void) {
     extern int totalmults;
     extern int qsonum;
     extern int total;
-    extern int sprint;
     extern int bandinx;
     extern int multscore[];
     extern int serial_section_mult;
@@ -348,7 +346,7 @@ void showscore(void) {
     }
 
     /* show score summary */
-    if (sprint == 1) {
+    if (IS_CONTEST(SPRINT)) {
 
 	mvprintw(5, START_COL, "Score: %d", get_nr_of_points());
     } else if (focm == 1) {

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -138,6 +138,9 @@ int get_nr_of_mults() {
     int totalcountries;
     int totalmults;
 
+    if (!iscontest)
+	return 1;
+
     /* precalculate summaries */
     totalzones = 0;
     totalcountries = 0;
@@ -175,10 +178,10 @@ int get_nr_of_mults() {
     } else if (dx_arrlsections == 1) {
 
 	return totalmults + totalcountries;
-    } else if (universal == 1 && country_mult == 1) {
+    } else if (country_mult == 1) {
 
 	return totalcountries;
-    } else if (universal == 1 && multlist == 1 && !IS_CONTEST(ARRL_SS)) {
+    } else if (multlist == 1 && !IS_CONTEST(ARRL_SS)) {
 
 	return totalmults ;
     } else if (IS_CONTEST(PACC_PA)) {
@@ -229,7 +232,6 @@ int get_total_score() {
 void showscore(void) {
 
     extern int showscore_flag;
-    extern int universal;
     extern int country_mult;
     extern int wysiwyg_once;
     extern int wysiwyg_multi;
@@ -321,7 +323,7 @@ void showscore(void) {
 	}
     }
 
-    if (universal == 1 && country_mult == 1) {
+    if (iscontest && country_mult == 1) {
 
 	mvprintw(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
@@ -355,9 +357,7 @@ void showscore(void) {
     attron(COLOR_PAIR(C_HEADER));
     mvprintw(6, 55, spaces(19));
 
-    if (IS_CONTEST(CQWW) || IS_CONTEST(WPX) || pfxmult == 1
-	    || IS_CONTEST(ARRLDX_USA) || (IS_CONTEST(PACC_PA))
-	    || (wysiwyg_once == 1) || (universal == 1)) {   /* cqww or wpx */
+    if (iscontest) {   /* show statistics in any contest */
 
 	totalmults = get_nr_of_mults();
 	totalmults = totalmults ? totalmults : 1;	/* at least one */

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -119,9 +119,6 @@ void display_header(int *bi) {
 }
 
 
-extern int focm;
-extern int foc_get_nr_of_points();
-
 /* get total number of points */
 int get_nr_of_points() {
     return total;
@@ -218,7 +215,7 @@ int get_nr_of_mults() {
 
 /* calculate total score */
 int get_total_score() {
-    if (focm == 1)
+    if (IS_CONTEST(FOCMARATHON))
 	return foc_total_score();
     else
 	return get_nr_of_points() * get_nr_of_mults();
@@ -349,7 +346,7 @@ void showscore(void) {
     if (IS_CONTEST(SPRINT)) {
 
 	mvprintw(5, START_COL, "Score: %d", get_nr_of_points());
-    } else if (focm == 1) {
+    } else if (IS_CONTEST(FOCMARATHON)) {
 	foc_show_scoring(START_COL);
     } else if (IS_CONTEST(STEWPERRY)) {
 	/* no normal multis, but may have POWERMULT set (fixedmult != 0.) */

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -351,7 +351,7 @@ void showscore(void) {
 	mvprintw(5, START_COL, "Score: %d", get_nr_of_points());
     } else if (focm == 1) {
 	foc_show_scoring(START_COL);
-    } else if (stewperry_flg == 1) {
+    } else if (IS_CONTEST(STEWPERRY)) {
 	/* no normal multis, but may have POWERMULT set (fixedmult != 0.) */
 	stewperry_show_summary(get_nr_of_points(), fixedmult);
     } else {

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -155,7 +155,7 @@ int get_nr_of_mults() {
     if (IS_CONTEST(SPRINT)) {
 	/* no multis used */
 	return 1;
-    } else if (arrlss == 1) {
+    } else if (IS_CONTEST(ARRL_SS)) {
 
 	return nr_multis;
     } else if (IS_CONTEST(CQWW)) {
@@ -178,7 +178,7 @@ int get_nr_of_mults() {
     } else if (universal == 1 && country_mult == 1) {
 
 	return totalcountries;
-    } else if (universal == 1 && multlist == 1 && arrlss != 1) {
+    } else if (universal == 1 && multlist == 1 && !IS_CONTEST(ARRL_SS)) {
 
 	return totalmults ;
     } else if (pacc_pa_flg == 1) {
@@ -229,7 +229,6 @@ int get_total_score() {
 void showscore(void) {
 
     extern int showscore_flag;
-    extern int arrlss;
     extern int pacc_pa_flg;
     extern int universal;
     extern int country_mult;

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -34,6 +34,7 @@
 #include "nicebox.h"		// Includes curses.h
 #include "printcall.h"
 #include "bands.h"
+#include "setcontest.h"
 #include "ui_utils.h"
 
 #define START_COL 45	/* start display in these column */
@@ -199,7 +200,7 @@ int get_nr_of_mults() {
 	       || (sectn_mult == 1)) {
 
 	return totalmults;
-    } else if (wpx == 1 || pfxmult == 1) {
+    } else if (IS_CONTEST(WPX) || pfxmult == 1) {
 
 	return GetNrOfPfx_once();
     } else if (pfxmultab == 1) {
@@ -244,7 +245,6 @@ void showscore(void) {
     extern int totalmults;
     extern int qsonum;
     extern int total;
-    extern int wpx;
     extern int sprint;
     extern int bandinx;
     extern int multscore[];
@@ -365,8 +365,9 @@ void showscore(void) {
     attron(COLOR_PAIR(C_HEADER));
     mvprintw(6, 55, spaces(19));
 
-    if (cqww == 1 || pfxmult == 1 || wpx == 1 || arrldx_usa == 1 || pacc_pa_flg == 1
-	    || wysiwyg_once == 1 || universal == 1) {	/* cqww or wpx */
+    if ((cqww == 1) || IS_CONTEST(WPX) || pfxmult == 1
+	    || (arrldx_usa == 1) || (pacc_pa_flg == 1)
+	    || (wysiwyg_once == 1) || (universal == 1)) {   /* cqww or wpx */
 
 	totalmults = get_nr_of_mults();
 	totalmults = totalmults ? totalmults : 1;	/* at least one */
@@ -378,7 +379,7 @@ void showscore(void) {
 	    mvprintw(6, 55, "Q/M %.1f ", p);
     }
 
-    if (wpx == 1) {
+    if (IS_CONTEST(WPX)) {
 	if (minute_timer > 0)
 	    mvprintw(6, 75, "%d", minute_timer);
     }

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -155,19 +155,19 @@ int get_nr_of_mults() {
 		       bandweight_multis[bi_normal[n]]);
     }
 
-    if (IS_CONTEST(SPRINT)) {
+    if (CONTEST_IS(SPRINT)) {
 	/* no multis used */
 	return 1;
-    } else if (IS_CONTEST(ARRL_SS)) {
+    } else if (CONTEST_IS(ARRL_SS)) {
 
 	return nr_multis;
-    } else if (IS_CONTEST(CQWW)) {
+    } else if (CONTEST_IS(CQWW)) {
 
 	return totalcountries + totalzones;
-    } else if (IS_CONTEST(ARRLDX_USA)) {
+    } else if (CONTEST_IS(ARRLDX_USA)) {
 
 	return totalcountries;
-    } else if (IS_CONTEST(ARRL_FD)) {
+    } else if (CONTEST_IS(ARRL_FD)) {
 	/* arrl mults are always integers */
 	int mult = (int)floor(fixedmult + 0.5); 	/* round to nearest integer */
 	if (mult > 0) {
@@ -181,10 +181,10 @@ int get_nr_of_mults() {
     } else if (country_mult == 1) {
 
 	return totalcountries;
-    } else if (multlist == 1 && !IS_CONTEST(ARRL_SS)) {
+    } else if (multlist == 1 && !CONTEST_IS(ARRL_SS)) {
 
 	return totalmults ;
-    } else if (IS_CONTEST(PACC_PA)) {
+    } else if (CONTEST_IS(PACC_PA)) {
 
 	return totalcountries;
     } else if ((wysiwyg_once == 1)
@@ -199,7 +199,7 @@ int get_nr_of_mults() {
 	       || (sectn_mult == 1)) {
 
 	return totalmults;
-    } else if (IS_CONTEST(WPX) || pfxmult == 1) {
+    } else if (CONTEST_IS(WPX) || pfxmult == 1) {
 
 	return GetNrOfPfx_once();
     } else if (pfxmultab == 1) {
@@ -218,7 +218,7 @@ int get_nr_of_mults() {
 
 /* calculate total score */
 int get_total_score() {
-    if (IS_CONTEST(FOCMARATHON))
+    if (CONTEST_IS(FOCMARATHON))
 	return foc_total_score();
     else
 	return get_nr_of_points() * get_nr_of_mults();
@@ -302,7 +302,7 @@ void showscore(void) {
 	}
     }
 
-    if (IS_CONTEST(CQWW)) {
+    if (CONTEST_IS(CQWW)) {
 
 	mvprintw(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
@@ -315,7 +315,7 @@ void showscore(void) {
 	}
     }
 
-    if (IS_CONTEST(ARRLDX_USA)) {
+    if (CONTEST_IS(ARRLDX_USA)) {
 
 	mvprintw(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
@@ -331,7 +331,7 @@ void showscore(void) {
 	}
     }
 
-    if (IS_CONTEST(PACC_PA)) {
+    if (CONTEST_IS(PACC_PA)) {
 
 	mvprintw(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
@@ -340,12 +340,12 @@ void showscore(void) {
     }
 
     /* show score summary */
-    if (IS_CONTEST(SPRINT)) {
+    if (CONTEST_IS(SPRINT)) {
 
 	mvprintw(5, START_COL, "Score: %d", get_nr_of_points());
-    } else if (IS_CONTEST(FOCMARATHON)) {
+    } else if (CONTEST_IS(FOCMARATHON)) {
 	foc_show_scoring(START_COL);
-    } else if (IS_CONTEST(STEWPERRY)) {
+    } else if (CONTEST_IS(STEWPERRY)) {
 	/* no normal multis, but may have POWERMULT set (fixedmult != 0.) */
 	stewperry_show_summary(get_nr_of_points(), fixedmult);
     } else {
@@ -369,7 +369,7 @@ void showscore(void) {
 	    mvprintw(6, 55, "Q/M %.1f ", p);
     }
 
-    if (IS_CONTEST(WPX)) {
+    if (CONTEST_IS(WPX)) {
 	if (minute_timer > 0)
 	    mvprintw(6, 75, "%d", minute_timer);
     }

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -161,7 +161,7 @@ int get_nr_of_mults() {
     } else if (IS_CONTEST(CQWW)) {
 
 	return totalcountries + totalzones;
-    } else if (arrldx_usa == 1) {
+    } else if (IS_CONTEST(ARRLDX_USA)) {
 
 	return totalcountries;
     } else if (arrl_fd == 1) {
@@ -229,7 +229,6 @@ int get_total_score() {
 void showscore(void) {
 
     extern int showscore_flag;
-    extern int arrldx_usa;
     extern int arrl_fd;
     extern int arrlss;
     extern int pacc_pa_flg;
@@ -317,7 +316,7 @@ void showscore(void) {
 	}
     }
 
-    if (arrldx_usa == 1) {
+    if (IS_CONTEST(ARRLDX_USA)) {
 
 	mvprintw(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
@@ -360,7 +359,7 @@ void showscore(void) {
     mvprintw(6, 55, spaces(19));
 
     if (IS_CONTEST(CQWW) || IS_CONTEST(WPX) || pfxmult == 1
-	    || (arrldx_usa == 1) || (pacc_pa_flg == 1)
+	    || IS_CONTEST(ARRLDX_USA) || (pacc_pa_flg == 1)
 	    || (wysiwyg_once == 1) || (universal == 1)) {   /* cqww or wpx */
 
 	totalmults = get_nr_of_mults();

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -158,7 +158,7 @@ int get_nr_of_mults() {
     } else if (arrlss == 1) {
 
 	return nr_multis;
-    } else if (cqww == 1) {
+    } else if (IS_CONTEST(CQWW)) {
 
 	return totalcountries + totalzones;
     } else if (arrldx_usa == 1) {
@@ -229,7 +229,6 @@ int get_total_score() {
 void showscore(void) {
 
     extern int showscore_flag;
-    extern int cqww;
     extern int arrldx_usa;
     extern int arrl_fd;
     extern int arrlss;
@@ -305,7 +304,7 @@ void showscore(void) {
 	}
     }
 
-    if (cqww == 1) {
+    if (IS_CONTEST(CQWW)) {
 
 	mvprintw(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
@@ -360,7 +359,7 @@ void showscore(void) {
     attron(COLOR_PAIR(C_HEADER));
     mvprintw(6, 55, spaces(19));
 
-    if ((cqww == 1) || IS_CONTEST(WPX) || pfxmult == 1
+    if (IS_CONTEST(CQWW) || IS_CONTEST(WPX) || pfxmult == 1
 	    || (arrldx_usa == 1) || (pacc_pa_flg == 1)
 	    || (wysiwyg_once == 1) || (universal == 1)) {   /* cqww or wpx */
 

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -181,7 +181,7 @@ int get_nr_of_mults() {
     } else if (universal == 1 && multlist == 1 && !IS_CONTEST(ARRL_SS)) {
 
 	return totalmults ;
-    } else if (pacc_pa_flg == 1) {
+    } else if (IS_CONTEST(PACC_PA)) {
 
 	return totalcountries;
     } else if ((wysiwyg_once == 1)
@@ -229,7 +229,6 @@ int get_total_score() {
 void showscore(void) {
 
     extern int showscore_flag;
-    extern int pacc_pa_flg;
     extern int universal;
     extern int country_mult;
     extern int wysiwyg_once;
@@ -330,7 +329,7 @@ void showscore(void) {
 	}
     }
 
-    if (pacc_pa_flg == 1) {
+    if (IS_CONTEST(PACC_PA)) {
 
 	mvprintw(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
@@ -357,7 +356,7 @@ void showscore(void) {
     mvprintw(6, 55, spaces(19));
 
     if (IS_CONTEST(CQWW) || IS_CONTEST(WPX) || pfxmult == 1
-	    || IS_CONTEST(ARRLDX_USA) || (pacc_pa_flg == 1)
+	    || IS_CONTEST(ARRLDX_USA) || (IS_CONTEST(PACC_PA))
 	    || (wysiwyg_once == 1) || (universal == 1)) {   /* cqww or wpx */
 
 	totalmults = get_nr_of_mults();

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -164,7 +164,7 @@ int get_nr_of_mults() {
     } else if (IS_CONTEST(ARRLDX_USA)) {
 
 	return totalcountries;
-    } else if (arrl_fd == 1) {
+    } else if (IS_CONTEST(ARRL_FD)) {
 	/* arrl mults are always integers */
 	int mult = (int)floor(fixedmult + 0.5); 	/* round to nearest integer */
 	if (mult > 0) {
@@ -229,7 +229,6 @@ int get_total_score() {
 void showscore(void) {
 
     extern int showscore_flag;
-    extern int arrl_fd;
     extern int arrlss;
     extern int pacc_pa_flg;
     extern int universal;

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -36,6 +36,7 @@
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "lancode.h"
 #include "printcall.h"
+#include "setcontest.h"
 #include "showscore.h"
 #include "tlf_curses.h"
 #include "trx_memory.h"
@@ -135,7 +136,7 @@ void time_update(void) {
     /* do it every second */
     oldsecs = this_second;
 
-    if (wpx == 1) {
+    if (IS_CONTEST(WPX)) {
 	if (minute_timer > 0)
 	    minute_timer--;
     }

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -136,7 +136,7 @@ void time_update(void) {
     /* do it every second */
     oldsecs = this_second;
 
-    if (IS_CONTEST(WPX)) {
+    if (CONTEST_IS(WPX)) {
 	if (minute_timer > 0)
 	    minute_timer--;
     }

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -200,8 +200,6 @@ typedef enum {
     PACC_PA,
     STEWPERRY,
     FOCMARATHON,
-    OTHER,
-    UNIVERSAL,
     UNKNOWN
 } contest_type_t;
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -203,6 +203,8 @@ typedef enum {
     UNKNOWN
 } contest_type_t;
 
+#define QSO_MODE ("qso")
+
 /** contest configuration
  *
  */

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -201,7 +201,8 @@ typedef enum {
     STEWPERRY,
     FOCMARATHON,
     OTHER,
-    UNIVERSAL
+    UNIVERSAL,
+    UNKNOWN
 } contest_type_t;
 
 /** contest configuration

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -213,5 +213,7 @@ typedef struct {
     char		*name;
 } contest_config_t;
 
+#define FREE_DYNAMIC_STRING(p)  if (p != NULL) {g_free(p); p = NULL;}
+
 #endif /* TLF_H */
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -187,5 +187,30 @@ void refreshp();
 
 extern const char *backgrnd_str;
 
+typedef enum {
+    QSO,
+    DXPED,
+    WPX,
+    CQWW,
+    SPRINT,
+    ARRLDX_USA,
+    ARRLDX_DX,
+    ARRL_SS,
+    ARRL_FD,
+    PACC_PA,
+    STEWPERRY,
+    FOCMARATHON,
+    OTHER,
+    UNIVERSAL
+} contest_type_t;
+
+/** contest configuration
+ *
+ */
+typedef struct {
+    contest_type_t	id;
+    char		*name;
+} contest_config_t;
+
 #endif /* TLF_H */
 

--- a/test/data.c
+++ b/test/data.c
@@ -73,7 +73,6 @@ int arrldx_usa = 0;
 int arrl_fd = 0;
 int arrlss = 0;
 int pacc_pa_flg = 0;
-int focm = 0;
 
 int universal = 0;
 int addcallarea;

--- a/test/data.c
+++ b/test/data.c
@@ -235,7 +235,7 @@ int early_started = 0;			/**< 1 if sending call started early,
 char lastcall[20];
 char qsonrstr[5] = "0001";
 char band[NBANDS][4] =
-{ "160", " 80", " 40", " 30", " 20", " 17", " 15", " 12", " 10" };
+{ "160", " 80", " 60", " 40", " 30", " 20", " 17", " 15", " 12", " 10", "???" };
 char comment[80];
 char mode[20] = "Log     ";
 char cqzone[3] = "";

--- a/test/data.c
+++ b/test/data.c
@@ -69,7 +69,6 @@ contest_config_t *contest;	/* contest configuration */
 
 /* predefined contests */
 int cqww = 0;
-int dxped = 0;
 int sprint = 0;
 int arrldx_usa = 0;
 int arrl_fd = 0;

--- a/test/data.c
+++ b/test/data.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../src/globalvars.h"
+#include "../src/setcontest.h"
 #include "../src/tlf.h"
 #include "../src/tlf_curses.h"
 
@@ -61,6 +62,10 @@ int cqwwm2 = 0;
 
 int cwkeyer = NO_KEYER;
 int digikeyer = NO_KEYER;
+
+char whichcontest[40] = "qso";
+bool iscontest = false;		/* false =  General,  true  = contest */
+contest_config_t *contest;	/* contest configuration */
 
 /* predefined contests */
 int cqww = 0;
@@ -166,12 +171,10 @@ int searchflg = 0;		/* 1  = display search  window */
 int show_time = 0;
 cqmode_t cqmode = CQ;
 int demode = 0;			/* 1 =  send DE  before s&p call  */
-bool iscontest = false;		/* false =  General,  true  = contest */
 int announcefilter = FILTER_ANN; /*  filter cluster  announcements */
 int showscore_flag = 0;		/* show  score window */
 int change_rst = 0;
 char exchange[40];
-char whichcontest[40] = "qso";
 int defer_store = 0;
 mystation_t my;
 char logfile[120] = "general.log";

--- a/test/data.c
+++ b/test/data.c
@@ -69,7 +69,6 @@ contest_config_t *contest;	/* contest configuration */
 
 /* predefined contests */
 int cqww = 0;
-int wpx = 0;
 int dxped = 0;
 int sprint = 0;
 int arrldx_usa = 0;

--- a/test/data.c
+++ b/test/data.c
@@ -68,7 +68,6 @@ bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest;	/* contest configuration */
 
 
-int universal = 0;
 int addcallarea;
 int pfxmult = 0;
 int pfxmultab = 0;

--- a/test/data.c
+++ b/test/data.c
@@ -68,7 +68,6 @@ bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest;	/* contest configuration */
 
 /* predefined contests */
-int cqww = 0;
 int arrldx_usa = 0;
 int arrl_fd = 0;
 int arrlss = 0;

--- a/test/data.c
+++ b/test/data.c
@@ -69,7 +69,6 @@ contest_config_t *contest;	/* contest configuration */
 
 /* predefined contests */
 int cqww = 0;
-int sprint = 0;
 int arrldx_usa = 0;
 int arrl_fd = 0;
 int arrlss = 0;

--- a/test/data.c
+++ b/test/data.c
@@ -68,7 +68,6 @@ bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest;	/* contest configuration */
 
 /* predefined contests */
-int arrlss = 0;
 int pacc_pa_flg = 0;
 
 int universal = 0;

--- a/test/data.c
+++ b/test/data.c
@@ -68,7 +68,6 @@ bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest;	/* contest configuration */
 
 /* predefined contests */
-int arrldx_usa = 0;
 int arrl_fd = 0;
 int arrlss = 0;
 int pacc_pa_flg = 0;

--- a/test/data.c
+++ b/test/data.c
@@ -67,8 +67,6 @@ char whichcontest[40] = "qso";
 bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest;	/* contest configuration */
 
-/* predefined contests */
-int pacc_pa_flg = 0;
 
 int universal = 0;
 int addcallarea;

--- a/test/data.c
+++ b/test/data.c
@@ -68,7 +68,6 @@ bool iscontest = false;		/* false =  General,  true  = contest */
 contest_config_t *contest;	/* contest configuration */
 
 /* predefined contests */
-int arrl_fd = 0;
 int arrlss = 0;
 int pacc_pa_flg = 0;
 

--- a/test/data.c
+++ b/test/data.c
@@ -73,7 +73,6 @@ int arrldx_usa = 0;
 int arrl_fd = 0;
 int arrlss = 0;
 int pacc_pa_flg = 0;
-int stewperry_flg = 0;
 int focm = 0;
 
 int universal = 0;

--- a/test/data/continents.txt
+++ b/test/data/continents.txt
@@ -1,0 +1,2 @@
+xx=EU,OC
+aadx= AS

--- a/test/data/countries.txt
+++ b/test/data/countries.txt
@@ -1,0 +1,3 @@
+adx=G,GM,F
+BDX= EA, CT
+cdx= LY, YL, ES

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -45,10 +45,7 @@ int pacc_pa(void) {
 
 /* setups */
 int setup_default(void **state) {
-    char filename[100];
-
-    strcpy(filename, TOP_SRCDIR);
-    strcat(filename, "/share/cty.dat");
+    static char filename[] =  TOP_SRCDIR "/share/cty.dat";
     assert_int_equal(load_ctydata(filename), 0);
 
     nr_worked = 0;

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -56,7 +56,6 @@ int setup_default(void **state) {
     bandinx = BANDINDEX_10;
 
     setcontest("CQWW");
-    cqww = 1;
 
     pfxmult = 0;
     dupe = 0;

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -59,7 +59,6 @@ int setup_default(void **state) {
 
     pfxmult = 0;
     dupe = 0;
-    arrldx_usa = 0;
 
     /* it may be a bug that addcall does not initialize addcallarea */
     addcallarea = 0;

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -5,6 +5,7 @@
 #include "../src/getctydata.h"
 #include "../src/globalvars.h"
 #include "../src/score.h"
+#include "../src/setcontest.h"
 
 // OBJECT ../src/addcall.o
 // OBJECT ../src/addmult.o
@@ -19,6 +20,7 @@
 // OBJECT ../src/qrb.o
 // OBJECT ../src/score.o
 // OBJECT ../src/searchcallarray.o
+// OBJECT ../src/setcontest.o
 // OBJECT ../src/zone_nr.o
 
 
@@ -45,11 +47,17 @@ int pacc_pa(void) {
 int setup_default(void **state) {
     char filename[100];
 
+    strcpy(filename, TOP_SRCDIR);
+    strcat(filename, "/share/cty.dat");
+    assert_int_equal(load_ctydata(filename), 0);
+
     nr_worked = 0;
     memset(&worked, 0, sizeof(worked));
     bandinx = BANDINDEX_10;
-    cqww = 1;   /* trigger zone evaluation */
-    wpx = 0;
+
+    setcontest("CQWW");
+    cqww = 1;
+
     pfxmult = 0;
     dupe = 0;
     arrldx_usa = 0;
@@ -79,11 +87,6 @@ int setup_default(void **state) {
 
     memset(zones, 0, sizeof(zones));
     memset(zonescore, 0, sizeof(zonescore));
-
-    strcpy(filename, TOP_SRCDIR);
-    strcat(filename, "/share/cty.dat");
-    assert_int_equal(load_ctydata(filename), 0);
-
 
     return 0;
 }

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -51,10 +51,8 @@ void setup_multis(char *multstring) {
 
 
 int setup_default(void **state) {
-    char filename[100];
 
-    strcpy(filename, TOP_SRCDIR);
-    strcat(filename, "/share/cty.dat");
+    static char filename[] =  TOP_SRCDIR "/share/cty.dat";
     assert_int_equal(load_ctydata(filename), 0);
 
     setcontest("qso");

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -2,19 +2,31 @@
 
 #include "../src/tlf.h"
 #include "../src/addmult.h"
+#include "../src/dxcc.h"
 #include "../src/globalvars.h"
 #include "../src/bands.h"
+#include "../src/setcontest.h"
 #include <stdio.h>
 #include <unistd.h>
 
 // OBJECT ../src/addmult.o
 // OBJECT ../src/bands.o
+// OBJECT ../src/dxcc.o
+// OBJECT ../src/setcontest.o
 
 extern mults_t multis[MAX_MULTS];
 extern int nr_multis;
 
 extern char multsfile[];	/* name of file with a list of allowed
 				   multipliers */
+
+/* dummies */
+int getctynr() {
+    return 42;
+}
+
+contest_config_t config_focm;
+
 
 char *testfile = "mults";
 
@@ -39,13 +51,19 @@ void setup_multis(char *multstring) {
 
 
 int setup_default(void **state) {
+    char filename[100];
+
+    strcpy(filename, TOP_SRCDIR);
+    strcat(filename, "/share/cty.dat");
+    assert_int_equal(load_ctydata(filename), 0);
+
+    setcontest("qso");
+
     bandinx = BANDINDEX_80;
 
-    arrlss = 0;
     shownewmult = -1;
     wysiwyg_once = 0;
     wysiwyg_multi = 0;
-    arrlss = 0;
     serial_section_mult = 0;
     sectn_mult = 0;
     serial_grid4_mult = 0;
@@ -266,7 +284,8 @@ void test_serial_grid4_empty(void **state) {
 }
 
 void test_arrlss(void **state) {
-    arrlss = 1;
+    setcontest("arrl_ss");
+
     setup_multis("SC\nSCV\n");
     strcpy(ssexchange, "SCV");
     addmult();
@@ -319,7 +338,8 @@ char logline_2[] =
     " 20CW  08-Feb-11 17:06 0025  W3ND           599  599  WAC                     2 ";
 
 void test_arrlss_2(void **state) {
-    arrlss = 1;
+    setcontest("arrl_ss");
+
     setup_multis("SC\nSCV\n");
     strcpy(lan_logline, logline);
     addmult2();

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -30,11 +30,9 @@ void makelogline() {
     bandinx_spy = bandinx;
 }
 
-char formatfile[100];
+char formatfile[] = TOP_SRCDIR "/share/cabrillo.fmt" ;
 
 int setup(void **state) {
-    strcpy(formatfile, TOP_SRCDIR);
-    strcat(formatfile, "/share/cabrillo.fmt");
     return 0;
 }
 
@@ -136,10 +134,10 @@ void test_readCabrilloFormatWAE(void **state) {
 
 void test_readCabrilloFileNotFound(void **state) {
     struct cabrillo_desc *desc;
-    char formatfile1[100];
-    strcpy(formatfile1, TOP_SRCDIR);
-    strcat(formatfile1, "/share/cabrillo1.fmt");
+
+    static char formatfile1[] = TOP_SRCDIR "/share/cabrillo1.fmt";
     desc = read_cabrillo_format(formatfile1, "WAEDC");
+
     assert_null(desc);
 }
 

--- a/test/test_contest.c
+++ b/test/test_contest.c
@@ -14,8 +14,7 @@ int getctynr() {
     return 42;
 }
 
-void foc_init() {
-}
+contest_config_t config_focm;
 
 int setup_default(void **state) {
     char filename[100];

--- a/test/test_contest.c
+++ b/test/test_contest.c
@@ -17,10 +17,7 @@ int getctynr() {
 contest_config_t config_focm;
 
 int setup_default(void **state) {
-    char filename[100];
-
-    strcpy(filename, TOP_SRCDIR);
-    strcat(filename, "/share/cty.dat");
+    static char filename[] =  TOP_SRCDIR "/share/cty.dat";
     assert_int_equal(load_ctydata(filename), 0);
 
     contest = NULL;

--- a/test/test_contest.c
+++ b/test/test_contest.c
@@ -1,0 +1,45 @@
+#include "test.h"
+
+#include "../src/dxcc.h"
+#include "../src/globalvars.h"
+#include "../src/setcontest.h"
+
+
+
+// OBJECT ../src/dxcc.o
+// OBJECT ../src/setcontest.o
+
+/* dummys */
+int getctynr() {
+    return 42;
+}
+
+void foc_init() {
+}
+
+int setup_default(void **state) {
+    char filename[100];
+
+    strcpy(filename, TOP_SRCDIR);
+    strcat(filename, "/share/cty.dat");
+    assert_int_equal(load_ctydata(filename), 0);
+
+    contest = NULL;
+
+    return 0;
+}
+
+void test_lookup_contest(void **state) {
+    contest = lookup_contest("CQWW");
+    assert_int_equal(contest->id, CQWW);
+}
+
+void test_lookup_contest_ignore_case(void **state) {
+    contest = lookup_contest("cqww");
+    assert_int_equal(contest->id, CQWW);
+}
+
+void test_lookup_contest_not_found(void **state){
+    contest = lookup_contest("A23b9");
+    assert_int_equal(contest->id, UNKNOWN);
+}

--- a/test/test_contest.c
+++ b/test/test_contest.c
@@ -25,6 +25,7 @@ int setup_default(void **state) {
     assert_int_equal(load_ctydata(filename), 0);
 
     contest = NULL;
+    strcpy(whichcontest, "");
 
     return 0;
 }
@@ -42,4 +43,15 @@ void test_lookup_contest_ignore_case(void **state) {
 void test_lookup_contest_not_found(void **state){
     contest = lookup_contest("A23b9");
     assert_int_equal(contest->id, UNKNOWN);
+}
+
+void test_lookup_contest_ignore_incomplete(void **state) {
+    config_qso.name = NULL;
+    contest = lookup_contest("A23b9");
+    assert_int_equal(contest->id, UNKNOWN);
+}
+
+void test_set_whichcontest(void **state) {
+    setcontest("Hello");
+    assert_string_equal(whichcontest, "Hello");
 }

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -4,12 +4,14 @@
 #include "../src/dxcc.h"
 #include "../src/readctydata.h"
 #include "../src/globalvars.h"
+#include "../src/setcontest.h"
 
 #include "../src/getctydata.h"
 
 // OBJECT ../src/dxcc.o
 // OBJECT ../src/getctydata.o
 // OBJECT ../src/getpx.o
+// OBJECT ../src/setcontest.o
 
 /* export internal function */
 int location_unknown(char *call);
@@ -17,17 +19,20 @@ int getpfxindex(char *checkcallptr, char **normalized_call);
 
 extern char countrylist[255][6];
 
+void foc_init() {
+}
 
 int setup_default(void **state) {
     char filename[100];
 
-    wpx = 0;
-    pfxmult = 0;
-    strcpy(countrylist[0], "");
-
     strcpy(filename, TOP_SRCDIR);
     strcat(filename, "/share/cty.dat");
     assert_int_equal(load_ctydata(filename), 0);
+
+    setcontest("qso");
+    pfxmult = 0;
+    strcpy(countrylist[0], "");
+
     return 0;
 }
 
@@ -91,7 +96,6 @@ void test_same_result(void **data) {
 
 void test_no_wpx(void **state) {
     int nr;
-    wpx = 0;
     pxstr[0] = '\0';
     nr = getctydata("DJ/PA3LM");
     assert_string_equal(pxstr, "");
@@ -100,7 +104,18 @@ void test_no_wpx(void **state) {
 
 void test_is_wpx(void **state) {
     int nr;
-    wpx = 1;
+
+    setcontest("wpx");
+    pxstr[0] = '\0';
+    nr = getctydata("DJ/PA3LM");
+    assert_string_equal(pxstr, "DJ0");
+    assert_int_equal(getctydata("DL"), nr);
+}
+
+void test_pfxmult_set(void **state) {
+    int nr;
+
+    pfxmult = 1;
     pxstr[0] = '\0';
     nr = getctydata("DJ/PA3LM");
     assert_string_equal(pxstr, "DJ0");

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -22,10 +22,8 @@ extern char countrylist[255][6];
 contest_config_t config_focm;
 
 int setup_default(void **state) {
-    char filename[100];
 
-    strcpy(filename, TOP_SRCDIR);
-    strcat(filename, "/share/cty.dat");
+    static char filename[] =  TOP_SRCDIR "/share/cty.dat";
     assert_int_equal(load_ctydata(filename), 0);
 
     setcontest("qso");

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -19,8 +19,7 @@ int getpfxindex(char *checkcallptr, char **normalized_call);
 
 extern char countrylist[255][6];
 
-void foc_init() {
-}
+contest_config_t config_focm;
 
 int setup_default(void **state) {
     char filename[100];

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -11,6 +11,9 @@
 #include "../src/qtcvars.h"
 #include "../src/tlf.h"
 #include "../src/globalvars.h"
+#include "../src/getwwv.h"
+#include "../src/change_rst.h"
+#include "../src/setcontest.h"
 
 // OBJECT ../src/parse_logcfg.o
 // OBJECT ../src/get_time.o
@@ -19,6 +22,7 @@
 // OBJECT ../src/locator2longlat.o
 // OBJECT ../src/score.o
 // OBJECT ../src/qrb.o
+// OBJECT ../src/setcontest.o
 
 extern char keyer_device[10];
 extern int partials;
@@ -74,12 +78,62 @@ extern int sectn_mult_once;
 extern int lan_port;
 extern char rigconf[];
 extern char ph_message[14][80];
+extern char *cabrillo;
+extern int timeoffset;
+extern int cwkeyer;
+extern int digikeyer;
+extern char *rigportname;
+extern int tnc_serial_rate;
+extern char tncportname[];
+extern int serial_rate;
+extern int packetinterface;
+extern char pr_hostaddress[];
+extern int portnum;
+extern int cluster;
+extern int cqdelay;
+extern int ssbpoints;
+extern int cwpoints;
+extern int tlfcolors[8][2];
+extern char whichcontest[40];
+extern int use_bandoutput;
+extern int bandindexarray[10];
+extern char tonestr[];
+extern int txdelay;
+extern int multlist;
+extern char multsfile[];
+extern int xplanet;
+extern char markerfile[];
+extern char countrylist[][6];
+extern bool mult_side;
+extern int countrylist_points;
+extern bool countrylist_only;
+extern int my_country_points;
+extern int my_cont_points;
+extern int dx_cont_points;
+extern char synclogfile[];
+extern char sc_volume[];
+extern char sc_device[];
+extern char modem_mode[];
+extern char controllerport[];
+extern char clusterlogin[];
+extern int cw_bandwidth;
+extern char exchange_list[40];
+extern char rttyoutput[];
+extern float fixedmult;
+extern int continentlist_points;
+extern char continent_multiplier_list[7][3];
+extern int bandweight_points[NBANDS];
+extern int bandweight_multis[NBANDS];
+extern pfxnummulti_t pfxnummulti[MAXPFXNUMMULT];
+extern int pfxnummultinr;
+extern int exclude_multilist_type;
+extern unsigned char rigptt;
 
 // lancode.c
 int nodes = 0;
-int node;
 struct sockaddr_in bc_address[MAXNODES];
 int lan_port = 6788;
+int lan_active;
 int landebug = 0;
 char thisnode = 'A';
 int time_master;
@@ -102,28 +156,41 @@ int call_update = 0;
 
 t_qtc_ry_line qtc_ry_lines[QTC_RY_LINE_NR];
 
-void setcontest(char * name) {
-    // TBD
-}
+contest_config_t config_focm;
 
+static bool fldigi_on;
 bool fldigi_isenabled(void) {
-    return false;   // TBD
-}
-
-void SetCWSpeed(unsigned int wpm) {
-    // TBD
+    return fldigi_on;
 }
 
 void fldigi_toggle() {
-    // TBD
+    fldigi_on = !fldigi_on;
 }
 
+static int wpm_spy;
+void SetCWSpeed(unsigned int wpm) {
+    wpm_spy = wpm;
+}
+
+static char rst_init_spy[100];
 void rst_init(char *init_string) {
-    // TBD
+    if (init_string != NULL) {
+	strcpy(rst_init_spy, init_string);
+    } else {
+	strcpy(rst_init_spy, "(NULL)");
+    }
 }
 
 int getctydata(char *checkcallptr) {
-    // TBD
+    // used for "PFX_NUM_MULTIS=W,VE,VK,ZL,ZS,JA,PY,UA9"
+    if (g_str_has_prefix(checkcallptr, "W")) return 18;
+    if (g_str_has_prefix(checkcallptr, "VE")) return 17;
+    if (g_str_has_prefix(checkcallptr, "VK")) return 16;
+    if (g_str_has_prefix(checkcallptr, "ZL")) return 15;
+    if (g_str_has_prefix(checkcallptr, "ZS")) return 14;
+    if (g_str_has_prefix(checkcallptr, "JA")) return 13;
+    if (g_str_has_prefix(checkcallptr, "PY")) return 12;
+    if (g_str_has_prefix(checkcallptr, "UA9")) return 11;
     return 0;
 }
 
@@ -137,8 +204,17 @@ int foc_score(char *a) {
     return 0;
 }
 
+
 /* setup/teardown */
 int setup_default(void **state) {
+    int result = chdir(SRCDIR);
+    if (result == -1)
+	perror("chdir");
+
+    memset(&my, 0, sizeof(my));
+    memset(&bm_config, 0, sizeof(bm_config));
+    memset(&pfxnummulti, 0, sizeof(pfxnummulti));
+
     *keyer_device = 0;
     partials = 0;
     use_part = 0;
@@ -146,25 +222,101 @@ int setup_default(void **state) {
     ignoredupe = false;
     continentlist_only = false;
     lan_port = 0;
+    timeoffset = 0;
+    cwkeyer = 0;
+    digikeyer = NO_KEYER;
+    packetinterface = 0;
+    portnum = 0;
+    shortqsonr = 0;
+    cluster = 0;
+    cqdelay = 8;
+    ssbpoints = 1;
+    cwpoints = 1;
+    trxmode = CWMODE;
+    use_bandoutput = 0;
+    one_point = 0;
+    two_point = 0;
+    three_point = 0;
+    thisnode = 'A';
+    nodes = 0;
+    xplanet = 0;
+    dx_arrlsections = 0;
+    mult_side = false;
+    countrylist_points = -1;
+    my_country_points = -1;
+    my_cont_points = -1;
+    dx_cont_points = -1;
+    continentlist_points = -1;
+    cw_bandwidth = 0;
+    change_rst = false;
+    fixedmult = 0.0;
+    exclude_multilist_type = EXCLUDE_NONE;
+    rigptt = 0;
+    minitest = 0;
+
+    setcontest(QSO_MODE);
+
+    tonestr[0] = 0;
+    multsfile[0] = 0;
+    markerfile[0] = 0;
+    synclogfile[0] = 0;
+    sc_volume[0] = 0;
+    sc_device[0] = 0;
+    modem_mode[0] = 0;
+    controllerport[0] = 0;
+    clusterlogin[0] = 0;
+    exchange_list[0] = 0;
+    rttyoutput[0] = 0;
+    qtcrec_record_command[0][0] = 0;
+    qtcrec_record_command[1][0] = 0;
+    qtcrec_record_command_shutdown[0] = 0;
+    unique_call_multi = 0;
+    digi_mode = -1;
 
     for (int i = 0; i < SP_CALL_MSG; ++i) {
 	message[i][0] = 0;
     }
-    for (int i = 0; i < 14; ++i) {
+    for (int i = 0; i < CQ_TU_MSG; ++i) {
 	ph_message[i][0] = 0;
+	qtc_phrecv_message[i][0] = 0;
+	qtc_phsend_message[i][0] = 0;
     }
-    for (int i = 0; i < SP_CALL_MSG; ++i) {
-	if (digi_message[i] != NULL) {
-	    g_free(digi_message[i]);
-	    digi_message[i] = NULL;
-	}
+    for (int i = 0; i < SP_TU_MSG; ++i) {
+	qtc_send_msgs[i][0] = 0;
+	qtc_recv_msgs[i][0] = 0;
+    }
+    for (int i = 0; i < 12; ++i) {
+	FREE_DYNAMIC_STRING(digi_message[i]);
+    }
+    for (int i = 0; i < 10; ++i) {
+	bandindexarray[i] = 0;
+    }
+    for (int i = 0; i < MAXNODES; ++i) {
+	bc_hostaddress[i][0] = 0;
+	bc_hostservice[i][0] = 0;
+    }
+    for (int i = 0; i < 255; ++i) {
+	countrylist[i][0] = 0;
+    }
+    for (int i = 0; i < 7; ++i) {
+	continent_multiplier_list[i][0] = 0;
+    }
+    for (int i = 0; i < NBANDS; ++i) {
+	bandweight_points[i] = 0;
+	bandweight_multis[i] = 0;
     }
 
     rigconf[0] = 0;
+    pr_hostaddress[0] = 0;
 
-    callmaster_filename = NULL;
+    FREE_DYNAMIC_STRING(editor_cmd);
+    FREE_DYNAMIC_STRING(cabrillo);
+    FREE_DYNAMIC_STRING(callmaster_filename);
+    FREE_DYNAMIC_STRING(rigportname);
 
     showmsg_spy = STRING_NOT_SET;
+    rst_init_spy[0] = 0;
+    fldigi_on = false;
 
     return 0;
 }
@@ -186,21 +338,21 @@ static int call_parse_logcfg(const char *input) {
 
 void test_unknown_keyword(void **state) {
     int rc = call_parse_logcfg("UNKNOWN\r\n");   // DOS line ending
-    assert_int_equal(rc, PARSE_CONFIRM);
+    assert_int_equal(rc, PARSE_ERROR);
     assert_string_equal(showmsg_spy,
 			"Keyword 'UNKNOWN' not supported. See man page.\n");
 }
 
 void test_unknown_keyword2(void **state) {
     int rc = call_parse_logcfg("F19=CQ\n");   // starts with an existing keyword
-    assert_int_equal(rc, PARSE_CONFIRM);
+    assert_int_equal(rc, PARSE_ERROR);
     assert_string_equal(showmsg_spy,
 			"Keyword 'F19' not supported. See man page.\n");
 }
 
 void test_deprecated_keyword(void **state) {
     int rc = call_parse_logcfg("CW_TU_MSG=TU\n");
-    assert_int_equal(rc, PARSE_CONFIRM);
+    assert_int_equal(rc, PARSE_ERROR);
     assert_string_equal(showmsg_spy,
 			"Keyword 'CW_TU_MSG' not supported. See man page.\n");
 }
@@ -213,9 +365,9 @@ void test_logfile(void **state) {
 
 void test_logfile_no_arg(void **state) {
     int rc = call_parse_logcfg("LOGFILE\r\n");   // DOS line ending
-    assert_int_equal(rc, PARSE_CONFIRM);
+    assert_int_equal(rc, PARSE_ERROR);
     assert_string_equal(showmsg_spy,
-			"Keyword 'LOGFILE' must be followed by an parameter ('=....'). See man page.\n");
+			"Keyword 'LOGFILE' must be followed by a parameter ('=....'). See man page.\n");
 }
 
 void test_keyer_device(void **state) {
@@ -250,7 +402,9 @@ void test_usepartials(void **state) {
 
 void test_usepartials_with_arg(void **state) {
     int rc = call_parse_logcfg("USEPARTIALS=no\n");
-    assert_int_equal(rc, 0); // FIXME: this should be 1
+    assert_int_equal(rc, PARSE_ERROR);
+    assert_string_equal(showmsg_spy,
+			"Keyword 'USEPARTIALS' can't have a parameter. See man page.\n");
 }
 
 typedef struct {
@@ -364,6 +518,7 @@ static int_one_t int_ones[] = {
     {"LOGFREQUENCY", &logfrequency},
     {"NO_RST", &no_rst},
     {"SERIAL_OR_SECTION", &serial_or_section},
+    {"PFX_MULT", &pfxmult},
     {"PFX_MULT_MULTIBAND", &pfxmultab},
     {"QTCREC_RECORD", &qtcrec_record},
     {"QTC_AUTO_FILLTIME", &qtc_auto_filltime},
@@ -403,7 +558,6 @@ void test_callmaster(void **state) {
     int rc = call_parse_logcfg("CALLMASTER=calls.txt\n");
     assert_int_equal(rc, PARSE_OK);
     assert_string_equal(callmaster_filename, "calls.txt");
-    g_free(callmaster_filename);
 }
 
 void test_vkmn(void **state) {
@@ -431,6 +585,7 @@ void test_vkcqm(void **state) {
     assert_string_equal(ph_message[CQ_TU_MSG], "b.wav");
 }
 
+// DKF1..DKF12
 void test_dkfn(void **state) {
     char line[80], msg[30];
     for (int i = 1; i <= 12; ++i) {
@@ -485,3 +640,699 @@ void test_dkspc(void **state) {
 			"DSPC "); // FIXME converts NL to space...
 }
 
+// QR_F1..QR_F12
+void test_qr_fn(void **state) {
+    char line[80], msg[30];
+    for (int i = 1; i <= 12; ++i) {
+	int j = i - 1;
+	qtc_recv_msgs[j][0] = 0;
+	sprintf(msg, "QRMSG%d MNO", i);
+	sprintf(line, "QR_F%d = %s \n", i, msg);
+	int rc = call_parse_logcfg(line);
+	assert_int_equal(rc, PARSE_OK);
+	sprintf(msg, "QRMSG%d MNO \n", i);    // FIXME NL is kept
+	assert_string_equal(qtc_recv_msgs[j], msg);
+    }
+}
+
+// QS_F1..QS_F12
+void test_qs_fn(void **state) {
+    char line[80], msg[30];
+    for (int i = 1; i <= 12; ++i) {
+	int j = i - 1;
+	qtc_send_msgs[j][0] = 0;
+	sprintf(msg, "QSMSG%d MNO", i);
+	sprintf(line, "QS_F%d = %s \n", i, msg);
+	int rc = call_parse_logcfg(line);
+	assert_int_equal(rc, PARSE_OK);
+	sprintf(msg, "QSMSG%d MNO \n", i);    // FIXME NL is kept
+	assert_string_equal(qtc_send_msgs[j], msg);
+    }
+}
+
+// QR_VKM1..QR_VKM12
+void test_qr_vkmn(void **state) {
+    char line[80], msg[30];
+    for (int i = 1; i <= 12; ++i) {
+	int j = i - 1;
+	qtc_phrecv_message[j][0] = 0;
+	sprintf(msg, "QRVK%d.wav", i);
+	sprintf(line, "QR_VKM%d = %s \n", i, msg);
+	int rc = call_parse_logcfg(line);
+	assert_int_equal(rc, PARSE_OK);
+	assert_string_equal(qtc_phrecv_message[j], msg);
+    }
+}
+
+// QS_VKM1..QS_VKM12
+void test_qs_vkmn(void **state) {
+    char line[80], msg[30];
+    for (int i = 1; i <= 12; ++i) {
+	int j = i - 1;
+	qtc_phsend_message[j][0] = 0;
+	sprintf(msg, "QSVK%d.wav", i);
+	sprintf(line, "QS_VKM%d = %s \n", i, msg);
+	int rc = call_parse_logcfg(line);
+	assert_int_equal(rc, PARSE_OK);
+	assert_string_equal(qtc_phsend_message[j], msg);
+    }
+}
+
+void test_qr_vkspm(void **state) {
+    int rc = call_parse_logcfg("QR_VKSPM=a.wav\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(qtc_phrecv_message[SP_TU_MSG], "a.wav");
+}
+
+void test_qr_vkcqm(void **state) {
+    int rc = call_parse_logcfg("QR_VKCQM=b.wav\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(qtc_phrecv_message[CQ_TU_MSG], "b.wav");
+}
+
+void test_qs_vkspm(void **state) {
+    int rc = call_parse_logcfg("QS_VKSPM=a.wav\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(qtc_phsend_message[SP_TU_MSG], "a.wav");
+}
+
+void test_qs_vkcqm(void **state) {
+    int rc = call_parse_logcfg("QS_VKCQM=b.wav\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(qtc_phsend_message[CQ_TU_MSG], "b.wav");
+}
+
+void test_call(void **state) {
+    int rc = call_parse_logcfg("CALL = AB1CD\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(my.call, "AB1CD\n");  // FIXME line end...
+}
+
+void test_cabrillo(void **state) {
+    int rc = call_parse_logcfg("CABRILLO = test.cab \r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(cabrillo, "test.cab");
+}
+
+void test_time_offset(void **state) {
+    int rc = call_parse_logcfg("TIME_OFFSET = -4\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(timeoffset, -4);
+}
+
+void test_netkeyer(void **state) {
+    int rc = call_parse_logcfg("NETKEYER\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(cwkeyer, NET_KEYER);
+}
+
+void test_netkeyerport(void **state) {
+    int rc = call_parse_logcfg("NETKEYERPORT = 16789\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(netkeyer_port, 16789);
+}
+
+void test_netkeyerhost(void **state) {
+    int rc = call_parse_logcfg("NETKEYERHOST = host.net \r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(netkeyer_hostaddress, "host.net");
+}
+
+void test_rigport(void **state) {
+    int rc = call_parse_logcfg("RIGPORT = /dev/rigport \r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_non_null(rigportname);
+    assert_string_equal(rigportname, "/dev/rigport \r\n");  // FIXME...
+}
+
+void test_tncspeed(void **state) {
+    int rc = call_parse_logcfg("TNCSPEED = 1200\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(tnc_serial_rate, 1200);
+}
+
+void test_rigspeed(void **state) {
+    int rc = call_parse_logcfg("RIGSPEED = 38400\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(serial_rate, 38400);
+}
+
+void test_fifo_interface(void **state) {
+    int rc = call_parse_logcfg("FIFO_INTERFACE\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(packetinterface, FIFO_INTERFACE);
+}
+
+void test_telnethost(void **state) {
+    int rc = call_parse_logcfg("TELNETHOST = host.net \r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(pr_hostaddress, "host.net");
+}
+
+void test_telnetport(void **state) {
+    int rc = call_parse_logcfg("TELNETPORT = 12345 \r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(portnum, 12345);
+    assert_int_equal(packetinterface, TELNET_INTERFACE);
+}
+
+void test_long_serial(void **state) {
+    shortqsonr = 1;
+    int rc = call_parse_logcfg("LONG_SERIAL  \r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(shortqsonr, 0);
+}
+
+void test_cluster(void **state) {
+    int rc = call_parse_logcfg("CLUSTER\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(cluster, CLUSTER);
+}
+
+void test_qtc_cap_calls(void **state) {
+    int rc = call_parse_logcfg(" QTC_CAP_CALLS = abc \r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(qtc_cap_calls, "abc");
+}
+
+void test_cqdelay(void **state) {
+    int rc = call_parse_logcfg("CQDELAY=12\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(cqdelay, 12);
+}
+
+void test_ssbpoints(void **state) {
+    int rc = call_parse_logcfg("SSBPOINTS=2\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(ssbpoints, 2);
+}
+
+void test_cwpoints(void **state) {
+    int rc = call_parse_logcfg("CWPOINTS=3\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(cwpoints, 3);
+}
+
+void test_ssbmode(void **state) {
+    int rc = call_parse_logcfg("SSBMODE\n");
+    assert_int_equal(rc, 0);
+    assert_int_equal(trxmode, SSBMODE);
+}
+
+// TLFCOLOR1..6
+void test_tlfcolorn(void **state) {
+    char line[80];
+    for (int i = 1 ; i <= 6; ++i) {
+	int j = (i == 1 ? 1 : i + 1);   // skip COLOR_RED
+	tlfcolors[j][0] = 0;
+	tlfcolors[j][1] = 0;
+	sprintf(line, "TLFCOLOR%d=%d%d\n", i, i, 7 - i);
+	int rc = call_parse_logcfg(line);
+	assert_int_equal(rc, 0);
+	assert_int_equal(tlfcolors[j][0], i);
+	assert_int_equal(tlfcolors[j][1], 7 - i);
+    }
+}
+
+void test_contest(void **state) {
+    int rc = call_parse_logcfg("CONTEST= adx \n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(whichcontest, "adx");
+    assert_int_equal(CONTEST_IS(UNKNOWN), 1);	/* setcontest() called */
+}
+
+void test_rules(void **state) {
+    int rc = call_parse_logcfg("RULES=bdx\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(whichcontest, "bdx");
+    assert_int_equal(CONTEST_IS(UNKNOWN), 1);
+}
+
+void test_bandoutput(void **state) {
+    int rc = call_parse_logcfg("BANDOUTPUT=9876543210\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(use_bandoutput, 1);
+    for (int i = 0; i <= 9; ++i) {
+	assert_int_equal(bandindexarray[i], 9 - i);
+    }
+}
+
+void test_one_points(void **state) {
+    int rc = call_parse_logcfg("ONE_POINT\n");
+    assert_int_equal(rc, 0);
+    assert_int_equal(one_point, 1);
+    assert_int_equal(two_point, 0);
+    assert_int_equal(three_point, 0);
+}
+void test_two_points(void **state) {
+    int rc = call_parse_logcfg("TWO_POINTS\n");
+    assert_int_equal(rc, 0);
+    assert_int_equal(one_point, 0);
+    assert_int_equal(two_point, 1);
+    assert_int_equal(three_point, 0);
+}
+
+void test_three_points(void **state) {
+    int rc = call_parse_logcfg("THREE_POINTS\n");
+    assert_int_equal(rc, 0);
+    assert_int_equal(one_point, 0);
+    assert_int_equal(two_point, 0);
+    assert_int_equal(three_point, 1);
+}
+
+void test_bandmap(void **state) {
+    int rc = call_parse_logcfg("BANDMAP\n");
+    assert_int_equal(rc, 0);
+    assert_int_equal(cluster, MAP);
+    assert_int_equal(bm_config.showdupes, 1);
+    assert_int_equal(bm_config.livetime, 900);
+}
+
+void test_bandmap_d100(void **state) {
+    int rc = call_parse_logcfg("BANDMAP=D,100\n");
+    assert_int_equal(rc, 0);
+    assert_int_equal(cluster, MAP);
+    assert_int_equal(bm_config.showdupes, 0);
+    assert_int_equal(bm_config.livetime, 100);
+}
+
+void test_cwspeed(void **state) {
+    int rc = call_parse_logcfg("CWSPEED= 18 \n");
+    assert_int_equal(rc, 0);
+    assert_int_equal(wpm_spy, 18);
+}
+
+void test_cwtone(void **state) {
+    int rc = call_parse_logcfg("CWTONE=765\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(tonestr, "765");
+}
+
+void test_txdelay(void **state) {
+    int rc = call_parse_logcfg("TXDELAY=28\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(txdelay, 28);
+}
+
+void test_sunspots(void **state) {
+    int rc = call_parse_logcfg("SUNSPOTS=123\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal((int)(ssn_r * 1000), 123 * 1000);
+}
+
+void test_sfi(void **state) {
+    int rc = call_parse_logcfg("SFI=160\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal((int)(ssn_r * 1000), 100 * 1000);
+}
+
+void test_tncport(void **state) {
+    int rc = call_parse_logcfg("TNCPORT=/dev/ttyUSB1\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(tncportname, "/dev/ttyUSB1\n"); // FIXME NL...
+}
+
+void test_rigmodel(void **state) {
+    int rc = call_parse_logcfg("RIGMODEL=123\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(myrig_model, 123);
+}
+
+void test_addnode(void **state) {
+    int rc = call_parse_logcfg("ADDNODE=hostx:1234\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(lan_active, 1);
+    assert_int_equal(nodes, 1);
+    assert_string_equal(bc_hostaddress[0], "hostx");
+    assert_string_equal(bc_hostservice[0], "1234");
+}
+
+void test_thisnode(void **state) {
+    int rc = call_parse_logcfg("THISNODE= C\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(thisnode, 'C');
+}
+
+void test_mult_list(void **state) {
+    int rc = call_parse_logcfg("MULT_LIST=mfile.txt\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(multlist, 1);
+    assert_string_equal(multsfile, "mfile.txt");
+}
+
+void test_markers(void **state) {
+    int rc = call_parse_logcfg("MARKERS=m.txt\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(xplanet, 1);
+    assert_string_equal(markerfile, "m.txt");
+}
+
+void test_markerdots(void **state) {
+    int rc = call_parse_logcfg("MARKERDOTS=md.txt\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(xplanet, 2);
+    assert_string_equal(markerfile, "md.txt");
+}
+
+void test_markercalls(void **state) {
+    int rc = call_parse_logcfg("MARKERCALLS=mc.txt\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(xplanet, 3);
+    assert_string_equal(markerfile, "mc.txt");
+}
+
+void test_dx_n_sections(void **state) {
+    strcpy(whichcontest, "abc");
+    int rc = call_parse_logcfg(" DX_&_SECTIONS \n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(dx_arrlsections, 1);
+    assert_int_equal(CONTEST_IS(UNKNOWN), 1);
+}
+
+void test_countrylist(void **state) {
+    strcpy(whichcontest, "abc");
+    strcpy(my.call, "GM1ABC");
+    int rc = call_parse_logcfg("COUNTRYLIST=G, GM , F\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(countrylist[0], "G");
+    assert_string_equal(countrylist[1], "GM");
+    assert_string_equal(countrylist[2], "F");
+    assert_string_equal(countrylist[3], "");
+    assert_true(mult_side);
+    assert_int_equal(CONTEST_IS(UNKNOWN), 1);
+}
+
+void test_countrylist_from_file(void **state) {
+    strcpy(my.call, "EB1ABC");
+    strcpy(whichcontest, "bdx");
+    int rc = call_parse_logcfg("COUNTRYLIST= data/countries.txt \n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(countrylist[0], "EA");
+    assert_string_equal(countrylist[1], "CT");
+    assert_string_equal(countrylist[2], "");
+    assert_true(mult_side);
+    assert_int_equal(CONTEST_IS(UNKNOWN), 1);
+}
+
+void test_countrylist_points(void **state) {
+    int rc = call_parse_logcfg("COUNTRY_LIST_POINTS=4\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(countrylist_points, 4);
+}
+
+void test_countrylist_only(void **state) {
+    int rc = call_parse_logcfg("USE_COUNTRYLIST_ONLY\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_true(countrylist_only);
+}
+
+void test_countrylist_only_mult_side(void **state) {
+    mult_side = true;
+    int rc = call_parse_logcfg("USE_COUNTRYLIST_ONLY\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_false(countrylist_only);
+}
+
+void test_my_country_points(void **state) {
+    int rc = call_parse_logcfg("MY_COUNTRY_POINTS=4\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(my_country_points, 4);
+}
+
+void test_my_continent_points(void **state) {
+    int rc = call_parse_logcfg("MY_CONTINENT_POINTS=3\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(my_cont_points, 3);
+}
+
+void test_dx_points(void **state) {
+    int rc = call_parse_logcfg("DX_POINTS=5\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(dx_cont_points, 5);
+}
+
+void test_syncfile(void **state) {
+    int rc = call_parse_logcfg("SYNCFILE = a.log\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(synclogfile, "a.log");
+}
+
+void test_sidetone_volume(void **state) {
+    int rc = call_parse_logcfg("SIDETONE_VOLUME = 63\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(sc_volume, "63");
+}
+
+void test_sc_device(void **state) {
+    int rc = call_parse_logcfg("SC_DEVICE = abc\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(sc_device, "abc");
+}
+
+void test_mfj1278_keyer(void **state) {
+    int rc = call_parse_logcfg("MFJ1278_KEYER = qwe\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(cwkeyer, MFJ1278_KEYER);
+    assert_int_equal(digikeyer, MFJ1278_KEYER);
+    assert_string_equal(controllerport, "qwe");
+}
+
+void test_clusterlogin(void **state) {
+    int rc = call_parse_logcfg("CLUSTERLOGIN = ab1cde\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(clusterlogin, "ab1cde\r\n");
+}
+
+void test_initial_exchange(void **state) {
+    int rc = call_parse_logcfg("INITIAL_EXCHANGE = abcde\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(exchange_list, "abcde");
+}
+
+void test_cwbandwidth(void **state) {
+    int rc = call_parse_logcfg("CWBANDWIDTH = 350\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(cw_bandwidth, 350);
+}
+
+void test_change_rst(void **state) {
+    int rc = call_parse_logcfg("CHANGE_RST= 55, 33 \r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_true(change_rst);
+    assert_string_equal(rst_init_spy, "55, 33");
+}
+
+void test_change_rst_no_arg(void **state) {
+    int rc = call_parse_logcfg("CHANGE_RST\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_true(change_rst);
+    assert_string_equal(rst_init_spy, "(NULL)");
+}
+
+void test_gmfsk(void **state) {
+    int rc = call_parse_logcfg("GMFSK=jkl\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(digikeyer, GMFSK);
+    assert_string_equal(controllerport, "jkl");
+}
+
+void test_rttymode(void **state) {
+    int rc = call_parse_logcfg("RTTYMODE\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(trxmode, DIGIMODE);
+    assert_string_equal(modem_mode, "RTTY");
+}
+
+void test_digimodem(void **state) {
+    int rc = call_parse_logcfg("DIGIMODEM=qwerty\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(rttyoutput, "qwerty");
+}
+
+void test_myqra(void **state) {
+    int rc = call_parse_logcfg("MYQRA=JN97\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(my.qra, "JN97\n");  // FIXME NL...
+}
+
+void test_powermult(void **state) {
+    int rc = call_parse_logcfg("POWERMULT=8.3\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal((int)(fixedmult * 1000), 8300);
+}
+
+void test_qtc_recv(void **state) {
+    int rc = call_parse_logcfg("QTC= RECV \n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(qtcdirection, RECV);
+}
+
+void test_qtc_send(void **state) {
+    int rc = call_parse_logcfg("QTC=SEND \n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(qtcdirection, SEND);
+}
+
+void test_qtc_both(void **state) {
+    int rc = call_parse_logcfg("QTC=BOTH\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(qtcdirection, RECV | SEND);
+}
+
+void test_continent_list_points(void **state) {
+    int rc = call_parse_logcfg("CONTINENT_LIST_POINTS=6\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(continentlist_points, 6);
+}
+
+void test_continentlist(void **state) {
+    strcpy(whichcontest, "abc");
+    int rc = call_parse_logcfg("CONTINENTLIST=NA, SA \n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(continent_multiplier_list[0], "NA");
+    assert_string_equal(continent_multiplier_list[1], "SA");
+    assert_string_equal(continent_multiplier_list[2], "");
+    assert_int_equal(CONTEST_IS(UNKNOWN), 1);
+}
+
+void test_continentlist_from_file(void **state) {
+    strcpy(whichcontest, "aadx");
+    int rc = call_parse_logcfg("CONTINENTLIST= data/continents.txt \n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(continent_multiplier_list[0], "AS");
+    assert_string_equal(continent_multiplier_list[1], "");
+    assert_int_equal(CONTEST_IS(UNKNOWN), 1);
+}
+
+void test_bandweight_points(void **state) {
+    int rc = call_parse_logcfg("BANDWEIGHT_POINTS=160:3,80:2,40:1,20:1,15:1,10:2\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(bandweight_points[BANDINDEX_160], 3);
+    assert_int_equal(bandweight_points[BANDINDEX_80], 2);
+    assert_int_equal(bandweight_points[BANDINDEX_60], 0);
+    assert_int_equal(bandweight_points[BANDINDEX_40], 1);
+    assert_int_equal(bandweight_points[BANDINDEX_30], 0);
+    assert_int_equal(bandweight_points[BANDINDEX_20], 1);
+    assert_int_equal(bandweight_points[BANDINDEX_17], 0);
+    assert_int_equal(bandweight_points[BANDINDEX_15], 1);
+    assert_int_equal(bandweight_points[BANDINDEX_12], 0);
+    assert_int_equal(bandweight_points[BANDINDEX_10], 2);
+    assert_int_equal(bandweight_points[BANDINDEX_OOB], 0);
+}
+
+void test_bandweight_multis(void **state) {
+    int rc = call_parse_logcfg("BANDWEIGHT_MULTIS=80:4,40:3,20:2,15:2,10:2");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(bandweight_multis[BANDINDEX_160], 0);
+    assert_int_equal(bandweight_multis[BANDINDEX_80], 4);
+    assert_int_equal(bandweight_multis[BANDINDEX_60], 0);
+    assert_int_equal(bandweight_multis[BANDINDEX_40], 3);
+    assert_int_equal(bandweight_multis[BANDINDEX_30], 0);
+    assert_int_equal(bandweight_multis[BANDINDEX_20], 2);
+    assert_int_equal(bandweight_multis[BANDINDEX_17], 0);
+    assert_int_equal(bandweight_multis[BANDINDEX_15], 2);
+    assert_int_equal(bandweight_multis[BANDINDEX_12], 0);
+    assert_int_equal(bandweight_multis[BANDINDEX_10], 2);
+}
+
+void test_pfx_num_multis(void **state) {
+    strcpy(whichcontest, "abc");
+    int rc = call_parse_logcfg("PFX_NUM_MULTIS=W,VE,VK,ZL,ZS,JA,PY,UA9");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(pfxnummultinr, 8);
+    assert_int_equal(pfxnummulti[0].countrynr, 18);
+    assert_int_equal(pfxnummulti[1].countrynr, 17);
+    assert_int_equal(pfxnummulti[2].countrynr, 16);
+    assert_int_equal(pfxnummulti[3].countrynr, 15);
+    assert_int_equal(pfxnummulti[4].countrynr, 14);
+    assert_int_equal(pfxnummulti[5].countrynr, 13);
+    assert_int_equal(pfxnummulti[6].countrynr, 12);
+    assert_int_equal(pfxnummulti[7].countrynr, 11);
+    assert_int_equal(pfxnummulti[8].countrynr, 0);
+    assert_int_equal(CONTEST_IS(UNKNOWN), 1);
+}
+
+void test_qtcrec_record_command(void **state) {
+    int rc = call_parse_logcfg("QTCREC_RECORD_COMMAND=rec -r 8000 $ -q");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(qtcrec_record_command[0], "rec -r 8000 ");
+    assert_string_equal(qtcrec_record_command[1], " -q &");
+    assert_string_equal(qtcrec_record_command_shutdown, "rec");
+}
+
+void test_exclude_multilist_continentlist(void **state) {
+    strcpy(continent_multiplier_list[0], "EU");
+    int rc = call_parse_logcfg("EXCLUDE_MULTILIST=CONTINENTLIST");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(exclude_multilist_type, EXCLUDE_CONTINENT);
+}
+
+void test_exclude_multilist_countrylist(void **state) {
+    strcpy(countrylist[0], "SM");
+    int rc = call_parse_logcfg("EXCLUDE_MULTILIST=COUNTRYLIST");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(exclude_multilist_type, EXCLUDE_COUNTRY);
+}
+
+void test_fldigi(void **state) {
+#ifdef HAVE_LIBXMLRPC
+    int rc = call_parse_logcfg("FLDIGI=http://host:1234/RPC2");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(digikeyer, FLDIGI);
+    assert_true(fldigi_isenabled());
+#endif
+}
+
+void test_rigptt(void **state) {
+    int rc = call_parse_logcfg("RIGPTT");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(rigptt, 1);
+}
+
+void test_minitest_no_arg(void **state) {
+    int rc = call_parse_logcfg("MINITEST");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(minitest, MINITEST_DEFAULT_PERIOD);
+}
+
+void test_minitest(void **state) {
+    int rc = call_parse_logcfg("MINITEST=1200");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(minitest, 1200);
+}
+
+void test_unique_call_multi_all(void **state) {
+    int rc = call_parse_logcfg("UNIQUE_CALL_MULTI=ALL");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(unique_call_multi, UNIQUECALL_ALL);
+}
+
+void test_unique_call_multi_band(void **state) {
+    int rc = call_parse_logcfg("UNIQUE_CALL_MULTI=BAND");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(unique_call_multi, UNIQUECALL_BAND);
+}
+
+void test_digi_rig_mode_usb(void **state) {
+    int rc = call_parse_logcfg("DIGI_RIG_MODE=USB");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(digi_mode, RIG_MODE_USB);
+}
+
+void test_digi_rig_mode_lsb(void **state) {
+    int rc = call_parse_logcfg("DIGI_RIG_MODE=LSB");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(digi_mode, RIG_MODE_LSB);
+}
+
+void test_digi_rig_mode_rtty(void **state) {
+    int rc = call_parse_logcfg("DIGI_RIG_MODE=RTTY");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(digi_mode, RIG_MODE_RTTY);
+}
+
+void test_digi_rig_mode_rttyr(void **state) {
+    int rc = call_parse_logcfg("DIGI_RIG_MODE=RTTYR");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(digi_mode, RIG_MODE_RTTYR);
+}

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -102,7 +102,7 @@ int call_update = 0;
 
 t_qtc_ry_line qtc_ry_lines[QTC_RY_LINE_NR];
 
-void setcontest() {
+void setcontest(char * name) {
     // TBD
 }
 

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -53,10 +53,8 @@ bool check_veto();
 
 
 int setup_default(void **state) {
-    char filename[100];
 
-    strcpy(filename, TOP_SRCDIR);
-    strcat(filename, "/share/cty.dat");
+    static char filename[] =  TOP_SRCDIR "/share/cty.dat";
     assert_int_equal(load_ctydata(filename), 0);
 
     strcpy(countrylist[0], "DL");

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -3,6 +3,7 @@
 #include "../src/dxcc.h"
 #include "../src/getctydata.h"
 #include "../src/score.h"
+#include "../src/setcontest.h"
 #include "../src/tlf.h"
 
 #include "../src/globalvars.h"
@@ -16,6 +17,7 @@
 // OBJECT ../src/getpx.o
 // OBJECT ../src/locator2longlat.o
 // OBJECT ../src/qrb.o
+// OBJECT ../src/setcontest.o
 
 // ===========
 // these are missing from globalvars
@@ -67,16 +69,18 @@ int setup(void **state) {
 }
 
 int setup_default(void **state) {
+    char filename[100];
 
-    cqww = 0;
-    wpx = 0;
+    /* TODO */
+    /* load_ctydata needs means to destroy the database */
+    strcpy(filename, TOP_SRCDIR);
+    strcat(filename, "/share/cty.dat");
+    assert_int_equal(load_ctydata(filename), 0);
+
+    setcontest("qso");
+
     pfxmult = 0;
-    arrl_fd = 0;
     dupe = 0;
-    arrldx_usa = 0;
-    one_point = 0;
-    two_point = 0;
-    three_point = 0;
 
     my_country_points = -1;
     my_cont_points = -1;
@@ -123,7 +127,7 @@ int teardown_default(void **state) {
 
 
 void test_wpx(void **state) {
-    wpx = 1;
+    setcontest("wpx");
     pfxmult = 0;
 
     /* same country */

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -69,12 +69,8 @@ int setup(void **state) {
 }
 
 int setup_default(void **state) {
-    char filename[100];
 
-    /* TODO */
-    /* load_ctydata needs means to destroy the database */
-    strcpy(filename, TOP_SRCDIR);
-    strcat(filename, "/share/cty.dat");
+    static char filename[] =  TOP_SRCDIR "/share/cty.dat";
     assert_int_equal(load_ctydata(filename), 0);
 
     setcontest("qso");
@@ -103,13 +99,10 @@ int setup_default(void **state) {
 }
 
 int setup_ssbcw(void **state) {
-    char filename[100];
 
     setup_default(state);
-    /* TODO */
-    /* load_ctydata needs means to destroy the database */
-    strcpy(filename, TOP_SRCDIR);
-    strcat(filename, "/share/cty.dat");
+
+    static char filename[] =  TOP_SRCDIR "/share/cty.dat";
     assert_int_equal(load_ctydata(filename), 0);
 
     return 0;

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -209,7 +209,7 @@ void test_simple_points(void **state) {
 }
 
 void test_arrldx_usa(void **state) {
-    arrldx_usa = 1;
+    setcontest("arrldx_usa");
 
     countrynr = w_cty;
     check_points(0);

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -164,7 +164,7 @@ void test_wpx(void **state) {
 
 
 void test_cqww(void **state) {
-    cqww = 1;
+    setcontest("cqww");
 
     countrynr = my.countrynr;
     check_points(0);

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -184,7 +184,7 @@ void test_cqww(void **state) {
 }
 
 void test_arrl_fd(void **state) {
-    arrl_fd = 1;
+    setcontest("arrl_fd");
 
     trxmode = CWMODE;
     check_points(2);

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -89,8 +89,7 @@ int getctydata(char *checkcallptr) {
 }
 
 
-void foc_init() {
-}
+contest_config_t config_focm;
 
 int getctynr(void) {
     return 42;

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -28,7 +28,7 @@ extern int nr_bands;
 extern int searchflg;
 extern int use_part;
 extern int partials;
-extern int cqww;
+//extern int cqww;
 extern int mixedmode;
 
 extern char zone_export[];
@@ -379,7 +379,7 @@ void test_displayPartials(void **state) {
  * - can be picked up from previous qso if we have full match
  * - or overwritten in exchange field */
 void test_ZoneFromCountry(void **state) {
-    cqww = 1;
+    setcontest("cqww");
     strcpy(zone_export, "15");
     strcpy(hiscall, "OH2");
     filterLog();
@@ -387,7 +387,7 @@ void test_ZoneFromCountry(void **state) {
 }
 
 void test_ZoneFromExchange(void **state) {
-    cqww = 1;
+    setcontest("cqww");
     strcpy(zone_fix, "14");
     strcpy(zone_export, "15");
     strcpy(hiscall, "OH2");
@@ -396,8 +396,8 @@ void test_ZoneFromExchange(void **state) {
 }
 
 void test_ZoneFromLog_mixedmode(void **state) {
+    setcontest("cqww");
     mixedmode = 1;
-    cqww = 1;
     strcpy(zone_export, "14");
     strcpy(hiscall, "K4D");
     filterLog();
@@ -405,7 +405,7 @@ void test_ZoneFromLog_mixedmode(void **state) {
 }
 
 void test_ZoneFromLog(void **state) {
-    cqww = 1;
+    setcontest("cqww");
     strcpy(zone_export, "14");
     strcpy(hiscall, "SP9");
     filterLog();

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -123,7 +123,6 @@ int setup_default(void **state) {
     showmsg_spy = showstring_spy1 = showstring_spy2 = STRING_NOT_SET;
 
     contest = &config_qso;
-    arrlss = 0;
     iscontest = false;
 
     search_win = NULL;
@@ -207,8 +206,8 @@ void test_callmaster_ok_spaces(void **state) {
 }
 
 void test_callmaster_ok_arrlss(void **state) {
+    setcontest("arrl_ss");
     write_callmaster("callmaster", "# data\nA1AA\nG0CC\nN2BB\n\n");
-    arrlss = 1;
     int n = load_callmaster();
     assert_int_equal(n, 2);
     assert_string_equal(CALLMASTERARRAY(0), "A1AA");

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -5,6 +5,7 @@
 #include "../src/tlf_curses.h"
 #include "../src/tlf_panel.h"
 #include "../src/searchlog.h"
+#include "../src/setcontest.h"
 #include "../src/dxcc.h"
 
 // OBJECT ../src/addmult.o
@@ -17,6 +18,7 @@
 // OBJECT ../src/nicebox.o
 // OBJECT ../src/qtcutil.o
 // OBJECT ../src/printcall.o
+// OBJECT ../src/setcontest.o
 // OBJECT ../src/err_utils.o
 // OBJECT ../src/ui_utils.o
 
@@ -86,6 +88,14 @@ int getctydata(char *checkcallptr) {
     return 0;
 }
 
+
+void foc_init() {
+}
+
+int getctynr(void) {
+    return 42;
+}
+
 /*********************/
 #define QSO1 " 40SSB 12-Jan-18 16:34 0006  SP9ABC         599  599  15                     1         "
 #define QSO2 " 40CW  12-Jan-18 11:42 0127  K4DEF          599  599  05                     3   7026.1"
@@ -112,9 +122,11 @@ int setup_default(void **state) {
 	strcpy(searchresult[i], "");
 
     showmsg_spy = showstring_spy1 = showstring_spy2 = STRING_NOT_SET;
+
+    contest = &config_qso;
     arrlss = 0;
-    dxped = 0;
     iscontest = false;
+
     search_win = NULL;
     searchflg = SEARCHWINDOW;
     trxmode = CWMODE;
@@ -225,7 +237,7 @@ void test_init_search_panel_contest(void **state) {
 }
 
 void test_init_search_panel_dxped(void **state) {
-    dxped = 1;
+    contest = lookup_contest("dxped");
     InitSearchPanel();
     assert_int_equal(nr_bands, 9);
 }
@@ -409,7 +421,7 @@ void test_OnLowerSearchPanel_contest(void **state) {
 }
 
 void test_OnLowerSearchPanel_AllBand(void **state) {
-    dxped = 1;
+    contest = lookup_contest("dxped");
     OnLowerSearchPanel(4, "test");
     check_mvprintw_output(0, 11, 4, "test");
 }


### PR DESCRIPTION
Refactor 'setcontest()' to use predefined contest configurations. It replaces much of the variables to indicate the selected contest. 

The provided code should act as a starting point which introduces the mechanism. We can migrate in next time all contest related settings (scoring rules for points and multis, display variations, band timers and so on) to the  configuration struct and provide predefined settings for all supported contests.

For contests which are not hard coded  'config_unknow' is used which can be filled out by the keywords which were  already there (DX_&_SECTIONS, SSBPOINTS, ...).

I see several improvements with the new scheme:

- Contests are now mutually exclusive (No longer fear that 'cqww' and 'arrlss' are set simultaneously).

- It makes adding new contests easier - provide a configuration and maybe some helper functions which can be pointed to by the config).

- If needed we can provide dedicated functions for scoring, checking and so on and call them via function pointers in the config. That means the default functions can be simplified as special cases would be split out into these special functions.


As the code is quite fresh and contains quite some changes I would invite you to a thorough review. Comments and suggestions are welcome. 

There is no need to rush to merge it.

