### PR TITLE
Quell clang warning from cqww_similator.c

### DIFF
--- a/src/cqww_simulator.c
+++ b/src/cqww_simulator.c
@@ -149,10 +149,19 @@ void cqww_simulator(void) {
 	strcpy(callcpy, CALLMASTERARRAY(callnumber));
 	getctydata(callcpy);
 
-	char *str = g_strdup_printf("%s%s%s",
-				    "---" + 3 - slow,
+	/* Use the precision format specifier to set the number of '-' or '+'
+	 * characters prepended and appended to the callsign.
+	 *
+	 * See https://stackoverflow.com/a/16299867
+	 * and "man 3 printf"
+	 * for format explanation.
+	 */
+	char *str = g_strdup_printf("%.*s%s%.*s",
+				    3 - slow,
+				    "---",
 				    CALLMASTERARRAY(callnumber),
-				    "+++" + 3 - slow);
+				    3 - slow,
+				    "+++");
 	sendmessage(str);
 	write_keyer();
 


### PR DESCRIPTION
Quell the following warning using the precision flag of printf(3):

  CC       cqww_simulator.o
../../tlf/src/cqww_simulator.c:153:15: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                                    "---" + 3 - slow,
                                    ~~~~~~^~~
../../tlf/src/cqww_simulator.c:153:15: note: use array indexing to silence this warning
                                    "---" + 3 - slow,
                                          ^
                                    &     [  ]
../../tlf/src/cqww_simulator.c:155:15: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                                    "+++" + 3 - slow);
                                    ~~~~~~^~~
../../tlf/src/cqww_simulator.c:155:15: note: use array indexing to silence this warning
                                    "+++" + 3 - slow);
                                          ^
                                    &     [  ]
2 warnings generated.