### PR TITLE
Minor improvement of exist_in_country_list() and score.c

### DIFF
--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -170,7 +170,7 @@ extern int logfrequency;
 extern int bmautoadd;
 extern int bmautograb;
 extern int serial_or_section;
-extern int portable_x2;
+extern bool portable_x2;
 extern int clusterlog;
 extern int sprint_mode;
 extern int timeoffset;

--- a/src/main.c
+++ b/src/main.c
@@ -127,7 +127,7 @@ int exclude_multilist_type = EXCLUDE_NONE;
 bool mult_side = false;
 /* end LZ3NY mods */
 
-int portable_x2 = 0;
+bool portable_x2 = false;
 int wysiwyg_once = 0;
 int wysiwyg_multi = 0;
 int country_mult = 0;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1019,6 +1019,7 @@ static config_t logcfg_configs[] = {
     {"IGNOREDUPE",          CFG_BOOL_TRUE(ignoredupe)},
     {"USE_CONTINENTLIST_ONLY",  CFG_BOOL_TRUE(continentlist_only)},
     {"RADIO_CONTROL",           CFG_BOOL_TRUE(trx_control)},
+    {"PORTABLE_MULT_2",     CFG_BOOL_TRUE(portable_x2)},
 
     {"USEPARTIALS",     CFG_INT_ONE(use_part)},
     {"PARTIALS",        CFG_INT_ONE(partials)},
@@ -1032,7 +1033,6 @@ static config_t logcfg_configs[] = {
     {"SEND_DE",         CFG_INT_ONE(demode)},
     {"SERIAL_EXCHANGE", CFG_CONTEST_BOOL_TRUE(exchange_serial)},
     {"COUNTRY_MULT",    CFG_INT_ONE(country_mult)},
-    {"PORTABLE_MULT_2", CFG_INT_ONE(portable_x2)},
     {"CQWW_M2",         CFG_INT_ONE(cqwwm2)},
     {"LAN_DEBUG",       CFG_INT_ONE(landebug)},
     {"CALLUPDATE",      CFG_INT_ONE(call_update)},

--- a/test/data.c
+++ b/test/data.c
@@ -91,7 +91,7 @@ int exclude_multilist_type = EXCLUDE_NONE;
 bool mult_side = false;
 /* end LZ3NY mods */
 
-int portable_x2 = 0;
+bool portable_x2 = false;
 int recall_mult = 0;
 int wysiwyg_once = 0;
 int wysiwyg_multi = 0;

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -318,6 +318,7 @@ static bool_true_t bool_trues[] = {
     {"IGNOREDUPE", &ignoredupe},
     {"USE_CONTINENTLIST_ONLY", &continentlist_only},
     {"RADIO_CONTROL", &trx_control},
+    {"PORTABLE_MULT_2", &portable_x2},
 };
 
 void test_bool_trues(void **state) {
@@ -420,7 +421,6 @@ static int_one_t int_ones[] = {
     {"CHECKWINDOW", &searchflg},
     {"SEND_DE", &demode},
     {"COUNTRY_MULT", &country_mult},
-    {"PORTABLE_MULT_2", &portable_x2},
     {"CQWW_M2", &cqwwm2},
     {"LAN_DEBUG", &landebug},
     {"CALLUPDATE", &call_update},

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -19,23 +19,6 @@
 // OBJECT ../src/qrb.o
 // OBJECT ../src/setcontest.o
 
-// ===========
-// these are missing from globalvars
-extern int dupe;
-extern int cwpoints;
-extern int ssbpoints;
-extern int my_country_points;
-extern int my_cont_points;
-extern int dx_cont_points;
-extern bool countrylist_only;
-extern int countrylist_points;
-extern char countrylist[][6];
-extern bool continentlist_only;
-extern int continentlist_points;
-extern char continent_multiplier_list[7][3];
-extern int lowband_point_mult;
-extern int portable_x2;
-// ===========
 
 #define check_points(point) \
     do{ assert_int_equal(score(), point); }while(0)
@@ -93,7 +76,7 @@ int setup_default(void **state) {
     strcpy(my.continent, "EU");
 
     lowband_point_mult = 0;
-    portable_x2 = 0;
+    portable_x2 = false;
 
     return 0;
 }
@@ -233,7 +216,7 @@ void test_ssbcw(void **state) {
     bandinx = BANDINDEX_40;
     check_points(6);
 
-    portable_x2 = 1;
+    portable_x2 = true;
     check_call_points("DL3XYZ", 6);
     check_call_points("DL3XYZ/P", 12);
 


### PR DESCRIPTION
See my comment on #212 

- changed prefix match retries to a loop
  * BUT: the whole thing makes no sense as the actually called `country_found()` does not use its argument. To be fixed later on.
- increased the size of `prefix` to match the definition `char pxstr[11]`
  * use of global variable for implicit argument shall be fixed here too.

Additionally
- changed `portable_x2` to bool
- suffix match in `portable_doubles()` uses the more clear `g_str_has_suffix()`
- no point using `strncpy` in `calc_continent()`, changed to plain `strcpy`
- removed externs, also from test
- corrected typo in "weight"