### PR TITLE
Use int for myrig_model

### DIFF
--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -104,7 +104,7 @@ extern int highqsonr;
 extern RIG *my_rig;
 extern cqmode_t cqmode;
 extern int trxmode;
-extern rig_model_t myrig_model;
+extern int myrig_model;
 extern rmode_t rigmode;
 extern freq_t freq;
 extern char lastqsonr[];

--- a/src/main.c
+++ b/src/main.c
@@ -318,7 +318,7 @@ int bmautoadd = 0;
 int bmautograb = 0;
 
 /*-------------------------------------rigctl-------------------------------*/
-rig_model_t myrig_model = 351;  /* Ten-Tec Omni VI Plus */
+int myrig_model = 0;            /* unset */
 RIG *my_rig;			/* handle to rig (instance) */
 rmode_t rmode;			/* radio mode of operation */
 pbwidth_t width;
@@ -700,7 +700,7 @@ void hamlib_init() {
 	return;
     }
 
-    shownr("Rig model number is", (int) myrig_model);
+    shownr("Rig model number is", myrig_model);
     shownr("Rig speed is", serial_rate);
 
     showmsg("Trying to start rig control");

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -74,14 +74,14 @@ int read_logcfg(void) {
 	    showstring("Error opening config file: ", config_file);
 	    return PARSE_ERROR;
 	}
-    }else {
+    } else {
 	config_file = g_strdup(LOGCFG_DAT_FILE);
 
 	if (access(config_file, R_OK) == -1) {
 	    showmsg("No logcfg.dat found. Copying default config file.");
 	    showmsg("Please adapt the settings to your needs.");
 	    char *cmd = g_strdup_printf("cp %s %s", defltconf,
-		    LOGCFG_DAT_FILE);
+					LOGCFG_DAT_FILE);
 	    IGNORE(system(cmd));
 	    g_free(cmd);
 	    sleep(2);
@@ -1118,7 +1118,7 @@ static config_t logcfg_configs[] = {
     {"CWPOINTS",        CFG_INT(cwpoints, 0, INT32_MAX)},
     {"WEIGHT",          CFG_INT(weight, -50, 50)},
     {"TXDELAY",         CFG_INT(txdelay, 0, 50)},
-    {"RIGMODEL",        CFG_INT(myrig_model, 0, 9999)},
+    {"RIGMODEL",        CFG_INT(myrig_model, 0, 99999)},
     {"COUNTRY_LIST_POINTS", CFG_INT(countrylist_points, 0, INT32_MAX)},
     {"MY_COUNTRY_POINTS",   CFG_INT(my_country_points, 0, INT32_MAX)},
     {"MY_CONTINENT_POINTS", CFG_INT(my_cont_points, 0, INT32_MAX)},

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -73,10 +73,10 @@ int init_tlf_rig(void) {
     /*
      * allocate memory, setup & open port
      */
-    my_rig = rig_init(myrig_model);
+    my_rig = rig_init((rig_model_t) myrig_model);
 
     if (!my_rig) {
-	shownr("Unknown rig model", (int) myrig_model);
+	shownr("Unknown rig model", myrig_model);
 	return -1;
     }
 


### PR DESCRIPTION
To avoid warning in `parse_logcfg`. Also extended the range to match Hamlib4 rig numbering. (and dropped the default value as it's invalid anyway after the numbering change)