### PR TITLE
Add enums for rigptt, removed externs, added QRA evaluation

### DIFF
--- a/share/help.txt
+++ b/share/help.txt
@@ -86,7 +86,6 @@ $         Switch to MEM and clear it (pop)
 :INFo     Network status
 :TRXcont  Toggle TRX control on/off
 :CHAR     Autosend: number of chars before starting to send
-:DEBug_tty Test rig link
 :SOUnd    Record sound files
 :WRIte    Write cabrillo
 :ADIf     Write Adif

--- a/src/addcall.h
+++ b/src/addcall.h
@@ -22,6 +22,8 @@
 #ifndef ADDCALL_H
 #define ADDCALL_H
 
+extern int excl_add_veto;
+
 int addcall(void);
 int addcall2(void);
 int get_band(char *logline);

--- a/src/addspot.c
+++ b/src/addspot.c
@@ -32,10 +32,9 @@
 #include <time.h>
 
 #include "get_time.h"
+#include "globalvars.h"
 #include "lancode.h"
 #include "splitscreen.h"
-#include "tlf.h"
-#include "tlf_curses.h"
 #include "ui_utils.h"
 
 
@@ -45,9 +44,6 @@
  * and send it to other stations in the LAN
  */
 void add_to_spots(char *call, freq_t freq) {
-
-    extern int lanspotflg;
-    extern char thisnode;
 
     char spotline[160];
     char spottime[6];
@@ -60,16 +56,13 @@ void add_to_spots(char *call, freq_t freq) {
     strcat(spotline, "\n\n");
 
     send_lan_message(TLFSPOT, spotline);
-    lanspotflg = 1;
+    lanspotflg = true;
     addtext(spotline);
-    lanspotflg = 0;
+    lanspotflg = false;
 }
 
 
 void addspot(void) {
-    extern freq_t freq;
-    extern char hiscall[];
-    extern int trx_control;
 
     char frequency[8];
 
@@ -77,7 +70,7 @@ void addspot(void) {
 	return;
     }
 
-    if (trx_control == 0) {
+    if (!trx_control) {
 
 	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 

--- a/src/autocq.c
+++ b/src/autocq.c
@@ -54,9 +54,6 @@ static int get_autocq_time() {
 
 
 int auto_cq(void) {
-    extern char message[][80];
-    extern int cqdelay;
-    extern cqmode_t cqmode;
 
 #define NO_KEY -1
 

--- a/src/background_process.c
+++ b/src/background_process.c
@@ -41,28 +41,6 @@
 #include "tlf.h"
 #include "write_keyer.h"
 
-
-extern int cluster;
-extern int packetinterface;
-extern bool lan_active;
-extern char lan_message[];
-extern int recv_error;
-extern char thisnode;
-extern int lanspotflg;
-extern char talkarray[5][62];
-extern freq_t node_frequencies[MAXNODES];
-extern int qsonum;
-extern char qsonrstr[5];
-extern int lanqsos;
-extern int highqsonr;
-extern char zone_export[];
-extern long timecorr;
-extern int timeoffset;
-extern mystation_t my;
-extern int trxmode;
-extern int digikeyer;
-extern int trx_control;
-
 // don't start until we know what we are doing
 static bool stop_backgrnd_process = true;
 
@@ -96,8 +74,6 @@ static void background_process_wait(void) {
 }
 
 void *background_process(void *ptr) {
-
-    extern int landebug;
 
     static char prmessage[256];
     static int lantimesync = 0;
@@ -135,8 +111,7 @@ void *background_process(void *ptr) {
 	 *   fldigi_get_log_call() reads the callsign, if user clicks to a string in Fldigi's RX window
 	 *   fldigi_get_log_serial_number() reads the exchange
 	 */
-	if (digikeyer == FLDIGI && fldigi_isenabled()
-		&& trx_control == 1) {
+	if (digikeyer == FLDIGI && fldigi_isenabled() && trx_control) {
 	    if (fldigi_rpc_cnt == 0) {
 		fldigi_xmlrpc_get_carrier();
 		fldigi_get_log_call();

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -38,6 +38,7 @@
 #include "dxcc.h"
 #include "initial_exchange.h"
 #include "bands.h"
+#include "lancode.h"
 
 #define TOLERANCE 100 		/* spots with a QRG +/-TOLERANCE
 				   will be counted as the same QRG */
@@ -76,13 +77,6 @@ bm_config_t bm_config = {
     0  /* DO NOT show ONLY multipliers */
 };
 short	bm_initialized = 0;
-
-extern freq_t freq;
-extern int trx_control;
-extern int bandinx;
-extern int trxmode;
-extern char thisnode;
-extern worked_t worked[];
 
 char *qtc_format(char *call);
 
@@ -288,7 +282,6 @@ void bandmap_addspot(char *call, freq_t freq, char node) {
     int dxccindex;
     int wi;
     char *lastexch;
-    extern struct ie_list *main_ie_list;
     struct ie_list *current_ie;
 
     /* add only HF spots */
@@ -813,7 +806,7 @@ void bandmap_show() {
 		 : (startindex + NR_SPOTS - (1 - on_qrg));
 
     /* correct calculations if we have no rig frequency to show */
-    if (trx_control == 0) {
+    if (!trx_control) {
 	if (on_qrg) {
 	    on_qrg = 0;
 	} else {
@@ -832,7 +825,7 @@ void bandmap_show() {
 
     /* show highlighted frequency marker or spot on QRG if rig control
      * is active */
-    if (trx_control != 0) {
+    if (trx_control) {
 	move(bm_y, bm_x);
 	attrset(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 	if (!on_qrg) {

--- a/src/callinput.h
+++ b/src/callinput.h
@@ -24,7 +24,7 @@
 #include <hamlib/rig.h>
 
 int callinput(void);
-int play_file(char *audiofile);
+void play_file(char *audiofile);
 void send_bandswitch(freq_t freq);
 
 #endif /* CALLINPUT_H */

--- a/src/changefreq.c
+++ b/src/changefreq.c
@@ -21,20 +21,17 @@
 #include <unistd.h>
 
 #include "freq_display.h"
+#include "globalvars.h"
 #include "time_update.h"
-#include "tlf_curses.h"
 #include "ui_utils.h"
 #include "gettxinfo.h"
 
 
 void change_freq(void) {
 
-    extern freq_t freq;
-    extern int trx_control;
-
     int brkflg = 0;
 
-    if (trx_control == 0)
+    if (!trx_control)
 	return;
 
     curs_set(0);

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -71,30 +71,6 @@ void wipe_display();
 
 int changepars(void) {
 
-    extern int cluster;
-    extern int shortqsonr;
-    extern int searchflg;
-    extern int demode;
-    extern int announcefilter;
-    extern int showscore_flag;
-    extern int zonedisplay;
-    extern int trxmode;
-    extern char hiscall[];
-    extern int rit;
-    extern int trx_control;
-    extern int packetinterface;
-    extern int nopacket;
-    extern int cqdelay;
-    extern int ctcomp;
-    extern char *config_file;
-    extern int miniterm;
-    extern int cwkeyer;
-    extern char synclogfile[];
-    extern char sc_volume[];
-    extern int cwstart;
-    extern int digikeyer;
-    extern cqmode_t cqmode;
-
     char parameterstring[20] = "";
     char parameters[52][19];
     int i, k, x, nopar = 0;
@@ -387,13 +363,9 @@ int changepars(void) {
 	    break;
 	}
 	case 28: {		/*  trx ctl   */
-	    if (trx_control == 1)
-		trx_control = 0;
-	    else {
-		trx_control = 1;
+	    trx_control = !trx_control;
 
-	    }
-	    if (trx_control == 1) {
+	    if (trx_control) {
 		mvprintw(13, 29, "TRX control on");
 	    } else {
 		mvprintw(13, 29, "TRX control off");
@@ -423,7 +395,7 @@ int changepars(void) {
 	    break;
 	}
 	case 33: {		/* PACKET  */
-	    if ((nopacket == 0) && (packetinterface > 0))
+	    if (!nopacket && packetinterface > 0)
 		packet();
 	    break;
 	}
@@ -495,7 +467,7 @@ int changepars(void) {
 	}
 
 	case 37: {		/* RECONNECT  */
-	    if ((nopacket == 0) && (packetinterface > 0)) {
+	    if (!nopacket && packetinterface > 0) {
 		cleanup_telnet();
 		init_packet();
 		packet();
@@ -689,7 +661,7 @@ int changepars(void) {
 	mvprintw(12, 29, "OK !        ");
 	writeparas();
     } else {
-	if ((nopacket == 0) && (packetinterface > 0))
+	if (!nopacket && packetinterface > 0)
 	    packet();
     }
 
@@ -709,23 +681,6 @@ int changepars(void) {
 
 void networkinfo(void) {
 
-    extern int use_bandoutput;
-    extern int recv_packets;
-    extern int recv_error;
-    extern int send_packets[];
-    extern int send_error[];
-    extern bool lan_active;
-    extern int nodes;
-    extern char bc_hostaddress[MAXNODES][16];
-    extern char *config_file;
-    extern char whichcontest[];
-    extern char pr_hostaddress[];
-    extern char tncportname[];
-    extern char *rigportname;
-    extern char logfile[];
-
-    int inode;
-
     wipe_display();
 
     if (lan_active)
@@ -735,27 +690,27 @@ void networkinfo(void) {
 
     mvprintw(3, 28, "Packets rcvd: %d | %d", recv_packets, recv_error);
 
-    for (inode = 0; inode < nodes; inode++) {
-	mvprintw(4 + inode, 10, "%s", bc_hostaddress[inode]);
-	mvprintw(4 + inode, 28, "Packets sent: %d | %d ",
-		 send_packets[inode], send_error[inode], nodes);
+    for (int i = 0; i < nodes; i++) {
+	mvprintw(4 + i, 10, "%s", bc_hostaddress[i]);
+	mvprintw(4 + i, 28, "Packets sent: %d | %d ",
+		 send_packets[i], send_error[i]);
     }
 
     if (strlen(config_file) > 0)
-	mvprintw(6 + inode, 10, "Config file: %s", config_file);
+	mvprintw(6 + nodes, 10, "Config file: %s", config_file);
     else
-	mvprintw(6 + inode, 10,
-		 "Config file: /usr/local/share/tlf/logcfg.dat");
-    mvprintw(7 + inode, 10, "Contest    : %s", whichcontest);
-    mvprintw(8 + inode, 10, "Logfile    : %s", logfile);
+	mvprintw(6 + nodes, 10,
+		 "Config file: /usr/local/share/tlf/logcfg.dat");//FIXME
+    mvprintw(7 + nodes, 10, "Contest    : %s", whichcontest);
+    mvprintw(8 + nodes, 10, "Logfile    : %s", logfile);
 
-    mvprintw(9 + inode, 10, "Cluster    : %s", pr_hostaddress);
-    mvprintw(10 + inode, 10, "TNCport    : %s", tncportname);
-    mvprintw(11 + inode, 10, "RIGport    : %s", rigportname);
+    mvprintw(9 + nodes, 10, "Cluster    : %s", pr_hostaddress);
+    mvprintw(10 + nodes, 10, "TNCport    : %s", tncportname);
+    mvprintw(11 + nodes, 10, "RIGport    : %s", rigportname);
     if (use_bandoutput == 1)
-	mvprintw(12 + inode, 10, "Band output: on");
+	mvprintw(12 + nodes, 10, "Band output: on");
     else
-	mvprintw(12 + inode, 10, "Band output: off");
+	mvprintw(12 + nodes, 10, "Band output: off");
 
     refreshp();
 
@@ -771,11 +726,6 @@ void networkinfo(void) {
 /* -------------------------------------------------------------- */
 
 void multiplierinfo(void) {
-
-    extern int serial_section_mult;
-    extern int sectn_mult;
-    extern mults_t multis[MAX_MULTS];
-    extern int nr_multis;
 
     int j, k, vert, hor, cnt, found;
     char mprint[50];

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -35,17 +35,15 @@
 #include "err_utils.h"
 #include "get_time.h"
 #include "getctydata.h"
+#include "globalvars.h"
 #include "lancode.h"
 #include "nicebox.h"		// Includes curses.h
 #include "printcall.h"
-#include "tlf.h"
+#include "splitscreen.h"
 #include "ui_utils.h"
 
 #define MAXMINUTES 30
 
-
-extern int bandinx;
-extern pthread_mutex_t spot_ptr_mutex;
 
 char *bandmap[MAX_SPOTS];
 int spotarray[MAX_SPOTS];		/* Array of indices into spot_ptr */
@@ -54,15 +52,6 @@ int loadbandmap(void);
 int getclusterinfo(void);
 
 void clusterinfo(void) {
-
-    extern int cluster;
-    extern freq_t freq;
-    extern char band[NBANDS][4];
-    extern int bandinx;
-    extern int trx_control;
-    extern char spot_ptr[MAX_SPOTS][82];
-    extern freq_t node_frequencies[MAXNODES];
-    extern char thisnode;
 
     int f, j, k;
     char inputbuffer[160] = "";
@@ -94,10 +83,10 @@ void clusterinfo(void) {
 	for (f = 0; f < 8; f++)
 	    mvprintw(15 + f, 4, "                           ");
 
-	if (trx_control == 0)
-	    node_frequencies[thisnode - 'A'] = atof(band[bandinx]);
-	else
+	if (trx_control)
 	    node_frequencies[thisnode - 'A'] = freq;
+	else
+	    node_frequencies[thisnode - 'A'] = atof(band[bandinx]);
 
 	for (f = 0; f < MAXNODES; f++) {
 	    if (node_frequencies[f] != 0)
@@ -165,14 +154,6 @@ void clusterinfo(void) {
 /* ----------------------------------------------------*/
 
 int loadbandmap(void) {
-
-    extern char *bandmap[MAX_SPOTS];
-    extern int xplanet;
-    extern char markerfile[];
-    extern char lastmsg[];
-    extern char spot_ptr[MAX_SPOTS][82];
-    extern int nr_of_spots;
-
 
     int i = 0, j, m, x;
     unsigned int k;
@@ -391,11 +372,6 @@ int loadbandmap(void) {
 
 
 int getclusterinfo(void) {
-
-    extern char spot_ptr[MAX_SPOTS][82];
-    extern int nr_of_spots;
-    extern int announcefilter;
-    extern mystation_t my;
 
     int i;
     int si;

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -64,7 +64,6 @@ typedef struct xmlrpc_res_s {
 #define MAXSHIFT 20		/* max shift value in Fldigi, when Tlf set
 				   it back to RIG carrier */
 
-extern char fldigi_url[50];
 static bool use_fldigi = false;
 
 int fldigi_var_carrier = 0;
@@ -491,9 +490,6 @@ int fldigi_xmlrpc_get_carrier() {
     int rc;
     xmlrpc_res result;
     xmlrpc_env env;
-    extern rmode_t rigmode;
-    extern int trx_control;
-    extern freq_t freq;
     char fldigi_mode[6] = "";
 
     rc = fldigi_xmlrpc_query(&result, &env, "modem.get_carrier", "");
@@ -610,7 +606,6 @@ int fldigi_get_log_call() {
 
     xmlrpc_res_init(&result);
 
-    extern char hiscall[];
     char tempstr[20];
     int i, j;
 
@@ -672,7 +667,6 @@ int fldigi_get_log_serial_number() {
 
     xmlrpc_res_init(&result);
 
-    extern char comment[];
     char tempstr[20];
     int i, j;
 

--- a/src/getmessages.c
+++ b/src/getmessages.c
@@ -17,6 +17,9 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <stdio.h>
+#include <string.h>
+
 #include "dxcc.h"
 #include "getctydata.h"
 #include "globalvars.h"

--- a/src/getmessages.c
+++ b/src/getmessages.c
@@ -17,25 +17,10 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* ------------------------------------------------------------
- *        Get messages  from  -paras file
- *        and  gets  the last  5 qso records for  display
- *        also gets the nr of the last qso from  the logfile
- *--------------------------------------------------------------*/
-
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-
-#include "checklogfile.h"
 #include "dxcc.h"
 #include "getctydata.h"
-#include "globalvars.h"		// Includes glib.h and tlf.h
-#include "qsonr_to_str.h"
-#include "ignore_unused.h"
-#include "tlf_curses.h"
+#include "globalvars.h"
+#include "locator2longlat.h"
 
 
 /* get countrynumber, QTH, CQ zone and continent for myself */
@@ -47,8 +32,14 @@ void getstationinfo() {
 
     sprintf(my.cqzone, "%02d", mydx -> cq);
     strcpy(my.continent, mydx->continent);
-    my.Lat = mydx->lat; 	/* whereami? */
-    my.Long = mydx->lon;
+
+    /* whereami? use QRA is possible */
+    if (RIG_OK == locator2longlat(&my.Long, &my.Lat, my.qra)) {
+	my.Long = -my.Long;     // W <-> E fix
+    } else {
+	my.Long = mydx->lon;
+	my.Lat = mydx->lat;
+    }
 }
 
 

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -31,6 +31,7 @@
 #include "err_utils.h"
 #include "fldigixmlrpc.h"
 #include "gettxinfo.h"
+#include "globalvars.h"
 #include "tlf.h"
 #include "tlf_curses.h"
 #include "callinput.h"
@@ -43,20 +44,6 @@
 #else
 #define TLF_DEFAULT_PASSBAND RIG_PASSBAND_NORMAL
 #endif
-
-extern RIG *my_rig;
-extern int cw_bandwidth;
-extern int trxmode;
-extern rmode_t rigmode;
-extern int digikeyer;
-extern rmode_t digi_mode;
-
-extern freq_t freq;
-extern int bandinx;
-extern freq_t bandfrequency[];
-
-extern int trx_control;
-extern unsigned char rigptt;
 
 /* output frequency to rig or other rig-related request
  *
@@ -124,29 +111,27 @@ void gettxinfo(void) {
 	return;
 
     /* CAT PTT wanted, available, inactive, and PTT On requested
-     * bits 0, 1, and 3 set.
      */
-    if (rigptt == 0x0b) {
+    if (rigptt == (CAT_PTT_USE | CAT_PTT_ON)) {
 	retval = rig_set_ptt(my_rig, RIG_VFO_CURR, RIG_PTT_ON);
 
 	/* Set PTT active bit. */
-	rigptt |= (1 << 2);		/* 0x0f */
+	rigptt |= CAT_PTT_ACTIVE;
 
 	/* Clear PTT On requested bit. */
-	rigptt &= ~(1 << 3);		/* 0x07 */
+	rigptt &= ~CAT_PTT_ON;
     }
 
     /* CAT PTT wanted, available, active and PTT Off requested
-     * bits 0, 1, 2, and 4 set.
      */
-    if (rigptt == 0x17) {
+    if (rigptt == (CAT_PTT_USE | CAT_PTT_ACTIVE | CAT_PTT_OFF)) {
 	retval = rig_set_ptt(my_rig, RIG_VFO_CURR, RIG_PTT_OFF);
 
 	/* Clear PTT Off requested bit. */
-	rigptt &= ~(1 << 4);		/* 0x07 */
+	rigptt &= ~CAT_PTT_OFF;
 
 	/* Clear PTT active bit. */
-	rigptt &= ~(1 << 2);		/* 0x03 */
+	rigptt &= ~CAT_PTT_ACTIVE;
     }
 
     freq_t reqf = get_and_reset_outfreq();  // get actual request

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -6,6 +6,7 @@
 #include <config.h>
 
 #include "tlf.h"
+#include "tlf_curses.h"
 
 extern mystation_t my;			// all about my station
 extern char whichcontest[];
@@ -37,11 +38,14 @@ extern int countries[MAX_DATALINES];	// for every country, a bitfield
 
 extern int bandinx;			// band we're currently working on
 
+extern struct ie_list *main_ie_list;
+
 extern char logfile[];
 extern bool iscontest;
 
 extern int country_mult;
 extern char hiscall[20];
+extern char hiscall_sent[20];
 extern int total;
 extern int band_score[NBANDS];		// QSO/band
 extern int zones[MAX_ZONES];
@@ -72,6 +76,8 @@ extern char logline_edit[5][LOGLINELEN + 1];
 #define logline4 logline_edit[4]
 
 extern char band[NBANDS][4];
+extern freq_t bandfrequency[NBANDS];
+
 extern struct tm *time_ptr;
 extern struct tm time_ptr_cabrillo;
 
@@ -94,6 +100,7 @@ extern int exchange_serial;
 extern int highqsonr;
 
 
+extern RIG *my_rig;
 extern cqmode_t cqmode;
 extern int trxmode;
 extern rig_model_t myrig_model;
@@ -101,10 +108,10 @@ extern rmode_t rigmode;
 extern freq_t freq;
 extern char lastqsonr[];
 extern int cqwwm2;
-extern char thisnode;
 extern char lastcall[];
 extern char recvd_rst[];
 extern char sent_rst[];
+extern char last_rst[];
 extern char section[];
 extern int wazmult;
 extern int addcallarea;
@@ -136,13 +143,18 @@ extern int multlist;
 extern int xplanet;
 extern int cwkeyer;
 extern int digikeyer;
-extern unsigned char rigptt;
+extern int cwstart;
+extern int early_started;
+extern int zonedisplay;
+extern int rigptt;
+extern int k_ptt;
+extern int k_pin14;
+extern int sending_call;
 extern int exclude_multilist_type;
 extern int partials;
 extern int use_part;
 extern int shortqsonr;
 extern int recall_mult;
-extern int trx_control;
 extern int rit;
 extern int showscore_flag;
 extern int searchflg;
@@ -173,6 +185,12 @@ extern int countrylist_points;
 extern int my_country_points;
 extern int lowband_point_mult;
 extern int landebug;
+extern int dupe;
+extern int block_part;
+extern int miniterm;
+extern int announcefilter;
+extern int nr_of_spots;
+extern int fdSertnc;
 
 extern float fixedmult;
 
@@ -202,6 +220,8 @@ extern char synclogfile[];
 extern char sc_device[];
 extern char exchange_list[40];
 extern char rttyoutput[];
+extern char spot_ptr[MAX_SPOTS][82];
+extern char lastmsg[];
 #ifdef HAVE_LIBXMLRPC
 extern char fldigi_url[50];
 #endif
@@ -214,8 +234,14 @@ extern char *config_file;
 extern int bandindexarray[];
 extern int tlfcolors[8][2];
 
+extern SCREEN *mainscreen;
+
 extern bool mult_side;
 extern bool countrylist_only;
 extern bool mixedmode;
 extern bool ignoredupe;
 extern bool continentlist_only;
+extern bool debugflag;
+extern bool trx_control;
+extern bool nopacket;
+extern bool verbose;

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -38,10 +38,6 @@ void send_bandswitch(freq_t outfreq);
 static freq_t execute_grab(spot *data);
 
 freq_t grabspot(void) {
-    extern char hiscall[];
-    extern int trx_control;
-
-    spot *data;
 
     if (!trx_control) {
 	return 0;   // no trx control
@@ -51,7 +47,7 @@ freq_t grabspot(void) {
 	return 0;   // call input is empty
     }
 
-    data = bandmap_lookup(hiscall);
+    spot *data = bandmap_lookup(hiscall);
 
     if (data == NULL) {
 	return 0;   // no spot found
@@ -61,17 +57,14 @@ freq_t grabspot(void) {
 }
 
 freq_t grab_next(void) {
-    extern int trx_control;
 
     static int dir = 1;		/* start scanning up */
-
-    spot *data;
 
     if (!trx_control) {
 	return 0;   // no trx control
     }
 
-    data = bandmap_next(dir, freq);
+    spot *data = bandmap_next(dir, freq);
 
     if (data == NULL) {		/* nothing in that direction */
 	/* try other one */
@@ -90,8 +83,6 @@ freq_t grab_next(void) {
  * \return frequency of the spot in Hz
  */
 static freq_t execute_grab(spot *data) {
-    extern char hiscall[];
-    extern cqmode_t cqmode;
 
     freq_t f = data->freq;
     set_outfreq(f);

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -354,9 +354,6 @@ void talk(void) {
 
 int send_freq(freq_t freq) {
 
-    extern int bandinx;
-    extern int trx_control;
-
     char fbuffer[8];
 
     if (trx_control) {

--- a/src/lancode.h
+++ b/src/lancode.h
@@ -38,6 +38,15 @@
 
 extern char bc_hostaddress[MAXNODES][16];
 extern char bc_hostservice[MAXNODES][16];
+extern char talkarray[5][62];
+extern char thisnode;
+extern char lan_message[256];
+extern int recv_error;
+extern freq_t node_frequencies[MAXNODES];
+extern long timecorr;
+extern int recv_packets;
+extern int send_packets[MAXNODES];
+extern int send_error[MAXNODES];
 
 int lan_recv_init(void);
 int lan_recv_close(void);

--- a/src/locator2longlat.h
+++ b/src/locator2longlat.h
@@ -18,36 +18,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/*
- * original code in HAMLIB
- *
- * src/locator.c header file
- *
- * author Stephane Fillod and the Hamlib Group
- * date 2000-2010
- *
- *  Hamlib Interface - locator, bearing, and conversion calls
- *
- *
- *  Hamlib Interface - locator and bearing conversion calls
- *  Copyright (c) 2001-2010 by Stephane Fillod
- *  Copyright (c) 2003 by Nate Bargmann
- *  Copyright (c) 2003 by Dave Hines
- *
- *
- *  Code to determine bearing and range was taken from the Great Circle,
- *  by S. R. Sampson, N5OWK.
- *  Ref: "Air Navigation", Air Force Manual 51-40, 1 February 1987
- *  Ref: "ARRL Satellite Experimenters Handbook", August 1990
- *
- *  Code to calculate distance and azimuth between two Maidenhead locators,
- *  taken from wwl, by IK0ZSN Mirko Caserta.
- *
- *  New bearing code added by N0NB was found at:
- *  http://williams.best.vwh.net/avform.htm#Crs
- */
-
-
 #ifndef LOCATOR2LONGLAT_H
 #define LOCATOR2LONGLAT_H
 

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -54,17 +54,6 @@ char lan_logline[256];
  * \param from_lan true - Log lanmessage, false - normal message
  */
 void log_to_disk(int from_lan) {
-    extern char last_rst[4];
-    extern char qsonrstr[5];
-    extern int rit;
-    extern int trx_control;
-    extern cqmode_t cqmode;
-    extern int block_part;
-    extern char lan_message[];
-    extern char thisnode;
-    extern int lan_mutex;
-    extern int cqwwm2;
-    extern int no_rst;
 
     pthread_mutex_lock(&disk_mutex);
 

--- a/src/main.c
+++ b/src/main.c
@@ -691,6 +691,8 @@ int databases_load() {
 
 void hamlib_init() {
 
+    rig_set_debug(RIG_DEBUG_NONE);
+
     if (no_trx_control) {
 	trx_control = false;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -921,8 +921,6 @@ int main(int argc, char *argv[]) {
     showmsg("");
 
     memset(&my, 0, sizeof(my));
-    my.Lat = 51.;
-    my.Long = -7.;
 
     total = 0;
     if (databases_load() == EXIT_FAILURE) {

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -28,10 +28,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "addcall.h"
 #include "addpfx.h"
 #include "dxcc.h"
 #include "get_time.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "lancode.h"
 #include "qsonr_to_str.h"
 #include "score.h"
 #include "setcontest.h"
@@ -55,9 +57,6 @@ void fillto(int n);
  *   See function definitions below
  */
 void makelogline(void) {
-    extern int trx_control;
-    extern freq_t freq;
-
     static int lastbandinx = 0;
     char freq_buff[10];
     int points;
@@ -93,7 +92,7 @@ void makelogline(void) {
     fillto(80);
 
     /* add freq to end of logline */
-    if (trx_control == 1) {
+    if (trx_control) {
 	snprintf(freq_buff, 8, "%7.1f", freq / 1000.0);
 	strcat(logline4, freq_buff);
     }
@@ -121,12 +120,6 @@ void makelogline(void) {
  *                                                 his  my.\endverbatim
  */
 void prepare_fixed_part(void) {
-    extern int no_rst;
-    extern char whichcontest[];
-    extern int logfrequency;
-    extern int trx_control;
-    extern freq_t freq;
-
     static char time_buf[80];
 
     strcpy(logline4, band[bandinx]);
@@ -147,8 +140,7 @@ void prepare_fixed_part(void) {
     strcat(logline4, time_buf);
 
     qsonr_to_str();
-    if (logfrequency == 1 &&
-	    trx_control == 1 &&
+    if (logfrequency == 1 && trx_control &&
 	    ((strcmp(whichcontest, "qso") == 0) ||
 	     (strcmp(whichcontest, "dxped") == 0))) {
 	char khz[5];
@@ -233,8 +225,6 @@ void prepare_fixed_part(void) {
  *     class - TX count + operator class, sctn - ARRL/RAC section
  */
 void prepare_specific_part(void) {
-    extern int pfxnummultinr;
-    extern int excl_add_veto;
     int new_pfx;
     int sr_nr = 0;
     char grid[7] = "";
@@ -300,7 +290,7 @@ void prepare_specific_part(void) {
 	new_pfx = (add_pfx(pxstr, bandinx) == 0);	/* add prefix, remember if new */
     }
 
-    if (CONTEST_IS(WPX) ||pfxmult == 1 || pfxmultab == 1) {	/* wpx */
+    if (CONTEST_IS(WPX) || pfxmult == 1 || pfxmultab == 1) {	/* wpx */
 	if (new_pfx) {
 	    /** \todo FIXME: prefix can be longer than 5 char, e.g. LY1000 */
 	    strncat(logline4, pxstr, 5);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -927,12 +927,6 @@ static int cfg_fldigi(const cfg_arg_t arg) {
     return PARSE_OK;
 }
 
-static int cfg_rigptt(const cfg_arg_t arg) {
-    // FIXME: use enums
-    rigptt |= (1 << 0);		/* bit 0 set--CAT PTT wanted (RIGPTT) */
-    return PARSE_OK;
-}
-
 static int cfg_minitest(const cfg_arg_t arg) {
     if (parameter == NULL) {
 	minitest = MINITEST_DEFAULT_PERIOD;
@@ -1000,13 +994,13 @@ static config_t logcfg_configs[] = {
     {"MIXED",               CFG_BOOL_TRUE(mixedmode)},
     {"IGNOREDUPE",          CFG_BOOL_TRUE(ignoredupe)},
     {"USE_CONTINENTLIST_ONLY",  CFG_BOOL_TRUE(continentlist_only)},
+    {"RADIO_CONTROL",           CFG_BOOL_TRUE(trx_control)},
 
     {"USEPARTIALS",     CFG_INT_ONE(use_part)},
     {"PARTIALS",        CFG_INT_ONE(partials)},
     {"RECALL_MULTS",    CFG_INT_ONE(recall_mult)},
     {"WYSIWYG_MULTIBAND",   CFG_INT_ONE(wysiwyg_multi)},
     {"WYSIWYG_ONCE",    CFG_INT_ONE(wysiwyg_once)},
-    {"RADIO_CONTROL",   CFG_INT_ONE(trx_control)},
     {"RIT_CLEAR",       CFG_INT_ONE(rit)},
     {"SHORT_SERIAL",    CFG_INT_ONE(shortqsonr)},
     {"SCOREWINDOW",     CFG_INT_ONE(showscore_flag)},
@@ -1099,6 +1093,7 @@ static config_t logcfg_configs[] = {
     {"LONG_SERIAL",     CFG_INT_CONST(shortqsonr, 0)},
     {"CLUSTER",         CFG_INT_CONST(cluster, CLUSTER)},
     {"SSBMODE",         CFG_INT_CONST(trxmode, SSBMODE)},
+    {"RIGPTT",          CFG_INT_CONST(rigptt, CAT_PTT_WANTED)},
 
     {"RIGCONF",         CFG_STRING_STATIC(rigconf, 80)},
     {"LOGFILE",         CFG_STRING_STATIC(logfile, 120)},
@@ -1151,7 +1146,6 @@ static config_t logcfg_configs[] = {
     {"QTCREC_RECORD_COMMAND",   NEED_PARAM, cfg_qtcrec_record_command},
     {"EXCLUDE_MULTILIST",   NEED_PARAM, cfg_exclude_multilist},
     {"FLDIGI",              OPTIONAL_PARAM, cfg_fldigi},
-    {"RIGPTT",              NO_PARAM, cfg_rigptt},
     {"MINITEST",            OPTIONAL_PARAM, cfg_minitest},
     {"UNIQUE_CALL_MULTI",   NEED_PARAM, cfg_unique_call_multi},
     {"DIGI_RIG_MODE",       NEED_PARAM, cfg_digi_rig_mode},

--- a/src/qtc_log.c
+++ b/src/qtc_log.c
@@ -32,9 +32,6 @@
 #include "qtcvars.h"		// Includes globalvars.h
 #include "tlf_curses.h"
 
-extern int trx_control;
-extern freq_t freq;
-
 int log_recv_qtc_to_disk(int qsonr) {
 
     int i;
@@ -73,7 +70,7 @@ int log_recv_qtc_to_disk(int qsonr) {
 	    qtc_line.qtc_call[strlen(qtcreclist.qtclines[i].callsign)] = '\0';
 	    qtc_line.qtc_serial = atoi(qtcreclist.qtclines[i].serial);
 
-	    if (trx_control == 1) {
+	    if (trx_control) {
 		qtc_line.freq = freq;
 	    } else {
 		qtc_line.freq = 0;
@@ -170,7 +167,7 @@ int log_sent_qtc_to_disk(int qsonr) {
 
 	    qtc_line.callpos = qtclist.qtclines[i].qsoline + 1;
 
-	    if (trx_control == 1) {
+	    if (trx_control) {
 		qtc_line.freq = freq;
 	    } else {
 		qtc_line.freq = 0;

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -40,10 +40,6 @@ static void debug_tlf_rig();
  */
 int sendqrg(void) {
 
-    extern char hiscall[];
-    extern int trx_control;
-
-
     if (!trx_control) {
 	return 0;               /* nothing to do here */
     }
@@ -65,13 +61,6 @@ int sendqrg(void) {
 /**************************************************************************/
 
 int init_tlf_rig(void) {
-    extern RIG *my_rig;
-    extern rig_model_t myrig_model;
-    extern int serial_rate;
-    extern char *rigportname;
-    extern int debugflag;
-    extern unsigned char rigptt;
-
     freq_t rigfreq;		/* frequency  */
     vfo_t vfo;
     int retcode;		/* generic return code from functions */
@@ -105,12 +94,12 @@ int init_tlf_rig(void) {
     caps = my_rig->caps;
 
     /* If CAT PTT is wanted, test for CAT capability of rig backend. */
-    if (rigptt & (1 << 0)) {
+    if (rigptt & CAT_PTT_WANTED) {
 	if (caps->ptt_type == RIG_PTT_RIG) {
-	    rigptt |= (1 << 1);		/* bit 1 set--CAT PTT available. */
+	    rigptt |= CAT_PTT_AVAILABLE;
 	} else {
 	    rigptt = 0;
-	    showmsg("Controlling PTT via hamlib is not supported for that rig!");
+	    showmsg("Controlling PTT via Hamlib is not supported for that rig!");
 	}
     }
 
@@ -168,21 +157,15 @@ int init_tlf_rig(void) {
     return 0;
 }
 
-int close_tlf_rig(RIG *my_rig) {
-    extern char *rigportname;
+void close_tlf_rig(RIG *my_rig) {
 
     rig_close(my_rig);		/* close port */
     rig_cleanup(my_rig);	/* if you care about memory */
 
-    printf("Rig port %s closed ok\n", rigportname);
-
-    return 0;
+    printf("Rig port %s closed\n", rigportname);
 }
 
 static int parse_rigconf() {
-    extern char rigconf[];
-    extern RIG *my_rig;
-
     char *cnfparm, *cnfval;
     const int rigconf_len = strlen(rigconf);
     int i;
@@ -222,7 +205,6 @@ static int parse_rigconf() {
 
 
 static void debug_tlf_rig() {
-    extern RIG *my_rig;
     freq_t rigfreq;
     int retcode;
 

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -73,8 +73,6 @@ int init_tlf_rig(void) {
     /*
      * allocate memory, setup & open port
      */
-    rig_set_debug(RIG_DEBUG_NONE);
-
     my_rig = rig_init(myrig_model);
 
     if (!my_rig) {

--- a/src/sendqrg.h
+++ b/src/sendqrg.h
@@ -24,7 +24,7 @@
 #include <hamlib/rig.h>
 
 int init_tlf_rig(void);
-int close_tlf_rig(RIG *my_rig);
+void close_tlf_rig(RIG *my_rig);
 
 int sendqrg(void);
 

--- a/src/set_tone.c
+++ b/src/set_tone.c
@@ -53,8 +53,6 @@ void set_tone(void) {
 
 void write_tone(void) {
 
-    extern char sc_volume[];
-
     if (netkeyer(K_TONE, tonestr) < 0) {
 	TLF_LOG_INFO("keyer not active; switching to SSB");
 	trxmode = SSBMODE;

--- a/src/splitscreen.h
+++ b/src/splitscreen.h
@@ -20,10 +20,15 @@
 #ifndef SPLITSCREEN_H
 #define SPLITSCREEN_H
 
+#include <stdbool.h>
+
+extern bool lanspotflg;
+extern pthread_mutex_t spot_ptr_mutex;
+
 int init_packet(void) ;
 void cleanup_telnet(void);
 int packet(void);
-int send_cluster(void);
+void send_cluster(void);
 void addtext(char *s);
 int receive_packet(void);
 void refresh_splitlayout();

--- a/src/startmsg.c
+++ b/src/startmsg.c
@@ -21,12 +21,10 @@
 #include <unistd.h>
 
 #include "ignore_unused.h"
-#include "tlf.h"
-#include "tlf_curses.h"
+#include "globalvars.h"
 #include "ui_utils.h"
 
 
-extern int verbose;
 static int linectr = 0;
 
 void clearmsg() {

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -48,7 +48,6 @@
  * act as time master if allowed */
 void broadcast_lan(void) {
 
-    extern int time_master;
     static int frcounter = 0;
 
     frcounter++;
@@ -80,8 +79,6 @@ bool force_show_freq = false;
 /** show frequency and memory if rig control is active */
 void show_freq(void) {
 
-    extern int trx_control;
-
     attron(modify_attr(COLOR_PAIR(C_LOG)));
 
     freq_t memfreq = 0;
@@ -103,10 +100,6 @@ void show_freq(void) {
 
 
 void time_update(void) {
-
-    extern char qsonrstr[];
-    extern int bandinx;
-    extern int miniterm;
 
     static int s = 0;
     static int bm_timeout = 0;

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -21,15 +21,13 @@
 #ifndef TLF_H
 #define TLF_H
 
-#define NO_KEYER 0
-#define LPT_KEYER 1 	/* deprecated */
-#define COM1_KEYER 2	/* deprecated */
-#define NET_KEYER 3
-#define MFJ1278_KEYER 4
-#define ORION_KEYER 5 	/* deprecated */
-#define K2_KEYER 6 	/* deprecated */
-#define GMFSK 7
-#define FLDIGI 8
+enum {
+    NO_KEYER,
+    NET_KEYER,
+    MFJ1278_KEYER,
+    GMFSK,
+    FLDIGI,
+};
 
 #define SINGLE 0        /* single op */
 #define MULTI 1         /* multi op / single tx */

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -111,10 +111,10 @@ enum {
 #define ISDUPE 1
 #define NODUPE 0
 
-#define  MAX_QSOS 20000       /* internal qso array */
-#define  MAX_DATALINES 1000   /* from ctydb.dat  */
-#define  MAX_CALLS 5000      /*  max nr of calls in dupe array */
-#define  MAX_MULTS 1000        /* max nr of mults in mults array */
+#define MAX_QSOS 20000          /* internal qso array */
+#define MAX_DATALINES 1000      /* from ctydb.dat  */
+#define MAX_CALLS 5000          /* max nr of calls in dupe array */
+#define MAX_MULTS 1000          /* max nr of mults in mults array */
 #define	MAX_SPOTS 200		/* max nr. of spots in spotarray */
 #define CQ_ZONES 40
 #define ITU_ZONES 90
@@ -212,6 +212,22 @@ typedef struct {
     contest_type_t	id;
     char		*name;
 } contest_config_t;
+
+/**< Bitmask for Hamlib CAT PTT
+ * bit 0 set: CAT PTT wanted--RIGPTT in logcfg.dat (set in parse_logcfg)
+ * bit 1 set: CAT PTT available--from rig caps (set in sendqrg)
+ * bit 2 set: PTT active (set/unset in gettxinfo)
+ * bit 3 set: PTT On (set/unset in callinput)
+ * bit 4 set: PTT Off (set/unset in callinput)
+ */
+enum {
+    CAT_PTT_WANTED      = (1 << 0),
+    CAT_PTT_AVAILABLE   = (1 << 1),
+    CAT_PTT_USE         = CAT_PTT_WANTED | CAT_PTT_AVAILABLE,
+    CAT_PTT_ACTIVE      = (1 << 2),
+    CAT_PTT_ON          = (1 << 3),
+    CAT_PTT_OFF         = (1 << 4),
+};
 
 #define FREE_DYNAMIC_STRING(p)  if (p != NULL) {g_free(p); p = NULL;}
 

--- a/test/data.c
+++ b/test/data.c
@@ -50,7 +50,7 @@ int tlfcolors[8][2] = { {COLOR_BLACK, COLOR_WHITE},
 };
 
 
-int debugflag = 0;
+bool debugflag = false;
 char *editor_cmd = NULL;
 char rttyoutput[120];
 int tune_val = 0;
@@ -116,7 +116,7 @@ int nob4 = 0;			// allow auto b4
 bool ignoredupe = false;
 int noautocq = 0;
 int emptydir = 0;
-int verbose = 0;
+bool verbose = false;
 int no_rst = 0;			/* 1 - do not use RS/RST */
 int sprint_mode = 0;
 int qtc_recv_lazy = 0;
@@ -317,7 +317,7 @@ char *rigportname;
 int rignumber = 0;
 int rig_comm_error = 0;
 int rig_comm_success = 0;
-unsigned char rigptt = 0;
+int rigptt = 0;
 
 /*-------------------------------the log lines-----------------------------*/
 char qsos[MAX_QSOS][LOGLINELEN + 1];
@@ -364,11 +364,11 @@ freq_t freq;
 freq_t mem;
 int logfrequency = 0;
 int rit;
-int trx_control = 0;
+bool trx_control = false;
 int showfreq = 0;
-freq_t bandfrequency[10] = {
+freq_t bandfrequency[NBANDS] = {
     1830000.0, 3525000.0, 5352000.0, 7010000.0, 10105000.0, 14025000.0, 18070000.0, 21025000.0, 24900000.0,
-    28025000.0
+    28025000.0, 0.0
 };
 
 char headerline[81] =
@@ -397,8 +397,7 @@ int wazmult = 0;		/* to add the ability of WAZ zones to be multiplier */
 int itumult = 0;		/* to add the ability of ITU zones to be multiplier */
 char itustr[3];
 
-int nopacket = 0;		/* set if tlf is called with '-n' */
-int no_trx_control = 0;		/* set if tlf is called with '-r' */
+bool nopacket = false;		/* set if tlf is called with '-n' */
 
 int bandweight_points[NBANDS] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 int bandweight_multis[NBANDS] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};

--- a/test/test_clusterinfo.c
+++ b/test/test_clusterinfo.c
@@ -19,16 +19,8 @@ int getctynr(char *checkcall) {
     return 0;
 }
 
-extern char spot_ptr[MAX_SPOTS][82];
-extern int nr_of_spots;
-extern int announcefilter;
-extern int xplanet;
-extern int trx_control;
-extern freq_t freq;
-
 char thisnode = 'A';
 freq_t node_frequencies[MAXNODES];
-extern int cluster;
 
 #include <pthread.h>
 pthread_mutex_t spot_ptr_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/test/test_lancode.c
+++ b/test/test_lancode.c
@@ -8,10 +8,6 @@
 
 // OBJECT ../src/lancode.o
 
-extern int trx_control;
-extern int nodes;
-
-
 void handle_logging(enum log_lvl lvl, ...) {
     // empty
 }
@@ -22,7 +18,7 @@ time_t get_time() {
 
 int setup_default(void **state) {
 
-    trx_control = 1;
+    trx_control = true;
     nodes = 1;
     lan_active = true;
 
@@ -52,7 +48,7 @@ void test_send_freq_10(void **state) {
 
 void test_send_freq_80_notrx(void **state) {
 
-    trx_control = 0;
+    trx_control = false;
 
     bandinx = BANDINDEX_80;
     send_freq(0);
@@ -64,7 +60,7 @@ void test_send_freq_80_notrx(void **state) {
 
 void test_send_freq_10_notrx(void **state) {
 
-    trx_control = 0;
+    trx_control = false;
 
     bandinx = BANDINDEX_10;
     send_freq(0);

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -14,6 +14,7 @@
 #include "../src/getwwv.h"
 #include "../src/change_rst.h"
 #include "../src/setcontest.h"
+#include "../src/set_tone.h"
 
 // OBJECT ../src/parse_logcfg.o
 // OBJECT ../src/get_time.o
@@ -23,111 +24,6 @@
 // OBJECT ../src/score.o
 // OBJECT ../src/qrb.o
 // OBJECT ../src/setcontest.o
-
-extern char keyer_device[10];
-extern int partials;
-extern int use_part;
-extern char *editor_cmd;
-extern int weight;
-extern bool mixedmode;
-extern bool ignoredupe;
-extern bool continentlist_only;
-extern int recall_mult;
-extern int wysiwyg_multi;
-extern int wysiwyg_once;
-extern int trx_control;
-extern int rit;
-extern int shortqsonr;
-extern int showscore_flag;
-extern int searchflg;
-extern int demode;
-extern int exchange_serial;
-extern int country_mult;
-extern int portable_x2;
-extern int cqwwm2;
-extern int landebug;
-extern int call_update;
-extern int time_master;
-extern int ctcomp;
-extern int serial_section_mult;
-extern int sectn_mult;
-extern int nob4;
-extern int show_time;
-extern int use_rxvt;
-extern int wazmult;
-extern int itumult;
-extern int exc_cont;
-extern int noautocq;
-extern int no_arrows;
-extern int sc_sidetone;
-extern int lowband_point_mult;
-extern int clusterlog;
-extern int serial_grid4_mult;
-extern int logfrequency;
-extern int no_rst;
-extern int serial_or_section;
-extern int pfxmultab;
-extern int qtcrec_record;
-extern int qtc_auto_filltime;
-extern int bmautograb;
-extern int bmautoadd;
-extern int qtc_recv_lazy;
-extern int sprint_mode;
-extern int keyer_backspace;
-extern int sectn_mult_once;
-extern int lan_port;
-extern char rigconf[];
-extern char ph_message[14][80];
-extern char *cabrillo;
-extern int timeoffset;
-extern int cwkeyer;
-extern int digikeyer;
-extern char *rigportname;
-extern int tnc_serial_rate;
-extern char tncportname[];
-extern int serial_rate;
-extern int packetinterface;
-extern char pr_hostaddress[];
-extern int portnum;
-extern int cluster;
-extern int cqdelay;
-extern int ssbpoints;
-extern int cwpoints;
-extern int tlfcolors[8][2];
-extern char whichcontest[40];
-extern int use_bandoutput;
-extern int bandindexarray[10];
-extern char tonestr[];
-extern int txdelay;
-extern int multlist;
-extern char multsfile[];
-extern int xplanet;
-extern char markerfile[];
-extern char countrylist[][6];
-extern bool mult_side;
-extern int countrylist_points;
-extern bool countrylist_only;
-extern int my_country_points;
-extern int my_cont_points;
-extern int dx_cont_points;
-extern char synclogfile[];
-extern char sc_volume[];
-extern char sc_device[];
-extern char modem_mode[];
-extern char controllerport[];
-extern char clusterlogin[];
-extern int cw_bandwidth;
-extern char exchange_list[40];
-extern char rttyoutput[];
-extern float fixedmult;
-extern int continentlist_points;
-extern char continent_multiplier_list[7][3];
-extern int bandweight_points[NBANDS];
-extern int bandweight_multis[NBANDS];
-extern pfxnummulti_t pfxnummulti[MAXPFXNUMMULT];
-extern int pfxnummultinr;
-extern int exclude_multilist_type;
-extern unsigned char rigptt;
 
 // lancode.c
 int nodes = 0;
@@ -147,8 +43,6 @@ char netkeyer_hostaddress[16] = "127.0.0.1";
 int netkeyer_port = 6789;
 
 bm_config_t bm_config;
-
-extern rig_model_t myrig_model;
 
 char *callmaster_filename = NULL;
 
@@ -417,6 +311,7 @@ static bool_true_t bool_trues[] = {
     {"MIXED", &mixedmode},
     {"IGNOREDUPE", &ignoredupe},
     {"USE_CONTINENTLIST_ONLY", &continentlist_only},
+    {"RADIO_CONTROL", &trx_control},
 };
 
 void test_bool_trues(void **state) {
@@ -487,7 +382,6 @@ static int_one_t int_ones[] = {
     {"RECALL_MULTS", &recall_mult},
     {"WYSIWYG_MULTIBAND", &wysiwyg_multi},
     {"WYSIWYG_ONCE", &wysiwyg_once},
-    {"RADIO_CONTROL", &trx_control},
     {"RIT_CLEAR", &rit},
     {"SHORT_SERIAL", &shortqsonr},
     {"SCOREWINDOW", &showscore_flag},


### PR DESCRIPTION
The main change is adding enums for `rigptt` bits. Changed its type to `int` to simplify setting it in parse_logcfg, also dropped the ORing as other bits are not used at this stage.

Boolified variables from main that are controlled by command line switches (debugflag, no_trx_control, verbose, convert_cabrillo, nopacket). Also converted trx_control.

Replaced opening voice keyer wav file by `access()` in `play_file()`. This function was already used to check the presence of `./play_wk`, so the code is more consistent now.

Removed externs from all affected files, added variable to header files (globalcfg + lancode).
Removed the deprecated keyer enums. These are only internally used, so renumbered them.

Added a feature: use specfied QRA locator to determine lan/long.

Found an issue in `networkinfo()`: the reported config file is always either `logcfg.dat` or the given on command line. The system config is never shown as `config_file` is never empty. In addition the system config location is hard coded.
This can be fixed, but then we'll have an issue with re-reading the config via `:SET`/`:CFG`. Btw these probably anyway do not work as proper re-reading requires releasing all resources (net sockets, ...) which is not done at the moment.

