### PR TITLE
Speedup find_best_match function

### DIFF
--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -81,6 +81,15 @@ prefix_data *prefix_by_index(unsigned int index) {
     return (prefix_data *)g_ptr_array_index(prefix, index);
 }
 
+/* lookup key in table of hashed prefixes
+ * \return - true, if found in HashTable
+ * \param key - part of call to look up
+ * \param value - the corresponding prefix index
+ */
+gboolean lookup_hashed_prefix(const char *key, void *value) {
+    return g_hash_table_lookup_extended(hashed_prefix, key, NULL, value);
+}
+
 /* add a new prefix description */
 void prefix_add(char *pfxstr) {
 

--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -30,6 +30,7 @@
 
 GPtrArray *dxcc;
 GPtrArray *prefix;
+GHashTable *hashed_prefix;
 bool have_exact_matches;
 char cty_dat_version[12];   // VERyyyymmdd
 
@@ -56,6 +57,11 @@ void prefix_free(gpointer data) {
 
 
 void prefix_init(void) {
+    if (hashed_prefix) {
+	g_hash_table_destroy(hashed_prefix);
+    }
+    hashed_prefix = g_hash_table_new(g_str_hash, g_str_equal);
+
     if (prefix) {
 	g_ptr_array_free(prefix, TRUE);
     }
@@ -141,6 +147,9 @@ void prefix_add(char *pfxstr) {
     new_prefix -> dxcc_index = last_index;
 
     g_ptr_array_add(prefix, new_prefix);
+    g_hash_table_insert(hashed_prefix,
+	    new_prefix->pfx,
+	    GINT_TO_POINTER(prefix_count() - 1));
 }
 
 

--- a/src/dxcc.h
+++ b/src/dxcc.h
@@ -22,6 +22,7 @@
 #define DXCC_H
 
 #include <stdbool.h>
+#include <glib.h>
 
 typedef struct {
     char *pfx;
@@ -55,6 +56,8 @@ void prefix_init(void);
 unsigned int prefix_count(void);
 
 prefix_data *prefix_by_index(unsigned int index);
+
+gboolean lookup_hashed_prefix(const char *key, void *value);
 
 void prefix_add(char *pfxstr);
 

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -59,34 +59,34 @@ int find_full_match(const char *call) {
 
 /* search for the best mach of 'call' in pfx table */
 int find_best_match(const char *call) {
-    int bestlen = 0;
-    int i, w;
-    prefix_data *pfx;
-    int pfxmax = prefix_count();
+    void *value;
+    int w = -1;
 
-    w = -1;
-    for (i = 0; i < pfxmax; i++) {
-	int l;
-	pfx = prefix_by_index(i);
-	if (pfx->exact) {
-	    if (strcmp(call, pfx->pfx) == 0) {
-		w = i;
+    if (call == NULL)
+	return w;
+
+    /* first try full match */
+    if (g_hash_table_lookup_extended(hashed_prefix, call, NULL, &value)) {
+	w = GPOINTER_TO_INT(value);
+	return w;
+    }
+
+    /* stepwise shorten the call and pick up first one -> maximum length
+     * Be careful to not use entries which require an exact match
+     */
+    for (int i = strlen(call) - 1; i > 0; i--) {
+	char *temp = g_strndup(call, i);
+	if (g_hash_table_lookup_extended(hashed_prefix, temp, NULL, &value)) {
+	    int idx = GPOINTER_TO_INT(value);
+	    if (!prefix_by_index(idx)->exact) {
+		w = idx;
+		g_free(temp);
 		break;
 	    }
-	    continue;
 	}
-	if (*pfx->pfx != call[0])
-	    continue;
-
-	l = strlen(pfx->pfx);
-	if (l <= bestlen)
-	    continue;
-
-	if (strncmp(pfx->pfx, call, l) == 0) {
-	    bestlen = l;
-	    w = i;
-	}
+	g_free(temp);
     }
+
     return w;
 }
 

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -42,22 +42,17 @@ int location_unknown(const char *call) {
 				(GRegexCompileFlags)0, (GRegexMatchFlags)0);
 }
 
+extern GHashTable *hashed_prefix;
+
 /* search for a full match of 'call' in the pfx table */
 int find_full_match(const char *call) {
-    int i, w;
-    prefix_data *pfx;
-    int pfxmax = prefix_count();
+    void *value;
+    int  w = -1;
 
-    w = -1;
-    for (i = 0; i < pfxmax; i++) {
-	pfx = prefix_by_index(i);
-	if (have_exact_matches && !pfx->exact)
-	    continue;
-	if (strcmp(call, pfx->pfx) == 0) {
-	    w = i;
-	    break;
-	}
+    if (g_hash_table_lookup_extended(hashed_prefix, call, NULL, &value)) {
+	w = GPOINTER_TO_INT(value);
     }
+
     return w;
 }
 

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -42,14 +42,12 @@ int location_unknown(const char *call) {
 				(GRegexCompileFlags)0, (GRegexMatchFlags)0);
 }
 
-extern GHashTable *hashed_prefix;
-
 /* search for a full match of 'call' in the pfx table */
 int find_full_match(const char *call) {
     void *value;
     int  w = -1;
 
-    if (g_hash_table_lookup_extended(hashed_prefix, call, NULL, &value)) {
+    if (lookup_hashed_prefix(call, &value)) {
 	w = GPOINTER_TO_INT(value);
     }
 
@@ -66,7 +64,7 @@ int find_best_match(const char *call) {
 	return w;
 
     /* first try full match */
-    if (g_hash_table_lookup_extended(hashed_prefix, call, NULL, &value)) {
+    if (lookup_hashed_prefix(call, &value)) {
 	w = GPOINTER_TO_INT(value);
 	return w;
     }
@@ -76,7 +74,7 @@ int find_best_match(const char *call) {
      */
     for (int i = strlen(call) - 1; i > 0; i--) {
 	char *temp = g_strndup(call, i);
-	if (g_hash_table_lookup_extended(hashed_prefix, temp, NULL, &value)) {
+	if (lookup_hashed_prefix(temp, &value)) {
 	    int idx = GPOINTER_TO_INT(value);
 	    if (!prefix_by_index(idx)->exact) {
 		w = idx;

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -73,6 +73,8 @@ void test_best_match(void **state) {
     assert_string_equal(best_prefix("4U1U"), "");;
     assert_string_equal(best_prefix("EA3XYZ"), "EA");
     assert_string_equal(best_prefix("EA8XYZ"), "EA8");
+    assert_string_equal(best_prefix("W3A"), "W");
+    assert_string_equal(best_prefix("KL7ND"), "KL");
 }
 
 void test_location_known(void **state) {

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -17,6 +17,8 @@
 /* export internal function */
 int location_unknown(char *call);
 int getpfxindex(char *checkcallptr, char **normalized_call);
+int find_full_match(const char *call);
+int find_best_match(const char *call);
 
 extern char countrylist[255][6];
 
@@ -32,6 +34,45 @@ int setup_default(void **state) {
     strcpy(countrylist[0], "");
 
     return 0;
+}
+
+char *best_prefix(char *call) {
+    prefix_data *pfx;
+    int index;
+
+    index = find_best_match(call);
+    if (index < 0)
+	return "";
+
+    pfx = prefix_by_index(index);
+    return pfx->pfx;
+}
+
+char *full_prefix(char * call) {
+    prefix_data *pfx;
+    int index;
+
+    index = find_full_match(call);
+    if (index < 0)
+	return "";
+
+    pfx = prefix_by_index(index);
+    return pfx->pfx;
+}
+
+void test_full_match(void **state) {
+    assert_string_equal(full_prefix("DL1XXX"), "");
+    assert_string_equal(full_prefix("4U1UN"), "4U1UN");
+    assert_string_equal(full_prefix("4U1U"), "");
+}
+
+void test_best_match(void **state) {
+    assert_string_equal(best_prefix("DL1XXX"), "DL");
+    assert_string_equal(best_prefix("4U1UN"), "4U1UN");
+    assert_string_equal(best_prefix("4U1UNA"), "");;
+    assert_string_equal(best_prefix("4U1U"), "");;
+    assert_string_equal(best_prefix("EA3XYZ"), "EA");
+    assert_string_equal(best_prefix("EA8XYZ"), "EA8");
 }
 
 void test_location_known(void **state) {


### PR DESCRIPTION
Add a HashTable to prefix database to speedup lookup of station prefixes.

Using cluster for bandmap and/or xplanet display consumed a major part of time in find_best_function().
With the new lookup mechanism the time for these operation nearly vanished.