### PR TITLE
fix and test lancode

### DIFF
--- a/src/lancode.h
+++ b/src/lancode.h
@@ -41,7 +41,6 @@ int lan_recv_close(void);
 int lan_recv(void);
 int lan_send_init(void);
 int lan_send_close(void);
-int lan_send(char *lanbuffer) ;
 int send_lan_message(int opcode, char *message);
 void talk(void);
 int send_freq(freq_t freq);

--- a/src/main.c
+++ b/src/main.c
@@ -611,7 +611,6 @@ void ui_color_init() {
 
 static void init_variables() {
     extern int nodes;
-    extern int node;
 
     iscontest = false;
     partials = 0;
@@ -622,22 +621,16 @@ static void init_variables() {
     packetinterface = 0;
     tncport = 0;
     nodes = 0;
-    node = 0;
     shortqsonr = 0;
 
     /* Disable CT Mode until CTCOMPATIBLE is defined. */
     ctcomp = 0;
 
     for (int i = 0; i < 25; i++) {
-	if (digi_message[i] != NULL) {
-	    free(digi_message[i]);
-	    digi_message[i] = NULL;
-	}
+	FREE_DYNAMIC_STRING(digi_message[i]);
     }
-    if (cabrillo != NULL) {
-	free(cabrillo);
-	cabrillo = NULL;
-    }
+
+    FREE_DYNAMIC_STRING(cabrillo);
 
 }
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -187,5 +187,7 @@ void refreshp();
 
 extern const char *backgrnd_str;
 
+#define FREE_DYNAMIC_STRING(p)  if (p != NULL) {g_free(p); p = NULL;}
+
 #endif /* TLF_H */
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -7,6 +7,7 @@ LIBS = @LIBM_LIB@ @GLIB_LIBS@ @PANEL_LIBS@ @CURSES_LIBS@ @CMOCKA_LIBS@ \
         -Wl,-wrap=sleep \
         -Wl,-wrap=key_get \
         -Wl,-wrap=key_poll \
+        -Wl,-wrap=sendto \
         -Wl,-wrap=wgetch \
         -Wl,-wrap=refreshp
 

--- a/test/data.c
+++ b/test/data.c
@@ -29,7 +29,6 @@
 #include "test.h"
 
 
-int lan_active = 0;
 char lastqsonr[5];
 
 int prsock = 0;
@@ -244,7 +243,7 @@ int early_started = 0;			/**< 1 if sending call started early,
 char lastcall[20];
 char qsonrstr[5] = "0001";
 char band[NBANDS][4] =
-{ "160", " 80", " 40", " 30", " 20", " 17", " 15", " 12", " 10" };
+{ "160", " 80", " 60", " 40", " 30", " 20", " 17", " 15", " 12", " 10", "???" };
 char comment[80];
 char mode[20] = "Log     ";
 char cqzone[3] = "";
@@ -424,10 +423,6 @@ char section[8] = "";       // defined in getexchange.c
 char lan_logline[256];      // defined in lancode.c
 
 //////////////////
-
-int send_lan_message(int opcode, char *message) {
-    return 0;
-}
 
 #include <curses.h>
 NCURSES_EXPORT_VAR(WINDOW *) stdscr = NULL;

--- a/test/functions.c
+++ b/test/functions.c
@@ -28,6 +28,21 @@ int __wrap_wgetch(WINDOW *w) {
 void __wrap_refreshp() {
 }
 
+int sendto_call_count = 0;
+const char *sendto_last_message = NULL;
+int sendto_last_len = 0;
+
+ssize_t __wrap_sendto(int sockfd, const void *buf, size_t len, int flags,
+		      const struct sockaddr *dest_addr, socklen_t addrlen) {
+
+    FREE_DYNAMIC_STRING(sendto_last_message);
+    sendto_last_message = strdup(buf);
+    sendto_last_len = len;
+    ++sendto_call_count;
+
+    return len;
+}
+
 
 const char STRING_NOT_SET[] = "__NOT_SET__";
 

--- a/test/functions.c
+++ b/test/functions.c
@@ -29,7 +29,7 @@ void __wrap_refreshp() {
 }
 
 int sendto_call_count = 0;
-const char *sendto_last_message = NULL;
+char *sendto_last_message = NULL;
 int sendto_last_len = 0;
 
 ssize_t __wrap_sendto(int sockfd, const void *buf, size_t len, int flags,

--- a/test/test.h
+++ b/test/test.h
@@ -45,7 +45,7 @@ extern void clear_mvprintw_history();
 
 // sendto()
 extern int sendto_call_count;
-extern const char *sendto_last_message;
+extern char *sendto_last_message;
 extern int sendto_last_len;
 
 

--- a/test/test.h
+++ b/test/test.h
@@ -12,10 +12,16 @@
 #include <setjmp.h>
 #include <string.h>
 #include <stdbool.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 
 #include <glib.h>
 
 #include <cmocka.h>
+
+#ifndef FREE_DYNAMIC_STRING
+#define FREE_DYNAMIC_STRING(p)  if (p != NULL) {g_free(p); p = NULL;}
+#endif
 
 extern const char STRING_NOT_SET[];
 
@@ -36,5 +42,11 @@ extern int __real_key_poll();
 #define LINESZ  100
 extern char mvprintw_history[NLAST][LINESZ];
 extern void clear_mvprintw_history();
+
+// sendto()
+extern int sendto_call_count;
+extern const char *sendto_last_message;
+extern int sendto_last_len;
+
 
 #endif

--- a/test/test_lancode.c
+++ b/test/test_lancode.c
@@ -1,0 +1,76 @@
+#include "test.h"
+
+#include "../src/lancode.h"
+#include "../src/tlf.h"
+#include "../src/err_utils.h"
+
+#include "../src/globalvars.h"
+
+// OBJECT ../src/lancode.o
+
+extern int lan_active;
+extern int trx_control;
+extern int nodes;
+
+
+void handle_logging(enum log_lvl lvl, ...) {
+    // empty
+}
+
+time_t get_time() {
+    return 0;   // TBD
+}
+
+int setup_default(void **state) {
+
+    trx_control = 1;
+    nodes = 1;
+    lan_active = 1;
+
+    sendto_call_count = 0;
+    FREE_DYNAMIC_STRING(sendto_last_message);
+
+    return 0;
+}
+
+void test_send_freq_80(void **state) {
+
+    send_freq(3567891.0);
+
+    assert_int_equal(sendto_call_count, 1);
+    assert_non_null(sendto_last_message);
+    assert_string_equal(sendto_last_message, "A5 3567.9");
+}
+
+void test_send_freq_10(void **state) {
+
+    send_freq(28123456.0);
+
+    assert_int_equal(sendto_call_count, 1);
+    assert_non_null(sendto_last_message);
+    assert_string_equal(sendto_last_message, "A528123.5");
+}
+
+void test_send_freq_80_notrx(void **state) {
+
+    trx_control = 0;
+
+    bandinx = BANDINDEX_80;
+    send_freq(0);
+
+    assert_int_equal(sendto_call_count, 1);
+    assert_non_null(sendto_last_message);
+    assert_string_equal(sendto_last_message, "A5   80.0");
+}
+
+void test_send_freq_10_notrx(void **state) {
+
+    trx_control = 0;
+
+    bandinx = BANDINDEX_10;
+    send_freq(0);
+
+    assert_int_equal(sendto_call_count, 1);
+    assert_non_null(sendto_last_message);
+    assert_string_equal(sendto_last_message, "A5   10.0");
+}

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -129,9 +129,9 @@ extern unsigned char rigptt;
 
 // lancode.c
 int nodes = 0;
-int node;
 struct sockaddr_in bc_address[MAXNODES];
 int lan_port = 6788;
+int lan_active;
 int landebug = 0;
 char thisnode = 'A';
 int time_master;
@@ -205,8 +205,6 @@ int foc_score(char *a) {
     return 0;
 }
 
-#define FREE_DYNAMIC_STRING(p)  if (p != NULL) {g_free(p); p = NULL;}
-
 
 /* setup/teardown */
 int setup_default(void **state) {
@@ -242,6 +240,7 @@ int setup_default(void **state) {
     two_point = 0;
     three_point = 0;
     thisnode = 'A';
+    nodes = 0;
     xplanet = 0;
     dx_arrlsections = 0;
     mult_side = false;
@@ -968,7 +967,7 @@ void test_addnode(void **state) {
     int rc = call_parse_logcfg("ADDNODE=hostx:1234\n");
     assert_int_equal(rc, PARSE_OK);
     assert_int_equal(lan_active, 1);
-    assert_int_equal(node, 1);
+    assert_int_equal(nodes, 1);
     assert_string_equal(bc_hostaddress[0], "hostx");
     assert_string_equal(bc_hostservice[0], "1234");
 }
@@ -1221,6 +1220,7 @@ void test_bandweight_points(void **state) {
     assert_int_equal(bandweight_points[BANDINDEX_15], 1);
     assert_int_equal(bandweight_points[BANDINDEX_12], 0);
     assert_int_equal(bandweight_points[BANDINDEX_10], 2);
+    assert_int_equal(bandweight_points[BANDINDEX_OOB], 0);
 }
 
 void test_bandweight_multis(void **state) {

--- a/test/test_sendbuf.c
+++ b/test/test_sendbuf.c
@@ -10,6 +10,14 @@
 // OBJECT ../src/sendbuf.o
 // OBJECT ../src/sendspcall.o
 
+// lancode.c
+int lan_active = 0;
+
+int send_lan_message(int opcode, char *message) {
+    return 0;
+}
+
+
 char test_msg[1024];
 
 /* export internal function for test */


### PR DESCRIPTION
The rest of #196 

- removed variable `node`
- use `band[]` is lancode instead of local list
- added test for lancode (covers only sendfreq)
- fix 60m in `test/data.c`
- use common macro to free a dynamic string