### PR TITLE
Fixed buffer overflow error when typed longer comment than at last qso

### DIFF
--- a/src/addcall.c
+++ b/src/addcall.c
@@ -93,7 +93,7 @@ int addcall(void) {
     j = getctydata(hiscall);
     worked[i].country = j;
     if (strlen(comment) >= 1) {		/* remember last exchange */
-	g_strlcpy(worked[i].exchange, comment, 12);
+	g_strlcpy(worked[i].exchange, comment, sizeof(worked[i].exchange));
 
 	if (CONTEST_IS(CQWW) || wazmult == 1 || itumult == 1) {
 	    /*

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -93,7 +93,8 @@ int addcall(void) {
     j = getctydata(hiscall);
     worked[i].country = j;
     if (strlen(comment) >= 1) {		/* remember last exchange */
-	strcpy(worked[i].exchange, comment);
+	strncpy(worked[i].exchange, comment, 12);
+	worked[i].exchange[12] = 0;
 
 	if (CONTEST_IS(CQWW) || wazmult == 1 || itumult == 1) {
 	    /*

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -93,8 +93,7 @@ int addcall(void) {
     j = getctydata(hiscall);
     worked[i].country = j;
     if (strlen(comment) >= 1) {		/* remember last exchange */
-	strncpy(worked[i].exchange, comment, 12);
-	worked[i].exchange[12] = 0;
+	g_strlcpy(worked[i].exchange, comment, 12);
 
 	if (CONTEST_IS(CQWW) || wazmult == 1 || itumult == 1) {
 	    /*

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -160,7 +160,7 @@ typedef struct {
  * contains all informations about an already worked station */
 typedef struct {
     char call[20]; 		/**< call of the station */
-    char exchange[12]; 		/**< the last exchange */
+    char exchange[13]; 		/**< the last exchange */
     int band; 			/**< bitmap for worked bands */
     int country; 		/**< its country number */
     long qsotime[3][NBANDS];	/**< last timestamp of qso in gmtime


### PR DESCRIPTION
I ran into a problem in QSO mode when I typed a longer text in the comment field than 12 chars, and the call exists in list of previous contacts (aka `worked` list).

First, the available space in the WORKED window is 12 char wide, but the declaration contains only `char[12]`, so I incremented that value to 13.

Then I changed the `strcpy` by the `strncpy`, and set the max length. Finally, I set to `\0` at the max length position in the `worked[i].exchange`.