### PR TITLE
Update globalvars.h

### DIFF
--- a/src/getexchange.h
+++ b/src/getexchange.h
@@ -21,6 +21,8 @@
 #ifndef GETEXCHANGE_H
 #define GETEXCHANGE_H
 
+extern int call_update;
+
 int checkexchange(int x);
 char *getgrid(char *comment);
 int getexchange(void);

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -3,6 +3,8 @@
 #include <hamlib/rig.h>
 #include <stdbool.h>
 
+#include <config.h>
+
 #include "tlf.h"
 
 extern mystation_t my;			// all about my station
@@ -94,6 +96,7 @@ extern int highqsonr;
 
 extern cqmode_t cqmode;
 extern int trxmode;
+extern rig_model_t myrig_model;
 extern rmode_t rigmode;
 extern freq_t freq;
 extern char lastqsonr[];
@@ -112,8 +115,107 @@ extern int two_point;
 extern int three_point;
 extern int addzone;
 extern int do_cabrillo;
+extern int no_rst;
 extern rmode_t digi_mode;
 extern int minitest;    // minitest period length in seconds, 0 if not used
+extern int portnum;
+extern int lan_port;
+extern int txdelay;
+extern int weight;
+extern int cw_bandwidth;
+extern int cwpoints;
+extern int ssbpoints;
+extern int continentlist_points;
+extern int dx_cont_points;
+extern int my_cont_points;
+extern int packetinterface;
+extern int use_bandoutput;
+extern int cluster;
+extern int nodes;
+extern int multlist;
+extern int xplanet;
+extern int cwkeyer;
+extern int digikeyer;
+extern unsigned char rigptt;
+extern int exclude_multilist_type;
+extern int partials;
+extern int use_part;
+extern int shortqsonr;
+extern int recall_mult;
+extern int trx_control;
+extern int rit;
+extern int showscore_flag;
+extern int searchflg;
+extern int nob4;
+extern int demode;
+extern int ctcomp;
+extern int show_time;
+extern int use_rxvt;
+extern int time_master;
+extern int noautocq;
+extern int no_arrows;
+extern int exc_cont;
+extern int sc_sidetone;
+extern int logfrequency;
+extern int bmautoadd;
+extern int bmautograb;
+extern int serial_or_section;
+extern int portable_x2;
+extern int clusterlog;
+extern int sprint_mode;
+extern int timeoffset;
+extern int keyer_backspace;
+extern int netkeyer_port;
+extern int cqdelay;
+extern int serial_rate;
+extern int tnc_serial_rate;
+extern int countrylist_points;
+extern int my_country_points;
+extern int lowband_point_mult;
+extern int landebug;
+
+extern float fixedmult;
+
+extern int bandweight_points[NBANDS];
+extern int bandweight_multis[NBANDS];
+
+extern pfxnummulti_t pfxnummulti[MAXPFXNUMMULT];
+extern int pfxnummultinr;
 
 extern char message[][80];
 extern char *digi_message[];
+extern char ph_message[14][80];
+extern char tncportname[];
+extern char multsfile[];
+extern char markerfile[];
+extern char countrylist[][6];
+extern char continent_multiplier_list[7][3];
+extern char controllerport[];           // port for multi-mode controller
+extern char modem_mode[];
+extern char sc_volume[];
+extern char clusterlogin[];
+extern char rigconf[];
+extern char keyer_device[10];
+extern char netkeyer_hostaddress[];
+extern char pr_hostaddress[];
+extern char synclogfile[];
+extern char sc_device[];
+extern char exchange_list[40];
+extern char rttyoutput[];
+#ifdef HAVE_LIBXMLRPC
+extern char fldigi_url[50];
+#endif
+
+extern char *cabrillo;
+extern char *editor_cmd;
+extern char *rigportname;
+extern char *config_file;
+
+extern int bandindexarray[];
+extern int tlfcolors[8][2];
+
+extern bool mult_side;
+extern bool countrylist_only;
+extern bool mixedmode;
+extern bool ignoredupe;
+extern bool continentlist_only;

--- a/src/lancode.h
+++ b/src/lancode.h
@@ -36,6 +36,9 @@
 
 #include <hamlib/rig.h>
 
+extern char bc_hostaddress[MAXNODES][16];
+extern char bc_hostservice[MAXNODES][16];
+
 int lanrecv_init(void);
 int lan_recv_close(void);
 int lan_recv(void);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -35,6 +35,7 @@
 #include "fldigixmlrpc.h"
 #include "globalvars.h"
 #include "getctydata.h"
+#include "getexchange.h"
 #include "getpx.h"
 #include "getwwv.h"
 #include "lancode.h"
@@ -42,112 +43,10 @@
 #include "parse_logcfg.h"
 #include "qtcvars.h"		// Includes globalvars.h
 #include "setcontest.h"
+#include "set_tone.h"
 #include "startmsg.h"
 #include "tlf_curses.h"
 #include "searchlog.h"
