### PR TITLE
:INFo shows cty.dat version

### DIFF
--- a/src/changepars.c
+++ b/src/changepars.c
@@ -35,6 +35,7 @@
 #include "cqww_simulator.h"
 #include "changepars.h"
 #include "clear_display.h"
+#include "dxcc.h"
 #include "editlog.h"
 #include "err_utils.h"
 #include "fldigixmlrpc.h"
@@ -330,7 +331,7 @@ int changepars(void) {
 	    read_logcfg();
 	    read_rules();	/* also reread rules file */
 	    TLF_LOG_INFO("Logcfg.dat loaded, parameters written.");
-            center_fkey_header();
+	    center_fkey_header();
 	    clear_display();
 	    break;
 	}
@@ -709,6 +710,9 @@ void networkinfo(void) {
 	mvprintw(12 + nodes, 10, "Band output: on");
     else
 	mvprintw(12 + nodes, 10, "Band output: off");
+
+    mvprintw(13 + nodes, 10, "cty.dat    : %s",
+	     (cty_dat_version[0] != 0 ? cty_dat_version : "n/a"));
 
     refreshp();
 

--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -31,6 +31,7 @@
 GPtrArray *dxcc;
 GPtrArray *prefix;
 bool have_exact_matches;
+char cty_dat_version[12];   // VERyyyymmdd
 
 prefix_data dummy_pfx = {
     "No Prefix",
@@ -76,6 +77,12 @@ prefix_data *prefix_by_index(unsigned int index) {
 
 /* add a new prefix description */
 void prefix_add(char *pfxstr) {
+
+    char *ver = (*pfxstr == '=' ? pfxstr + 1 : pfxstr);
+    if (strlen(ver) == 11 && strncmp(ver, "VER", 3) == 0) {
+	strcpy(cty_dat_version, ver);    // save it
+    }
+
     gchar *loc;
     gint last_index = dxcc_count() - 1;
     dxcc_data *last_dx = dxcc_by_index(last_index);
@@ -148,6 +155,7 @@ void dxcc_free(gpointer data) {
 }
 
 void dxcc_init(void) {
+    cty_dat_version[0] = 0;
     if (dxcc) {
 	g_ptr_array_free(dxcc, TRUE);
     }

--- a/src/dxcc.h
+++ b/src/dxcc.h
@@ -48,6 +48,7 @@ typedef struct {
 } dxcc_data;
 
 extern bool have_exact_matches;
+extern char cty_dat_version[12];
 
 void prefix_init(void);
 


### PR DESCRIPTION
Recently came across this: https://www.country-files.com/contest/#Version

> In the list of prefixes/callsigns, you’ll find a “callsign” that looks like:VERyyyymmdd where “yyyymmdd” is the date of the release.


This is now stored and can be displayed with :INFo.

![image](https://user-images.githubusercontent.com/15141948/106806210-f3083c80-6667-11eb-94ad-335e255669fb.png)

The other method works too, that needs no change. (enter VERSION and check the country)

![image](https://user-images.githubusercontent.com/15141948/106806379-2ea30680-6668-11eb-9622-c5c74d8d73df.png)


