### PR TITLE
Quell warnings from use of strncpy()

### DIFF
--- a/src/background_process.c
+++ b/src/background_process.c
@@ -175,7 +175,7 @@ void *background_process(void *ptr) {
 			break;
 
 		    case CLUSTERMSG:
-			strncpy(prmessage, lan_message + 2, 80);
+			memcpy(prmessage, lan_message + 2, 80);
 			if (strstr(prmessage, my.call) != NULL) {	// alert for cluster messages
 			    TLF_LOG_INFO(prmessage);
 			}
@@ -183,7 +183,7 @@ void *background_process(void *ptr) {
 			addtext(prmessage);
 			break;
 		    case TLFSPOT:
-			strncpy(prmessage, lan_message + 2, 80);
+			memcpy(prmessage, lan_message + 2, 80);
 			lanspotflg = 1;
 			addtext(prmessage);
 			lanspotflg = 0;
@@ -248,4 +248,3 @@ void *background_process(void *ptr) {
     }
 
 }
-

--- a/src/background_process.c
+++ b/src/background_process.c
@@ -176,6 +176,8 @@ void *background_process(void *ptr) {
 
 		    case CLUSTERMSG:
 			memcpy(prmessage, lan_message + 2, 80);
+			prmessage[80] = '\0';
+
 			if (strstr(prmessage, my.call) != NULL) {	// alert for cluster messages
 			    TLF_LOG_INFO(prmessage);
 			}
@@ -184,6 +186,7 @@ void *background_process(void *ptr) {
 			break;
 		    case TLFSPOT:
 			memcpy(prmessage, lan_message + 2, 80);
+			prmessage[80] = '\0';
 			lanspotflg = 1;
 			addtext(prmessage);
 			lanspotflg = 0;

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -208,7 +208,7 @@ int loadbandmap(void) {
 
 	    g_strlcpy(spotcall, thisline + 26, 6);
 
-	    strncpy(spottime, thisline + 70, 4);	// how old?
+	    memcpy(spottime, thisline + 70, 4);	// how old?
 	    spottime[4] = spottime[3];
 	    spottime[3] = spottime[2];
 	    spottime[2] = ':';
@@ -418,5 +418,3 @@ int getclusterinfo(void) {
 
     return si;
 }
-
-

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -78,6 +78,8 @@ void log_to_disk(int from_lan) {
     } else {			// qso from lan
 
 	memcpy(lan_logline, lan_message + 2, 87);
+	lan_logline[87] = '\0';
+
 	strcat(lan_logline, spaces(78));
 
 	if (cqwwm2 == 1) {

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -77,7 +77,7 @@ void log_to_disk(int from_lan) {
 	cleanup_qso();		/* reset qso related parameters */
     } else {			// qso from lan
 
-	strncpy(lan_logline, lan_message + 2, 87);
+	memcpy(lan_logline, lan_message + 2, 87);
 	strcat(lan_logline, spaces(78));
 
 	if (cqwwm2 == 1) {

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -48,23 +48,27 @@ void get_next_serial(void) {
 
     if (!log_is_comment(logline4)) {
 	memcpy(qsonrstr, logline4 + 23, 4);
+	qsonrstr[4] = '\0';
 	mm = atoi(qsonrstr);
     }
     if (!log_is_comment(logline3)) {
 	if (atoi(logline3 + 23) > mm) {
 	    memcpy(qsonrstr, logline3 + 23, 4);
+	    qsonrstr[4] = '\0';
 	    mm = atoi(qsonrstr);
 	}
     }
     if (!log_is_comment(logline2)) {
 	if (atoi(logline2 + 23) > mm) {
 	    memcpy(qsonrstr, logline2 + 23, 4);
+	    qsonrstr[4] = '\0';
 	    mm = atoi(qsonrstr);
 	}
     }
     if (!log_is_comment(logline1)) {
 	if (atoi(logline1 + 23) > mm) {
 	    memcpy(qsonrstr, logline1 + 23, 4);
+	    qsonrstr[4] = '\0';
 	    mm = atoi(qsonrstr);
 	}
     }

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -47,24 +47,24 @@ void get_next_serial(void) {
     mm = qsonum - 1;
 
     if (!log_is_comment(logline4)) {
-	strncpy(qsonrstr, logline4 + 23, 4);
+	memcpy(qsonrstr, logline4 + 23, 4);
 	mm = atoi(qsonrstr);
     }
     if (!log_is_comment(logline3)) {
 	if (atoi(logline3 + 23) > mm) {
-	    strncpy(qsonrstr, logline3 + 23, 4);
+	    memcpy(qsonrstr, logline3 + 23, 4);
 	    mm = atoi(qsonrstr);
 	}
     }
     if (!log_is_comment(logline2)) {
 	if (atoi(logline2 + 23) > mm) {
-	    strncpy(qsonrstr, logline2 + 23, 4);
+	    memcpy(qsonrstr, logline2 + 23, 4);
 	    mm = atoi(qsonrstr);
 	}
     }
     if (!log_is_comment(logline1)) {
 	if (atoi(logline1 + 23) > mm) {
-	    strncpy(qsonrstr, logline1 + 23, 4);
+	    memcpy(qsonrstr, logline1 + 23, 4);
 	    mm = atoi(qsonrstr);
 	}
     }


### PR DESCRIPTION
Poking around the Web I found:

https://github.com/libfuse/libfuse/commit/f39c71dcf99292c188bb6f0a117d7e118f92bfb1

Which states in part:

Recent GCC releases have warnings related to common strncpy(3) bugs.
These warnings can be avoided by explicitly NUL-terminating the buffer
or using memcpy(3) when the intention is to copy just the characters
without the NUL terminator.

The use of memcpy() in this context does quell the warnings but requires
testing to be sure the behavior has not changed.

The following warnings were quelled:

../../tlf/src/background_process.c: In function ‘background_process’:
../../tlf/src/background_process.c:186:4: warning: ‘strncpy’ output may be truncated copying 80 bytes from a string of length 253 [-Wstringop-truncation]
  186 |    strncpy(prmessage, lan_message + 2, 80);
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../tlf/src/background_process.c:178:4: warning: ‘strncpy’ output may be truncated copying 80 bytes from a string of length 253 [-Wstringop-truncation]
  178 |    strncpy(prmessage, lan_message + 2, 80);
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../tlf/src/clusterinfo.c: In function ‘loadbandmap’:
../../tlf/src/clusterinfo.c:211:6: warning: ‘strncpy’ output may be truncated copying 4 bytes from a string of length 12 [-Wstringop-truncation]
  211 |      strncpy(spottime, thisline + 70, 4); // how old?
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../tlf/src/log_to_disk.c: In function ‘log_to_disk’:
../../tlf/src/log_to_disk.c:80:2: warning: ‘strncpy’ output may be truncated copying 87 bytes from a string of length 253 [-Wstringop-truncation]
   80 |  strncpy(lan_logline, lan_message + 2, 87);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../tlf/src/scroll_log.c: In function ‘get_next_serial’:
../../tlf/src/scroll_log.c:50:2: warning: ‘strncpy’ output may be truncated copying 4 bytes from a string of length 65 [-Wstringop-truncation]
   50 |  strncpy(qsonrstr, logline4 + 23, 4);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../tlf/src/scroll_log.c:55:6: warning: ‘strncpy’ output may be truncated copying 4 bytes from a string of length 154 [-Wstringop-truncation]
   55 |      strncpy(qsonrstr, logline3 + 23, 4);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../tlf/src/scroll_log.c:61:6: warning: ‘strncpy’ output may be truncated copying 4 bytes from a string of length 243 [-Wstringop-truncation]
   61 |      strncpy(qsonrstr, logline2 + 23, 4);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../tlf/src/scroll_log.c:67:6: warning: ‘strncpy’ output may be truncated copying 4 bytes from a string of length 332 [-Wstringop-truncation]
   67 |      strncpy(qsonrstr, logline1 + 23, 4);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~