-
-#include <config.h>
-
-
-extern bool mixedmode;
-extern bool ignoredupe;
-extern bool continentlist_only;
-extern int continentlist_points;
-extern int lan_port;
-extern char rigconf[];
-extern char ph_message[14][80];
-extern int cwkeyer;
-extern int digikeyer;
-extern int keyer_backspace;
-extern int partials;
-extern int use_part;
-extern int portnum;
-extern int packetinterface;
-extern char tncportname[];
-extern int shortqsonr;
-extern char *cabrillo;
-extern rmode_t digi_mode;
-extern int ctcomp;
-extern int recall_mult;
-extern int trx_control;
-extern int rit;
-extern int showscore_flag;
-extern int searchflg;
-extern int demode;
-extern int portable_x2;
-extern int landebug;
-extern int call_update;
-extern int nob4;
-extern int time_master;
-extern int show_time;
-extern int use_rxvt;
-extern int exc_cont;
-extern int noautocq;
-extern int bmautoadd;
-extern int bmautograb;
-extern int logfrequency;
-extern int no_rst;
-extern int serial_or_section;
-extern int sprint_mode;
-extern int sc_sidetone;
-extern int no_arrows;
-extern int lowband_point_mult;
-extern int cluster;
-extern int clusterlog;
-extern char keyer_device[10];
-extern int timeoffset;
-extern int netkeyer_port;
-extern char netkeyer_hostaddress[];
-extern char *rigportname;
-extern int tnc_serial_rate;
-extern int serial_rate;
-extern char pr_hostaddress[];
-extern char *editor_cmd;
-extern int cqdelay;
-extern int ssbpoints;
-extern int cwpoints;
-extern int tlfcolors[8][2];
-extern char whichcontest[];
-extern int use_bandoutput;
-extern int bandindexarray[];
-extern int txdelay;
-extern char tonestr[];
-extern int weight;
-extern int nodes;
-extern char bc_hostaddress[MAXNODES][16];
-extern char bc_hostservice[MAXNODES][16];
-extern rig_model_t myrig_model;
-extern int multlist;
-extern char multsfile[];
-extern char markerfile[];
-extern int xplanet;
-extern char countrylist[][6];
-extern bool mult_side;
-extern int countrylist_points;
-extern bool countrylist_only;
-extern int my_country_points;
-extern int my_cont_points;
-extern int dx_cont_points;
-extern char synclogfile[];
-extern char sc_device[40];
-extern char sc_volume[];
-extern char controllerport[80];	// port for multi-mode controller
-extern char clusterlogin[];
-extern int cw_bandwidth;
-extern char exchange_list[40];
-extern char modem_mode[];
-extern char rttyoutput[];
-extern float fixedmult;
-extern char continent_multiplier_list[7][3];
-extern int bandweight_points[NBANDS];
-extern int bandweight_multis[NBANDS];
-extern pfxnummulti_t pfxnummulti[MAXPFXNUMMULT];
-extern int pfxnummultinr;
-extern int exclude_multilist_type;
-#ifdef HAVE_LIBXMLRPC
-extern char fldigi_url[50];
-#endif
-extern unsigned char rigptt;
 
 bool exist_in_country_list();
 
@@ -162,8 +61,6 @@ static char *error_details = NULL;
 #define LOGCFG_DAT_FILE    "logcfg.dat"
 
 int read_logcfg(void) {
-
-    extern char *config_file;
 
     static char defltconf[] = PACKAGE_DATA_DIR "/" LOGCFG_DAT_FILE;
     FILE *fp;

--- a/test/data.c
+++ b/test/data.c
@@ -113,7 +113,7 @@ int noleadingzeros;
 int ctcomp = 0;
 int isdupe = 0;			// 0 if nodupe -- for auto qso b4 (LZ3NY)
 int nob4 = 0;			// allow auto b4
-int ignoredupe = 0;
+bool ignoredupe = false;
 int noautocq = 0;
 int emptydir = 0;
 int verbose = 0;
@@ -146,7 +146,7 @@ int trxmode = CWMODE;
 /* RIG_MODE_NONE in hamlib/rig.h, but if hamlib not compiled, then no dependecy */
 rmode_t rigmode = 0;
 rmode_t digi_mode = 0;
-int mixedmode = 0;
+bool mixedmode = false;
 char sent_rst[4] = "599";
 char recvd_rst[4] = "599";
 char last_rst[4] = "599";       /* Report for last QSO */
@@ -313,7 +313,7 @@ int outfreq;			/* output  to rig */
 int ssb_bandwidth = 3000;
 int cw_bandwidth = 0;
 int serial_rate = 2400;
-char rigportname[40];
+char *rigportname;
 int rignumber = 0;
 int rig_comm_error = 0;
 int rig_comm_success = 0;

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -25,15 +25,6 @@
 extern WINDOW *search_win;
 extern PANEL *search_panel;
 extern int nr_bands;
-extern int searchflg;
-extern int use_part;
-extern int partials;
-//extern int cqww;
-extern int mixedmode;
-
-extern char zone_export[];
-extern char zone_fix[];
-
 extern char searchresult[MAX_CALLS][82];
 extern char result[MAX_CALLS][82];
 


### PR DESCRIPTION
Moved all externs from `parse_logcg.c` to their respective `.h` files, mostly `globalvars.h`.
On mid term all other `.c` files shall be cleaned up. Additionally ints with a boolean semantics shall be converted to bools. 