### PR TITLE
Fix payload in lan_send()

### DIFF
--- a/src/lancode.c
+++ b/src/lancode.c
@@ -249,7 +249,7 @@ static int lan_send(char *lanbuffer) {
     for (int node = 0; node < nodes; node++) {
 
 	bc_sendto_rc = sendto(bc_socket_descriptor[node],
-			      lanbuffer, 256,
+			      lanbuffer, strlen(lanbuffer),
 			      0, (struct sockaddr *) &bc_address[node],
 			      sizeof(bc_address[node]));
 


### PR DESCRIPTION
When communicating with other TLF nodes `lan_send()` in `lancode.c` sends a fixed length, 256 bytes UDP payload.

Apart from wasting bandwidth the issue is that this payload originates from a smaller buffer
```
int send_lan_message(int opcode, char *message) {
    char sendbuffer[102];
```
which can potentially lead to reading from unallocated memory thus leading to SEGV and crasing TLF.

Here how it looks like when sending a talk message (actual payload is `A4hello\n`):
![Screenshot_20201230_102351](https://user-images.githubusercontent.com/15141948/103343972-92e11200-4a8d-11eb-8337-a7970d21fdff.png)
There is a bunch of garabge from the stack after the payload.

After the fix:
![Screenshot_20201230_103946](https://user-images.githubusercontent.com/15141948/103343999-a3918800-4a8d-11eb-92fa-fcd8536d39f5.png)

(Note the dreaded trailing NL. We have to iron it out later.)