### PR TITLE
Drop numeric tncport

### DIFF
--- a/src/changepars.c
+++ b/src/changepars.c
@@ -894,7 +894,6 @@ int debug_tty(void) {
     extern int serial_rate;
 
     int fdSertnc;
-    int tncport = 0;
     int i;
     struct termios termattribs;
     char line[20] = "?AF\015";
@@ -914,29 +913,11 @@ int debug_tty(void) {
     mvprintw(4, 0, "Trying to open %s ", rigportname);
     refreshp();
 
-    if (tncport == 1) {
-	if ((fdSertnc = open("/dev/ttyS2", O_RDWR | O_NONBLOCK)) < 0) {
-	    mvprintw(5, 0, "open of /dev/ttyS2 failed!!!");
-	    refreshp();
-	    sleep(2);
-	    return (-1);
-	}
-    } else if (tncport == 2) {
-
-	if ((fdSertnc = open("/dev/ttyS1", O_RDWR | O_NONBLOCK)) < 0) {
-	    mvprintw(5, 0, "open of /dev/ttyS1 failed!!!");
-	    refreshp();
-	    sleep(2);
-	    return (-1);
-	}
-    } else {
-	if ((fdSertnc = open(rigportname, O_RDWR | O_NONBLOCK)) < 0) {
-	    mvprintw(5, 0, "open of %s failed!!!", rigportname);
-	    refreshp();
-	    sleep(2);
-	    return (-1);
-	}
-
+    if ((fdSertnc = open(rigportname, O_RDWR | O_NONBLOCK)) < 0) {
+	mvprintw(5, 0, "open of %s failed!!!", rigportname);
+	refreshp();
+	sleep(2);
+	return (-1);
     }
 
     termattribs.c_iflag = IGNBRK | IGNPAR | IMAXBEL | IXOFF;

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -67,7 +67,6 @@
 #include "addmult.h"
 
 
-int debug_tty(void);
 void wipe_display();
 
 int changepars(void) {
@@ -150,7 +149,7 @@ int changepars(void) {
     strcpy(parameters[43], "SCVOLUME");
     //strcpy(parameters[44], "SCAN");	/* 05jan18 no longer supported */
     strcpy(parameters[44], "");
-    strcpy(parameters[45], "DEBUG");
+    strcpy(parameters[45], "");         //"DEBUG");
     strcpy(parameters[46], "MINITERM");
     strcpy(parameters[47], "RTTY");
     strcpy(parameters[48], "SOUND");
@@ -616,11 +615,6 @@ int changepars(void) {
 	    clear_display();
 	    break;
 	}
-	case 45: {		/* DEBUG */
-	    debug_tty();
-	    clear_display();
-	    break;
-	}
 	case 46: {		/* MINITERM ON/OFF */
 	    if (miniterm == 1)
 		miniterm = 0;
@@ -885,152 +879,6 @@ void multiplierinfo(void) {
     clear_display();
     return;
 }
-
-/* ------------------------- radio link debug ------------------------------ */
-
-int debug_tty(void) {
-
-    extern char *rigportname;
-    extern int serial_rate;
-
-    int fdSertnc;
-    int i;
-    struct termios termattribs;
-    char line[20] = "?AF\015";
-    char inputline[80] = "";
-    const char eom[2] = { '\015', '\0' };
-
-    /* initialize ttyS0*/
-
-    for (i = 0; i < 24; i++)
-	mvprintw(i, 0,
-		 "                                                                                ");
-    refreshp();
-
-    if (rigportname[strlen(rigportname) - 1] == '\n')
-	rigportname[strlen(rigportname) - 1] = '\0';	// remove \n
-
-    mvprintw(4, 0, "Trying to open %s ", rigportname);
-    refreshp();
-
-    if ((fdSertnc = open(rigportname, O_RDWR | O_NONBLOCK)) < 0) {
-	mvprintw(5, 0, "open of %s failed!!!", rigportname);
-	refreshp();
-	sleep(2);
-	return (-1);
-    }
-
-    termattribs.c_iflag = IGNBRK | IGNPAR | IMAXBEL | IXOFF;
-    termattribs.c_oflag = 0;
-    termattribs.c_cflag = CS8 | CSTOPB | CREAD | CLOCAL;
-
-    termattribs.c_lflag = 0;	/* Set some term flags */
-
-    /*  The ensure there are no read timeouts (possibly writes?) */
-    termattribs.c_cc[VMIN] = 1;
-    termattribs.c_cc[VTIME] = 0;
-
-    switch (serial_rate) {
-
-	case 1200: {
-	    cfsetispeed(&termattribs, B1200);	/* Set input speed */
-	    cfsetospeed(&termattribs, B1200);	/* Set output speed */
-	    break;
-	}
-
-	case 2400: {
-	    cfsetispeed(&termattribs, B2400);	/* Set input speed */
-	    cfsetospeed(&termattribs, B2400);	/* Set output speed */
-	    break;
-	}
-
-	case 4800: {
-	    cfsetispeed(&termattribs, B4800);	/* Set input speed */
-	    cfsetospeed(&termattribs, B4800);	/* Set output speed */
-	    break;
-	}
-
-	case 9600: {
-	    cfsetispeed(&termattribs, B9600);	/* Set input speed */
-	    cfsetospeed(&termattribs, B9600);	/* Set output speed */
-	    break;
-	}
-	case 57600: {
-	    cfsetispeed(&termattribs, B57600);	/* Set input speed */
-	    cfsetospeed(&termattribs, B57600);	/* Set output speed */
-	    break;
-	}
-
-	default: {
-
-	    cfsetispeed(&termattribs, B9600);	/* Set input speed */
-	    cfsetospeed(&termattribs, B9600);	/* Set output speed */
-	}
-    }
-
-    tcsetattr(fdSertnc, TCSANOW, &termattribs);	/* Set the serial port */
-
-    mvprintw(6, 0, "%s opened...", rigportname);
-    refreshp();
-
-    mvprintw(13, 0, "Input command: ");
-    refreshp();
-    echo();
-    getnstr(line, 12);
-    noecho();
-    strcat(line, eom);
-
-    /* send message */
-    mvprintw(7, 0, "sending message to trx: %s", line);
-    mvprintw(7, 40, "Length = %d characters", strlen(line));
-    refreshp();
-
-    IGNORE(write(fdSertnc, line, strlen(line)));;
-
-    mvprintw(8, 0, "receiving message from trx");
-    refreshp();
-    usleep(30000);
-
-    if (fdSertnc > 0) {
-
-	int j = 0;
-
-//                      i = read (fdSertnc, inputline, BUFFERSIZE-1);   ### bug fix
-	i = read(fdSertnc, inputline, sizeof(inputline));
-
-	if (i > 0) {
-	    for (j = 0; j < i; j++) {
-		mvprintw(10, j * 10, "%#x", (char) inputline[j]);
-		mvprintw(11, j, "%c", (char) inputline[j]);
-		mvprintw(12, j * 10, "%d", (char) inputline[j] & 0xff);
-		refreshp();
-	    }
-	}
-	mvprintw(8, 40, "Length = %d characters", i);
-	if (inputline[0] == '@' && inputline[1] == 'A'
-		&& inputline[2] != 'F') {
-	    mvprintw(20, 0, "Frequency = %d Hz",
-		     ((inputline[3] & 0xff) * 65536) +
-		     ((inputline[4] & 0xff) * 256) +
-		     (inputline[5] & 0xff));
-	}
-
-	refreshp();
-	sleep(1);
-    }
-
-    mvprintw(23, 0, "done");
-    refreshp();
-    (void)key_get();
-
-    /* close the tty */
-
-    if (fdSertnc > 0)
-	close(fdSertnc);
-
-    return (0);
-}
-
 
 void wipe_display() {
     int j;

--- a/src/main.c
+++ b/src/main.c
@@ -323,7 +323,6 @@ char spot_ptr[MAX_SPOTS][82];		/* Array of cluster spot lines */
 int nr_of_spots;			/* Anzahl Lines in spot_ptr array */
 int packetinterface = 0;
 int fdSertnc = 0;
-int tncport = 1;
 char tncportname[40];
 char rigconf[80];
 int tnc_serial_rate = 2400;
@@ -612,7 +611,6 @@ static void init_variables() {
     digikeyer = NO_KEYER;
     portnum = 0;
     packetinterface = 0;
-    tncport = 0;
     nodes = 0;
     shortqsonr = 0;
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -63,7 +63,6 @@ extern int partials;
 extern int use_part;
 extern int portnum;
 extern int packetinterface;
-extern int tncport;
 extern char tncportname[];
 extern int shortqsonr;
 extern char *cabrillo;
@@ -536,11 +535,8 @@ static int cfg_sfi(const cfg_arg_t arg) {
 }
 
 static int cfg_tncport(const cfg_arg_t arg) {
-    // FIXME remove tncport, keep tncportname only
-    if (strlen(parameter) > 2) {
-	strncpy(tncportname, parameter, 39);
-    } else
-	tncport = atoi(parameter) + 1;
+
+    strncpy(tncportname, parameter, 39);
 
     packetinterface = TNC_INTERFACE;
     return PARSE_OK;

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -751,7 +751,6 @@ int init_packet(void) {
     extern int portnum;
     extern char pr_hostaddress[];
     extern char spot_ptr[MAX_SPOTS][82];
-    extern int tncport;
     extern int fdSertnc;
     extern int packetinterface;
     extern int tnc_serial_rate;
@@ -823,33 +822,12 @@ int init_packet(void) {
 
     } else if (packetinterface == TNC_INTERFACE) {
 
-	if (strlen(tncportname) > 2) {
-	    tncportname[strlen(tncportname) - 1] = '\0';	// remove '\n'
-	    if ((fdSertnc = open(tncportname, O_RDWR | O_NONBLOCK)) < 0) {
-		wprintw(sclwin, "open of %s failed!!!\n", tncportname);
-		wrefresh(sclwin);
-		sleep(2);
-		return (-1);
-	    }
-	} else {
-	    if (tncport == 1) {
-		if ((fdSertnc =
-			    open("/dev/ttyS0", O_RDWR | O_NONBLOCK)) < 0) {
-		    wprintw(sclwin, "open of /dev/ttyS0 failed!!!\n");
-		    wrefresh(sclwin);
-		    sleep(2);
-		    return (-1);
-		}
-	    } else if (tncport == 2) {
-
-		if ((fdSertnc =
-			    open("/dev/ttyS1", O_RDWR | O_NONBLOCK)) < 0) {
-		    wprintw(sclwin, "open of /dev/ttyS1 failed!!!\n");
-		    wrefresh(sclwin);
-		    sleep(2);
-		    return (-1);
-		}
-	    }
+	tncportname[strlen(tncportname) - 1] = '\0';	// remove '\n'
+	if ((fdSertnc = open(tncportname, O_RDWR | O_NONBLOCK)) < 0) {
+	    wprintw(sclwin, "open of %s failed!!!\n", tncportname);
+	    wrefresh(sclwin);
+	    sleep(2);
+	    return -1;
 	}
 
 	termattribs.c_iflag = IGNBRK | IGNPAR | IMAXBEL | IXOFF;
@@ -895,7 +873,7 @@ int init_packet(void) {
 
 	tcsetattr(fdSertnc, TCSANOW, &termattribs);	/* Set the serial port */
 
-	wprintw(sclwin, "ttyS%d opened...\n", (tncport - 1));
+	wprintw(sclwin, "%s opened...\n", tncportname);
 	wrefresh(sclwin);
     } else if (packetinterface == FIFO_INTERFACE) {
 
@@ -946,13 +924,13 @@ int init_packet(void) {
 =
 ===========================================*/
 
-int cleanup_telnet(void) {
+void cleanup_telnet(void) {
 
     extern int packetinterface;
     extern int fdSertnc;
 
     if (!initialized) {
-	return 0;
+	return;
     }
 
     if (packetinterface == TELNET_INTERFACE) {
@@ -983,8 +961,6 @@ int cleanup_telnet(void) {
     clear();
     clear_display();
     keypad(stdscr, TRUE);
-
-    return (0);
 }
 
 /* =========================================
@@ -1068,7 +1044,7 @@ int packet() {
 
 		if (i == -1) {
 		    cleanup_telnet();
-		    return (-1);
+		    return -1;
 
 		} else if (i != -2) {
 		    line[i] = '\0';
@@ -1178,7 +1154,7 @@ int receive_packet(void) {
 	    view_state = STATE_EDITING;
 	    if (i == -1) {
 		cleanup_telnet();
-		return (-1);
+		return -1;
 	    } else if (i != -2) {
 		line[i] = '\0';
 		sanitize(line);

--- a/src/splitscreen.h
+++ b/src/splitscreen.h
@@ -21,7 +21,7 @@
 #define SPLITSCREEN_H
 
 int init_packet(void) ;
-int cleanup_telnet(void);
+void cleanup_telnet(void);
 int packet(void);
 int send_cluster(void);
 void addtext(char *s);

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -278,10 +278,6 @@ the contest).
 Switch TRX to CW|SSB|Digimode mode.
 .
 .TP
-.BR :DEB ug_tty
-Debug routine for rig communication links.
-.
-.TP
 .BR :EDI t
 Edit the log with your favourite editor. Be careful!
 .


### PR DESCRIPTION
Keep only fully qualified `tncportname` to specify the TNC port. Numeric `tncport` was only partially supported (for values 1 and 2, legacy DOS COM1 and COM2). Opening a port was reporting wrong text using `tncport` in case of using `tncportname`. IMO anyone using a TNC shall be able to specify the correct Linux port name.

The same code pops up in `debug_tty()` (`changepars.c`), but there `tncport` is an unused local variable. Cleaned this up, but I suggest to completely drop `debug_tty()` as it assumes an ASCII rig protocol and thus has very limited use. One shall instead serve of either Hamlib's utils or any serial terminal emulator.
