### PR TITLE
Clean lancode

### DIFF
--- a/src/background_process.c
+++ b/src/background_process.c
@@ -44,7 +44,7 @@
 
 extern int cluster;
 extern int packetinterface;
-extern int lan_active;
+extern bool lan_active;
 extern char lan_message[];
 extern int recv_error;
 extern char thisnode;
@@ -150,7 +150,7 @@ void *background_process(void *ptr) {
 	    cqww_simulator();
 	}
 
-	if (lan_active == 1) {
+	if (lan_active) {
 	    if (lan_message[0] == '\0') {
 
 		if (lan_recv() >= 0) {

--- a/src/background_process.c
+++ b/src/background_process.c
@@ -153,9 +153,7 @@ void *background_process(void *ptr) {
 	if (lan_active == 1) {
 	    if (lan_message[0] == '\0') {
 
-		if (lan_recv() < 0) {
-		    recv_error++;
-		} else {
+		if (lan_recv() >= 0) {
 		    lan_message[strlen(lan_message) - 1] = '\0';
 		}
 	    }

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -120,7 +120,7 @@ int callinput(void) {
     extern char ph_message[14][80];
     extern SCREEN *mainscreen;
     extern char talkarray[5][62];
-    extern int lan_active;
+    extern bool lan_active;
     extern int zonedisplay;
     extern int showscore_flag;
     extern int searchflg;
@@ -941,7 +941,7 @@ int callinput(void) {
 
 	    // Double quote, send talk message to other nodes.
 	    case '\"': {
-		if (lan_active != 0)
+		if (lan_active)
 		    talk();
 
 		break;
@@ -962,7 +962,7 @@ int callinput(void) {
 	    // Ctrl-T (^T) or Alt-i (M-i), show talk messages.
 	    case CTRL_T:
 	    case ALT_I: {
-		if (lan_active != 0) {
+		if (lan_active) {
 
 		    for (t = 0; t <= 5; t++)
 			mvprintw(14 + t, 1,

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -714,7 +714,7 @@ void networkinfo(void) {
     extern int recv_error;
     extern int send_packets[];
     extern int send_error[];
-    extern int lan_active;
+    extern bool lan_active;
     extern int nodes;
     extern char bc_hostaddress[MAXNODES][16];
     extern char *config_file;
@@ -728,7 +728,7 @@ void networkinfo(void) {
 
     wipe_display();
 
-    if (lan_active == 1)
+    if (lan_active)
 	mvprintw(1, 10, "Network status: on");
     else
 	mvprintw(1, 10, "Network status: off");

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -76,7 +76,6 @@ int getexchange(void) {
     extern int countrynr;
     extern int trxmode;
     extern int recall_mult;
-    extern int lan_active;
     extern char lastqsonr[];
     extern char qsonrstr[];
     extern char section[];
@@ -103,7 +102,7 @@ int getexchange(void) {
 
     instring[1] = '\0';
 
-    if ((lan_active == 1) && (exchange_serial == 1)) {
+    if (lan_active && (exchange_serial == 1)) {
 	strncpy(lastqsonr, qsonrstr, 5);
 	send_lan_message(INCQSONUM, qsonrstr);
     }

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -89,7 +89,7 @@ extern char lan_logline[];
 extern char logfile[];
 extern char qsonrstr[];
 extern int lan_mutex;
-extern int lan_active;
+extern bool lan_active;
 extern int exchange_serial;
 extern int highqsonr;
 

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -58,7 +58,7 @@ char default_lan_service[16] = "6788";
 /* lan port parsed from config */
 int lan_port = 6788;
 
-int lan_active = 0;
+bool lan_active = false;
 int send_error[MAXNODES];
 int send_error_limit[MAXNODES];
 int lan_mutex = 0;
@@ -97,7 +97,7 @@ int lan_recv_init(void) {
     long lan_save_file_flags;
     struct sockaddr_in lan_sin;
 
-    if (lan_active == 0)
+    if (!lan_active)
 	return 0;
 
     sprintf(default_lan_service, "%d", lan_port);
@@ -132,7 +132,7 @@ int lan_recv_init(void) {
 int lan_recv_close(void) {
     int lan_close_rc;
 
-    if (lan_active == 0)
+    if (!lan_active)
 	return 0;
 
     lan_close_rc = close(lan_socket_descriptor);
@@ -150,7 +150,7 @@ int lan_recv(void) {
     unsigned int lan_sin_len = sizeof(lan_sin);
     char lan_recv_message[256];
 
-    if (lan_active == 0)
+    if (!lan_active)
 	return 0;
 
     lan_recv_message[0] = '\0';

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -40,30 +40,19 @@
 
 
 int lan_socket_descriptor;
-struct sockaddr_in lan_sin;
-int lan_bind_rc, lan_close_rc;
-ssize_t lan_recv_rc;
-long lan_save_file_flags;
-char lan_recv_message[256];
 char lan_message[256];
 char lan_logline[256];
-unsigned int lan_sin_len;
 //--------------------------------------
 int bc_socket_descriptor[MAXNODES];
 ssize_t bc_sendto_rc;
-int bc_close_rc;
 int cl_send_inhibit = 0;
-char lanbuffer[255];
 struct sockaddr_in bc_address[MAXNODES];
-struct hostent *bc_hostbyname[MAXNODES];
 /* host names and UDP ports to send notifications to */
 char bc_hostaddress[MAXNODES][16];
 char bc_hostservice[MAXNODES][16] = {
     [0 ... MAXNODES - 1] = { [0 ... 15] = 0 }
 };
-char sendbuffer[256];
 int nodes = 0;
-int send_error_limit[MAXNODES];
 //--------------------------------------
 /* default port to listen for incomming packets and to send packet to */
 char default_lan_service[16] = "6788";
@@ -72,14 +61,13 @@ int lan_port = 6788;
 
 int lan_active = 0;
 int send_error[MAXNODES];
+int send_error_limit[MAXNODES];
 int lan_mutex = 0;
 int send_packets[MAXNODES];
 int recv_error;
 int recv_packets;
-int buflen;
 char talkarray[5][62];
 freq_t node_frequencies[MAXNODES];
-int lanqsos;
 char lastqsonr[5];
 int highqsonr;
 int landebug = 0;
@@ -105,21 +93,24 @@ int resolveService(const char *service) {
     return port;
 }
 
-int lanrecv_init(void) {
+int lan_recv_init(void) {
+    int lan_bind_rc;
+    long lan_save_file_flags;
+    struct sockaddr_in lan_sin;
+
     if (lan_active == 0)
-	return (1);
+	return 1;
 
     sprintf(default_lan_service, "%d", lan_port);
     bzero(&lan_sin, sizeof(lan_sin));
     lan_sin.sin_family = AF_INET;
     lan_sin.sin_addr.s_addr = htonl(INADDR_ANY);
     lan_sin.sin_port = htons(resolveService(default_lan_service));
-    lan_sin_len = sizeof(lan_sin);
 
     lan_socket_descriptor = socket(AF_INET, SOCK_DGRAM, 0);
     if (lan_socket_descriptor == -1) {
 	syslog(LOG_ERR, "%s\n", "LAN: socket");
-	return (-1);
+	return -1;
     }
 
     lan_bind_rc =
@@ -127,36 +118,41 @@ int lanrecv_init(void) {
 	     sizeof(lan_sin));
     if (lan_bind_rc == -1) {
 	syslog(LOG_ERR, "%s\n", "LAN: bind");
-	return (-2);
+	return -2;
     }
 
     lan_save_file_flags = fcntl(lan_socket_descriptor, F_GETFL);
     lan_save_file_flags |= O_NONBLOCK;
     if (fcntl(lan_socket_descriptor, F_SETFL, lan_save_file_flags) == -1) {
 	syslog(LOG_ERR, "%s\n", "trying non-blocking");
-	return (-3);
+	return -3;
     }
-    return (0);
+    return 0;
 }
 
 int lan_recv_close(void) {
+    int lan_close_rc;
 
     if (lan_active == 0)
-	return (-1);
+	return -1;
 
     lan_close_rc = close(lan_socket_descriptor);
     if (lan_close_rc == -1) {
 	syslog(LOG_ERR, "%s\n", "LAN: close call failed");
-	return (errno);
+	return errno;
     }
 
-    return (0);
+    return 0;
 }
 
 int lan_recv(void) {
+    ssize_t lan_recv_rc;
+    struct sockaddr_in lan_sin;
+    unsigned int lan_sin_len = sizeof(lan_sin);
+    char lan_recv_message[256];
 
     if (lan_active == 0)
-	return (-1);
+	return -1;
 
     lan_recv_message[0] = '\0';
 
@@ -167,9 +163,7 @@ int lan_recv(void) {
 
     if (lan_recv_rc == -1 && errno != EAGAIN) {
 	recv_error++;
-	return (errno);
-    } else if (lan_recv_rc == 0 || errno == EAGAIN) {	/* no data */
-	errno = 0;		/* clear the error */
+	return errno;
     }
 
     errno = 0;			/* clear the error */
@@ -181,15 +175,14 @@ int lan_recv(void) {
 	recv_packets++;
 
     strcpy(lan_message, lan_recv_message);
-    if (lan_recv_rc > buflen)
-	buflen = lan_recv_rc;
 
-    return (0);
+    return 0;
 }
 
 // ----------------send routines --------------------------
 
 int lan_send_init(void) {
+    struct hostent *bc_hostbyname[MAXNODES];
 
     if (!lan_active)
 	return 1;
@@ -228,6 +221,7 @@ int lan_send_init(void) {
 }
 
 int lan_send_close(void) {
+    int bc_close_rc;
 
     if (!lan_active)
 	return -1;

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -98,7 +98,7 @@ int lan_recv_init(void) {
     struct sockaddr_in lan_sin;
 
     if (lan_active == 0)
-	return 1;
+	return 0;
 
     sprintf(default_lan_service, "%d", lan_port);
     bzero(&lan_sin, sizeof(lan_sin));
@@ -133,7 +133,7 @@ int lan_recv_close(void) {
     int lan_close_rc;
 
     if (lan_active == 0)
-	return -1;
+	return 0;
 
     lan_close_rc = close(lan_socket_descriptor);
     if (lan_close_rc == -1) {
@@ -151,7 +151,7 @@ int lan_recv(void) {
     char lan_recv_message[256];
 
     if (lan_active == 0)
-	return -1;
+	return 0;
 
     lan_recv_message[0] = '\0';
 
@@ -184,7 +184,7 @@ int lan_send_init(void) {
     struct hostent *bc_hostbyname[MAXNODES];
 
     if (!lan_active)
-	return 1;
+	return 0;
 
     for (int node = 0; node < nodes; node++) {
 
@@ -223,7 +223,7 @@ int lan_send_close(void) {
     int bc_close_rc;
 
     if (!lan_active)
-	return -1;
+	return 0;
 
     for (int node = 0; node < nodes; node++) {
 
@@ -240,7 +240,7 @@ int lan_send_close(void) {
 static int lan_send(char *lanbuffer) {
 
     if (!lan_active)
-	return -1;
+	return 0;
 
     if (lanbuffer[0] == 0) {
 	return 0;       // nothing to send

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -41,7 +41,6 @@
 
 int lan_socket_descriptor;
 char lan_message[256];
-char lan_logline[256];
 //--------------------------------------
 int bc_socket_descriptor[MAXNODES];
 ssize_t bc_sendto_rc;

--- a/src/lancode.h
+++ b/src/lancode.h
@@ -39,7 +39,7 @@
 extern char bc_hostaddress[MAXNODES][16];
 extern char bc_hostservice[MAXNODES][16];
 
-int lanrecv_init(void);
+int lan_recv_init(void);
 int lan_recv_close(void);
 int lan_recv(void);
 int lan_send_init(void);

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -45,6 +45,8 @@
 
 pthread_mutex_t disk_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+char lan_logline[256];
+
 /** \brief logs one record to disk
  * Logs one record to disk which may come from different sources
  * (direct from tlf or from other instance via LAN)
@@ -54,7 +56,6 @@ pthread_mutex_t disk_mutex = PTHREAD_MUTEX_INITIALIZER;
 void log_to_disk(int from_lan) {
     extern char last_rst[4];
     extern char qsonrstr[5];
-    extern char lan_logline[];
     extern int rit;
     extern int trx_control;
     extern cqmode_t cqmode;

--- a/src/main.c
+++ b/src/main.c
@@ -69,7 +69,6 @@
 
 SCREEN *mainscreen;
 
-extern int lan_active;
 
 char pr_hostaddress[48] = "131.155.192.179";
 char *config_file = NULL;
@@ -744,7 +743,7 @@ void fldigi_init() {
 }
 
 void lan_init() {
-    if (lan_active == 1) {
+    if (lan_active) {
 	if (lan_recv_init() < 0)	/* set up the network */
 	    showmsg("LAN receive  init failed");
 	else

--- a/src/main.c
+++ b/src/main.c
@@ -745,7 +745,7 @@ void fldigi_init() {
 
 void lan_init() {
     if (lan_active == 1) {
-	if (lanrecv_init() < 0)	/* set up the network */
+	if (lan_recv_init() < 0)	/* set up the network */
 	    showmsg("LAN receive  init failed");
 	else
 	    showmsg("LAN receive  initialized");

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -156,14 +156,14 @@ void prepare_fixed_part(void) {
 	strcat(logline4, khz);
 
     } else {
-	if ((lan_active == 1) && (exchange_serial == 1)) {	// show qso nr
+	if (lan_active && (exchange_serial == 1)) {	// show qso nr
 	    strcat(logline4, lastqsonr);
 	    lastqsonr[0] = '\0';
 	} else
 	    strcat(logline4, qsonrstr);
     }
 
-    if (lan_active == 1 && cqwwm2 == 1) {
+    if (lan_active && cqwwm2 == 1) {
 	logline4[27] = thisnode;	// set node ID...
 	logline4[28] = '\0';
 	strcat(logline4, " ");

--- a/src/note.c
+++ b/src/note.c
@@ -54,7 +54,7 @@ int include_note(void) {
     getnstr(buffer, 78);
     noecho();
 
-    if (lan_active == 1) {
+    if (lan_active) {
 	sprintf(buffer2, "; Node %c, %d : ", thisnode, atoi(qsonrstr) - 1);
     } else
 	sprintf(buffer2, "; ");

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -458,7 +458,7 @@ static int cfg_addnode(const cfg_arg_t arg) {
     g_strfreev(an_fields);
 
     nodes++;
-    lan_active = 1;
+    lan_active = true;
 
     return PARSE_OK;
 }

--- a/src/qtc_log.c
+++ b/src/qtc_log.c
@@ -247,7 +247,7 @@ void make_qtc_logline(struct read_qtc_t qtc_line, char *fname) {
     char qtclogline[120];
     char padding[2] = " ";
 
-    if (lan_active == 1) {
+    if (lan_active) {
 	nodemark = thisnode;
     }
 
@@ -266,7 +266,7 @@ void make_qtc_logline(struct read_qtc_t qtc_line, char *fname) {
 		qtc_line.qtc_time, qtc_line.qtc_call, padding, qtc_line.qtc_serial,
 		qtc_line.freq / 1000.0);
 	store_qtc(qtclogline, qtc_line.direction, fname);
-	if (lan_active == 1) {
+	if (lan_active) {
 	    send_lan_message(QTCRENTRY, qtclogline);
 	}
     }
@@ -279,7 +279,7 @@ void make_qtc_logline(struct read_qtc_t qtc_line, char *fname) {
 		qtc_line.qtc_time, qtc_line.qtc_call, padding, qtc_line.qtc_serial,
 		qtc_line.freq / 1000.0);
 	store_qtc(qtclogline, qtc_line.direction, fname);
-	if (lan_active == 1) {
+	if (lan_active) {
 	    send_lan_message(QTCSENTRY, qtclogline);
 	}
     }

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -69,7 +69,7 @@ void get_next_serial(void) {
 	}
     }
 
-    if ((lan_active == 1) && (exchange_serial == 1)) {
+    if (lan_active && (exchange_serial == 1)) {
 
 	if (lan_mutex == 2) {	/* last stored message is from lan */
 

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -175,8 +175,6 @@ void ExpandMacro(void) {
     extern char lastqsonr[];
     extern int early_started;
     extern int noleadingzeros;
-    extern int lan_active;
-    extern int exchange_serial;
 
     int i;
     static char comstr[BUFSIZE] = "";
@@ -230,7 +228,7 @@ void ExpandMacro(void) {
 	replace_all(buffer, BUFSIZE, "#",
 		    qsonroutput + leading_zeros);   /* serial nr */
 
-	if ((lan_active == 1) && (exchange_serial == 1)) {
+	if (lan_active && (exchange_serial == 1)) {
 	    strncpy(lastqsonr, qsonrstr, 5);
 	    send_lan_message(INCQSONUM, qsonrstr);
 	}

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -584,8 +584,6 @@ void refresh_splitlayout() {
 }
 
 void addtext(char *s) {
-    extern int lan_active;
-    extern char hiscall[];
     extern char talkarray[5][62];
 
     char lan_out[256];
@@ -715,7 +713,7 @@ void addtext(char *s) {
 
 	    addlog(tln_input_buffer);
 
-	    if (lan_active == 1 && lanspotflg == 0) {
+	    if (lan_active && lanspotflg == 0) {
 		if ((strlen(tln_input_buffer) > 0)
 			&& (tln_input_buffer[0] > 32)
 			&& (tln_input_buffer[0] < 126)) {

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -55,7 +55,7 @@ void broadcast_lan(void) {
 
     if (frcounter >= 60) {	// every 60 calls
 	frcounter = 0;
-	if (lan_active != 0) {
+	if (lan_active) {
 	    send_freq(freq);
 	    if (time_master == 1)
 		send_time();

--- a/test/data.c
+++ b/test/data.c
@@ -411,7 +411,7 @@ int unique_call_multi = 0;          /* do we count calls as multiplier */
 //////////////////
 char ssexchange[30] = "";   // defined in getexchange.c
 char section[8] = "";       // defined in getexchange.c
-char lan_logline[256];      // defined in lancode.c
+char lan_logline[256];	    // defined in log_to_disk.c
 
 //////////////////
 

--- a/test/test_lancode.c
+++ b/test/test_lancode.c
@@ -8,7 +8,6 @@
 
 // OBJECT ../src/lancode.o
 
-extern int lan_active;
 extern int trx_control;
 extern int nodes;
 
@@ -25,7 +24,7 @@ int setup_default(void **state) {
 
     trx_control = 1;
     nodes = 1;
-    lan_active = 1;
+    lan_active = true;
 
     sendto_call_count = 0;
     FREE_DYNAMIC_STRING(sendto_last_message);

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -133,7 +133,7 @@ extern unsigned char rigptt;
 int nodes = 0;
 struct sockaddr_in bc_address[MAXNODES];
 int lan_port = 6788;
-int lan_active;
+bool lan_active;
 int landebug = 0;
 char thisnode = 'A';
 int time_master;
@@ -961,7 +961,7 @@ void test_rigmodel(void **state) {
 void test_addnode(void **state) {
     int rc = call_parse_logcfg("ADDNODE=hostx:1234\n");
     assert_int_equal(rc, PARSE_OK);
-    assert_int_equal(lan_active, 1);
+    assert_int_equal(lan_active, true);
     assert_int_equal(nodes, 1);
     assert_string_equal(bc_hostaddress[0], "hostx");
     assert_string_equal(bc_hostservice[0], "1234");

--- a/test/test_sendbuf.c
+++ b/test/test_sendbuf.c
@@ -11,7 +11,7 @@
 // OBJECT ../src/sendspcall.o
 
 // lancode.c
-int lan_active = 0;
+bool lan_active = false;
 
 int send_lan_message(int opcode, char *message) {
     return 0;


### PR DESCRIPTION
The PR summarizes some work to cleanup the code

- drop unused variables, move others to local scope, drop dead code
- do not count inactive lan as errors during function return
- cleanup wrong error counting
- finally make lan_active bool and adapt all  tests of the variable