### PR TITLE
Extend Multi check for bandmap display

### DIFF
--- a/src/addpfx.c
+++ b/src/addpfx.c
@@ -43,6 +43,44 @@ struct {
 
 unsigned int pfxs_per_band[NBANDS] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
+/** lookup worked prefix and return index in prefixes_worked[] or
+ * -1 if not found
+ */
+int find_worked_pfx(char *prefix) {
+    int found = -1;
+
+    for (int i = 0; i < nr_of_px; i++) {
+	if (strcmp(prefix, prefixes_worked[i].pfx) == 0) {
+	    found = i;
+	    break;
+	}
+    }
+
+    return found;
+}
+
+bool pfx_is_new(char * prefix) {
+    return (find_worked_pfx(prefix) == -1);
+}
+
+
+bool pfx_is_new_on(char *prefix, int bandindex) {
+    int index;
+    int worked_bands;
+
+    index = find_worked_pfx(prefix);
+
+    if (index == -1)
+	return true;
+
+    worked_bands = prefixes_worked[index].bands;
+    if ((worked_bands & inxes[bandindex]) == 0)
+	return true;
+
+    return false;
+}
+
+
 int add_pfx(char *pxstr, unsigned int bandindex) {
     extern int pfxmultab;
     int q = 0, found = 0, bandfound = 0;

--- a/src/addpfx.c
+++ b/src/addpfx.c
@@ -59,7 +59,7 @@ int find_worked_pfx(char *prefix) {
     return found;
 }
 
-bool pfx_is_new(char * prefix) {
+bool pfx_is_new(char *prefix) {
     return (find_worked_pfx(prefix) == -1);
 }
 

--- a/src/addpfx.c
+++ b/src/addpfx.c
@@ -46,7 +46,7 @@ unsigned int pfxs_per_band[NBANDS] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 /** lookup worked prefix and return index in prefixes_worked[] or
  * -1 if not found
  */
-int find_worked_pfx(char *prefix) {
+static int find_worked_pfx(char *prefix) {
     int found = -1;
 
     for (int i = 0; i < nr_of_px; i++) {

--- a/src/addpfx.h
+++ b/src/addpfx.h
@@ -21,6 +21,10 @@
 #ifndef ADDPFX_H
 #define ADDPFX_H
 
+#include <stdbool.h>
+
+bool pfx_is_new(char * prefix);
+bool pfx_is_new_on(char *prefix, int bandindex);
 int add_pfx(char *pxstr, unsigned int bandindex);
 unsigned int GetNrOfPfx_once();
 unsigned int GetNrOfPfx_multiband();

--- a/src/addpfx.h
+++ b/src/addpfx.h
@@ -23,7 +23,7 @@
 
 #include <stdbool.h>
 
-bool pfx_is_new(char * prefix);
+bool pfx_is_new(char *prefix);
 bool pfx_is_new_on(char *prefix, int bandindex);
 int add_pfx(char *pxstr, unsigned int bandindex);
 unsigned int GetNrOfPfx_once();

--- a/src/background_process.c
+++ b/src/background_process.c
@@ -198,7 +198,7 @@ void *background_process(void *ptr) {
 			talkarray[4][1] = ':';
 			talkarray[4][2] = '\0';
 			g_strlcat(talkarray[4], lan_message + 2,
-				sizeof(talkarray[4]));
+				  sizeof(talkarray[4]));
 			TLF_LOG_INFO(" MSG from %s", talkarray[4]);
 			break;
 		    case FREQMSG:

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -447,17 +447,17 @@ void bandmap_age() {
  *
  * \return true if new multi
  */
-bool bm_ismulti(spot *data, int band) {
+bool bm_ismulti(spot *data) {
 
     if (data == NULL || data->cqzone <= 0 || data->ctynr <= 0) {
 	return false;   // no data
     }
 
     if (contest->is_multi) {
-	return contest->is_multi(data, band);
+	return contest->is_multi(data);
     }
 
-    return general_ismulti(data, band);
+    return general_ismulti(data);
 }
 
 
@@ -594,7 +594,7 @@ void show_spot(spot *data) {
     printw("%7.1f%c", (data->freq / 1000.),
 	   (data->node == thisnode ? '*' : data->node));
 
-    if (bm_ismulti(data, data->band)) {
+    if (bm_ismulti(data)) {
 	attrset(COLOR_PAIR(CB_NORMAL));
 	printw("M");
 	attrset(COLOR_PAIR(CB_DUPE) | A_BOLD);
@@ -616,7 +616,7 @@ void show_spot_on_qrg(spot *data) {
 
     printw("%7.1f%c%c ", (data->freq / 1000.),
 	   (data->node == thisnode ? '*' : data->node),
-	   bm_ismulti(data, data->band) ? 'M' : ' ');
+	   bm_ismulti(data) ? 'M' : ' ');
 
     char *temp = format_spot(data);
     printw("%-12s", temp);
@@ -707,7 +707,7 @@ void filter_spots() {
 	    continue;
 
 	/* Ignore non-multis if we want to show only multis */
-	multi = bm_ismulti(data, data->band);
+	multi = bm_ismulti(data);
 	if (!multi && bm_config.onlymults)
 	    continue;
 

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -457,7 +457,7 @@ bool bm_ismulti(spot *data, int band) {
 	return contest->is_multi(data, band);
     }
 
-    return false;
+    return general_ismulti(data, band);
 }
 
 

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -447,17 +447,14 @@ void bandmap_age() {
  *
  * \return true if new multi
  */
-bool bm_ismulti(char *call, spot *data, int band) {
+bool bm_ismulti(spot *data, int band) {
 
     if (data == NULL || data->cqzone <= 0 || data->ctynr <= 0) {
 	return false;   // no data
     }
 
-    if (CONTEST_IS(CQWW)) {
-	if ((zones[data->cqzone] & inxes[band]) == 0
-		|| (countries[data->ctynr] & inxes[band]) == 0) {
-	    return true;
-	}
+    if (contest->is_multi) {
+	return contest->is_multi(data, band);
     }
 
     return false;
@@ -597,7 +594,7 @@ void show_spot(spot *data) {
     printw("%7.1f%c", (data->freq / 1000.),
 	   (data->node == thisnode ? '*' : data->node));
 
-    if (bm_ismulti(NULL, data, data->band)) {
+    if (bm_ismulti(data, data->band)) {
 	attrset(COLOR_PAIR(CB_NORMAL));
 	printw("M");
 	attrset(COLOR_PAIR(CB_DUPE) | A_BOLD);
@@ -619,7 +616,7 @@ void show_spot_on_qrg(spot *data) {
 
     printw("%7.1f%c%c ", (data->freq / 1000.),
 	   (data->node == thisnode ? '*' : data->node),
-	   bm_ismulti(NULL, data, data->band) ? 'M' : ' ');
+	   bm_ismulti(data, data->band) ? 'M' : ' ');
 
     char *temp = format_spot(data);
     printw("%-12s", temp);
@@ -710,7 +707,7 @@ void filter_spots() {
 	    continue;
 
 	/* Ignore non-multis if we want to show only multis */
-	multi = bm_ismulti(NULL, data, data->band);
+	multi = bm_ismulti(data, data->band);
 	if (!multi && bm_config.onlymults)
 	    continue;
 

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -271,10 +271,10 @@ gint	cmp_freq(spot *a, spot *b) {
 }
 
 /* free an allocated spot */
-void free_spot(spot * data) {
-	g_free(data->call);
-	g_free(data->pfx);
-	g_free(data);
+void free_spot(spot *data) {
+    g_free(data->call);
+    g_free(data->pfx);
+    g_free(data);
 }
 
 /** add a new spot to bandmap data
@@ -691,7 +691,7 @@ void filter_spots() {
     spots = g_ptr_array_new_full(128, (GDestroyNotify)free_spot);
 
 
-    for(list = allspots; list; list = list->next)	{
+    for (list = allspots; list; list = list->next)	{
 	data = list->data;
 
 	/* check and mark spot as dupe */
@@ -714,8 +714,8 @@ void filter_spots() {
 	/* if spot is allband or allmode is set or band or mode matches
 	 * than add to the filtered 'spot' array
 	 */
-	if ( (bm_config.allband || band_matches(data)) &&
-	    (bm_config.allmode || mode_matches(data))) {
+	if ((bm_config.allband || band_matches(data)) &&
+		(bm_config.allmode || mode_matches(data))) {
 
 	    spot *copy = copy_spot(data);
 	    g_ptr_array_add(spots, copy);

--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -62,7 +62,7 @@ enum {
 };
 
 /* free an allocated spot */
-void free_spot(spot * data);
+void free_spot(spot *data);
 
 /*
  * write bandmap spots to a file

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -173,8 +173,8 @@ void show_xplanet() {
 	return;
     }
 
-    memset (spot_age, '\0', sizeof(spot_age));
-    memset (spot_band, '\0', sizeof(spot_band));
+    memset(spot_age, '\0', sizeof(spot_age));
+    memset(spot_band, '\0', sizeof(spot_band));
 
     for (i = 0; i < MAX_SPOTS; i++) {
 	if (bandmap[i] != NULL) {
@@ -257,9 +257,10 @@ void show_xplanet() {
 	    int ctynr;
 	    char *color;
 	    static char *bandcolor[NBANDS] = {"Red", "Magenta", "Cyan",
-		    "Yellow", "Cyan", "Blue",
-		    "Cyan", "White", "Cyan",
-		    "Green", NULL };
+					      "Yellow", "Cyan", "Blue",
+					      "Cyan", "White", "Cyan",
+					      "Green", NULL
+					     };
 
 	    strncpy(callcopy, bandmap[j] + 26, 16);	// call
 	    for (int m = 0; m < 16; m++) {
@@ -271,7 +272,7 @@ void show_xplanet() {
 
 	    ctynr = getctynr(callcopy);		// CTY of station
 
-	    if (ctynr != 0 ) {
+	    if (ctynr != 0) {
 		/* show no callsign if MARKERDOTS */
 		if (xplanet == MARKER_DOTS)
 		    callcopy[0] = '\0';

--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -340,7 +340,7 @@ int load_ctydata(char *filename) {
     dxcc_init();
     prefix_init();
 
-    // set default for empty country
+    // set default for empty country == country nr 0
     dxcc_add("Not Specified        :    --:  --:  --:  -00.00:    00.00:     0.0:     :");
 
     while (fgets(buf, sizeof(buf), fd) != NULL) {

--- a/src/focm.c
+++ b/src/focm.c
@@ -31,7 +31,9 @@
 #include "ui_utils.h"
 #include "bands.h"
 
-
+bool no_multi() {
+    return false;
+}
 
 struct pos {
     int column;
@@ -57,7 +59,8 @@ contest_config_t config_focm = {
     .points = {
 	.type = FUNCTION,
 	.fn = score_foc
-    }
+    },
+    .is_multi = no_multi,
 };
 
 /** calculate score for last QSO

--- a/src/getpx.c
+++ b/src/getpx.c
@@ -60,17 +60,24 @@ int letters_only(const char *call) {
     return 1;
 }
 
-void getpx(char *checkcall) {
-    char pxbuffer[16] = "";
-    int i, len;
+/* parses checkcall string and returns new allocated buffer with
+ * separated prefix string
+ * ATTENTION: needs to be freed afterwards
+ */
+char *get_pfx(char *checkcall) {
+    int i;
     char portable = '\0';
+    char *pxbuffer;
+
+    int len = strlen(checkcall);
 
     if (letters_only(checkcall)) {
+	pxbuffer = g_malloc0(len + 1 + 1);
 	/* only characters in call */
 	strncpy(pxbuffer, checkcall, 2);
 	strcat(pxbuffer, "0");
     } else {
-	len = strlen(checkcall);
+	pxbuffer = g_malloc0(len + 1);
 	if (len >= 2) {
 	    if ((checkcall[len - 2] == '/') && isdigit(checkcall[len - 1]))
 		/*  portable /3 */
@@ -96,5 +103,11 @@ void getpx(char *checkcall) {
 	if (isalpha(pxbuffer[i - 1]))
 	    pxbuffer[i] = '0';
     }
-    strcpy(pxstr, pxbuffer);
+    return pxbuffer;
+}
+
+void getpx(char *checkcall) {
+    char *buffer = get_pfx(checkcall);
+    strcpy(pxstr, buffer);
+    g_free(buffer);
 }

--- a/src/getpx.h
+++ b/src/getpx.h
@@ -21,6 +21,7 @@
 #ifndef GETPX_H
 #define GETPX_H
 
+char *get_pfx(char *checkcall);
 void getpx(char *checkcall);
 
 #endif /* GETPX_H */

--- a/src/main.c
+++ b/src/main.c
@@ -344,7 +344,7 @@ int nr_worked = 0;		/**< number of calls in worked[] */
 worked_t worked[MAX_CALLS]; 	/**< worked stations */
 
 /*----------------------statistic of worked countries,zones ... -----------*/
-int countries[MAX_DATALINES];	/* per country bit fieldwith worked bands set */
+int countries[MAX_DATALINES];	/* per country field with worked bands set */
 int zones[MAX_ZONES];		/* same for cq zones or itu zones;
 				   using 1 - 40 or 1 - 90 */
 

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -233,14 +233,14 @@ void prepare_specific_part(void) {
 
     if (CONTEST_IS(ARRL_SS)) {
 	// ----------------------------arrlss----------------
-	tmp = g_strndup(ssexchange,22);
+	tmp = g_strndup(ssexchange, 22);
 	strcat(logline4, tmp);
 	g_free(tmp);
 	section[0] = '\0';
 
     } else if (serial_section_mult == 1) {
 	//-------------------------serial_section---------------
-	tmp = g_strndup(comment,22);
+	tmp = g_strndup(comment, 22);
 	strcat(logline4, tmp);
 	g_free(tmp);
 	section[0] = '\0';
@@ -261,7 +261,7 @@ void prepare_specific_part(void) {
 
     } else if (sectn_mult == 1) {
 	//-------------------------section only---------------
-	tmp = g_strndup(comment,22);
+	tmp = g_strndup(comment, 22);
 	strcat(logline4, tmp);
 	g_free(tmp);
 	section[0] = '\0';
@@ -280,11 +280,11 @@ void prepare_specific_part(void) {
 	    comment[4] = 'X';
 	    comment[5] = '\0';
 	}
-	tmp = g_strndup(comment,22);
+	tmp = g_strndup(comment, 22);
 	strcat(logline4, tmp);
 	g_free(tmp);
     } else {	//----------------------end cqww ---------------
-	tmp = g_strndup(comment,22);
+	tmp = g_strndup(comment, 22);
 	strcat(logline4, tmp);
 	g_free(tmp);
     }

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -774,8 +774,6 @@ int load_callmaster(void) {
 
     if ((cfp = fopen(callmaster_location, "r")) == NULL) {
 	g_free(callmaster_location);
-	g_ptr_array_free(callmaster, TRUE);
-	callmaster = NULL;
 	TLF_LOG_WARN("Error opening callmaster file.");
 	return 0;
     }

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -30,6 +30,7 @@
 #include "bands.h"
 #include "focm.h"
 #include "getctydata.h"
+#include "getpx.h"
 #include "globalvars.h"
 #include "setcontest.h"
 #include "score.h"
@@ -39,6 +40,18 @@
  * Code works also for modes with no multiplier at all */
 static bool no_multi(spot *data) {
     return false;
+}
+
+
+static bool wpx_ismulti(spot *data) {
+    bool multi = false;
+    int band = data->band;
+    char *call = data->call;
+
+    char *prefix = get_pfx(call);
+    // lookup prefix and check if new on band
+    g_free(prefix);
+    return multi;
 }
 
 static bool cqww_ismulti(spot *data) {

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -43,16 +43,25 @@ static bool no_multi(spot *data) {
     return false;
 }
 
-static bool wpx_ismulti(spot *data) {
-    bool multi = false;
+
+static bool pfx_on_band_ismulti(spot *data) {
     int band = data->band;
     char *call = data->call;
 
     char *prefix = get_pfx(call);
-    multi = pfx_is_new_on(prefix, band);
+    bool multi = pfx_is_new_on(prefix, band);
     g_free(prefix);
     return multi;
 }
+
+
+static bool wpx_ismulti(spot *data) {
+    char *prefix = get_pfx(data->call);
+    bool multi = pfx_is_new(prefix);
+    g_free(prefix);
+    return multi;
+}
+
 
 static bool cqww_ismulti(spot *data) {
     int band = data->band;
@@ -91,7 +100,13 @@ bool general_ismulti(spot *data) {
 	return ((countries[data->ctynr] & inxes[band]) == 0);
     }
 
-    /* TODO: pfxmultab is missing */
+    if (pfxmult == 1) {
+	return wpx_ismulti(data);
+    }
+
+    if (pfxmultab == 1) {
+	return pfx_on_band_ismulti(data);
+    }
 
     if ((itumult == 1) || (wazmult == 1)) {
 	return ((zones[data->cqzone] & inxes[band]) == 0);

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -74,10 +74,10 @@ bool general_ismulti(spot *data, int band) {
 	return ((countries[data->ctynr] & inxes[band]) == 0);
     }
 
-    /* TODO: pfxmultab */
+    /* TODO: pfxmultab is missing */
 
     if ((itumult == 1) || (wazmult == 1)) {
-	return ((zones[data->cqzone] && inxes[band]) == 0);
+	return ((zones[data->cqzone] & inxes[band]) == 0);
     }
 
     return false;

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -37,11 +37,12 @@
 
 /* contests where multiplier get determined from comment field can not be
  shown in bandmap works also for modes with no multiplier at all */
-static bool no_multi(spot *data, int band) {
+static bool no_multi(spot *data) {
     return false;
 }
 
-static bool cqww_ismulti(spot *data, int band) {
+static bool cqww_ismulti(spot *data) {
+    int band = data->band;
 
     if ((zones[data->cqzone] & inxes[band]) == 0
 	    || (countries[data->ctynr] & inxes[band]) == 0) {
@@ -51,8 +52,9 @@ static bool cqww_ismulti(spot *data, int band) {
     return false;
 }
 
-static bool arrldx_usa_ismulti(spot *data, int band)  {
+static bool arrldx_usa_ismulti(spot *data)  {
     int ctynr = data->ctynr;
+    int band = data->band;
 
     if ((countries[ctynr] & inxes[band]) != 0)
 	return false;
@@ -64,10 +66,12 @@ static bool arrldx_usa_ismulti(spot *data, int band)  {
 }
 
 
-bool general_ismulti(spot *data, int band) {
+bool general_ismulti(spot *data) {
+    int band = data->band;
+
     if (dx_arrlsections == 1) {
-	/* no evaluation of sections, only country */
-	return arrldx_usa_ismulti(data, band);
+	/* no evaluation of sections, check only country */
+	return arrldx_usa_ismulti(data);
     }
 
     if (country_mult == 1) {

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -54,13 +54,15 @@ contest_config_t config_unknown = {
 
 contest_config_t config_qso = {
     .id = QSO,
-    .name = QSO_MODE
+    .name = QSO_MODE,
+    .is_multi = NULL,
 };
 
 contest_config_t config_dxped = {
     .id = DXPED,
     .name = "DXPED",
     .recall_mult = true,
+    .is_multi = NULL,
 };
 
 contest_config_t config_wpx = {
@@ -69,7 +71,8 @@ contest_config_t config_wpx = {
     .points = {
 	.type = FUNCTION,
 	.fn = score_wpx,
-    }
+    },
+    // .ismulti
 };
 
 contest_config_t config_cqww = {
@@ -89,7 +92,8 @@ contest_config_t config_sprint = {
     .points = {
 	.type = FIXED,
 	.point = 1,
-    }
+    },
+    .is_multi = NULL,
 };
 
 contest_config_t config_arrldx_usa = {
@@ -129,7 +133,8 @@ contest_config_t config_arrl_fd = {
     .points = {
 	.type = FUNCTION,
 	.fn = score_arrlfd,
-    }
+    },
+    .is_multi = NULL,
 };
 
 contest_config_t config_pacc_pa = {
@@ -147,7 +152,8 @@ contest_config_t config_stewperry = {
     .points = {
 	.type = FUNCTION,
 	.fn = score_stewperry
-    }
+    },
+    .is_multi = NULL,
 };
 
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "addpfx.h"
 #include "bandmap.h"
 #include "bands.h"
 #include "focm.h"
@@ -42,14 +43,13 @@ static bool no_multi(spot *data) {
     return false;
 }
 
-
 static bool wpx_ismulti(spot *data) {
     bool multi = false;
     int band = data->band;
     char *call = data->call;
 
     char *prefix = get_pfx(call);
-    // lookup prefix and check if new on band
+    multi = pfx_is_new_on(prefix, band);
     g_free(prefix);
     return multi;
 }
@@ -128,7 +128,7 @@ contest_config_t config_wpx = {
 	.type = FUNCTION,
 	.fn = score_wpx,
     },
-    // .ismulti
+    .is_multi = wpx_ismulti,
 };
 
 contest_config_t config_cqww = {

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -35,7 +35,13 @@
 #include "score.h"
 #include "tlf.h"
 
-bool cqww_ismulti(spot *data, int band) {
+/* contests where multiplier get determined from comment field can not be
+ shown in bandmap works also for modes with no multiplier at all */
+static bool no_multi(spot *data, int band) {
+    return false;
+}
+
+static bool cqww_ismulti(spot *data, int band) {
 
     if ((zones[data->cqzone] & inxes[band]) == 0
 	    || (countries[data->ctynr] & inxes[band]) == 0) {
@@ -44,6 +50,39 @@ bool cqww_ismulti(spot *data, int band) {
 
     return false;
 }
+
+static bool arrldx_usa_ismulti(spot *data, int band)  {
+    int ctynr = data->ctynr;
+
+    if ((countries[ctynr] & inxes[band]) != 0)
+	return false;
+
+    if (ctynr == w_cty || ctynr == ve_cty)
+	return false;
+
+    return true;
+}
+
+
+bool general_ismulti(spot *data, int band) {
+    if (dx_arrlsections == 1) {
+	/* no evaluation of sections, only country */
+	return arrldx_usa_ismulti(data, band);
+    }
+
+    if (country_mult == 1) {
+	return ((countries[data->ctynr] & inxes[band]) == 0);
+    }
+
+    /* TODO: pfxmultab */
+
+    if ((itumult == 1) || (wazmult == 1)) {
+	return ((zones[data->cqzone] && inxes[band]) == 0);
+    }
+
+    return false;
+}
+
 
 
 /* configurations for supported contest */
@@ -55,14 +94,14 @@ contest_config_t config_unknown = {
 contest_config_t config_qso = {
     .id = QSO,
     .name = QSO_MODE,
-    .is_multi = NULL,
+    .is_multi = no_multi,
 };
 
 contest_config_t config_dxped = {
     .id = DXPED,
     .name = "DXPED",
     .recall_mult = true,
-    .is_multi = NULL,
+    .is_multi = no_multi,
 };
 
 contest_config_t config_wpx = {
@@ -93,7 +132,7 @@ contest_config_t config_sprint = {
 	.type = FIXED,
 	.point = 1,
     },
-    .is_multi = NULL,
+    .is_multi = no_multi,
 };
 
 contest_config_t config_arrldx_usa = {
@@ -103,7 +142,8 @@ contest_config_t config_arrldx_usa = {
     .points = {
 	.type = FUNCTION,
 	.fn = score_arrldx_usa,
-    }
+    },
+    .is_multi = arrldx_usa_ismulti,
 };
 
 contest_config_t config_arrldx_dx = {
@@ -113,7 +153,8 @@ contest_config_t config_arrldx_dx = {
     .points = {
 	.type = FIXED,
 	.point = 3,
-    }
+    },
+    .is_multi = no_multi,
 };
 
 contest_config_t config_arrl_ss = {
@@ -123,7 +164,8 @@ contest_config_t config_arrl_ss = {
     .points = {
 	.type = FIXED,
 	.point = 2,
-    }
+    },
+    .is_multi = no_multi,
 };
 
 contest_config_t config_arrl_fd = {
@@ -134,7 +176,7 @@ contest_config_t config_arrl_fd = {
 	.type = FUNCTION,
 	.fn = score_arrlfd,
     },
-    .is_multi = NULL,
+    .is_multi = no_multi,
 };
 
 contest_config_t config_pacc_pa = {
@@ -143,7 +185,8 @@ contest_config_t config_pacc_pa = {
     .points = {
 	.type = FIXED,
 	.point = 1,
-    }
+    },
+    // .ismulti =
 };
 
 contest_config_t config_stewperry = {
@@ -153,7 +196,7 @@ contest_config_t config_stewperry = {
 	.type = FUNCTION,
 	.fn = score_stewperry
     },
-    .is_multi = NULL,
+    .is_multi = no_multi,
 };
 
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -170,7 +170,7 @@ contest_config_t config_sprint = {
 contest_config_t config_arrldx_usa = {
     .id = ARRLDX_USA,
     .name = "ARRLDX_USA",
-    .recall_mult =true,
+    .recall_mult = true,
     .points = {
 	.type = FUNCTION,
 	.fn = score_arrldx_usa,
@@ -181,7 +181,7 @@ contest_config_t config_arrldx_usa = {
 contest_config_t config_arrldx_dx = {
     .id = ARRLDX_DX,
     .name = "ARRLDX_DX",
-    .recall_mult =true,
+    .recall_mult = true,
     .points = {
 	.type = FIXED,
 	.point = 3,
@@ -203,7 +203,7 @@ contest_config_t config_arrl_ss = {
 contest_config_t config_arrl_fd = {
     .id = ARRL_FD,
     .name = "ARRL_FD",
-    .recall_mult =true,
+    .recall_mult = true,
     .points = {
 	.type = FUNCTION,
 	.fn = score_arrlfd,
@@ -273,8 +273,8 @@ contest_config_t *lookup_contest(char *name) {
 void list_contests() {
     puts(
 	"\nTLF has built-in support for the following contest identifiers:"
-	);
-    for(int i = 0; i < NR_CONTESTS; i++) {
+    );
+    for (int i = 0; i < NR_CONTESTS; i++) {
 	printf("\t%s\n", contest_configs[i]->name);
     }
     puts("");
@@ -316,7 +316,7 @@ void setcontest(char *name) {
     ve_cty = getctynr(vecall);
 
     if (whichcontest != name) {    /* avoid overlapping copy */
-        strcpy(whichcontest, name);
+	strcpy(whichcontest, name);
     }
 
     contest = lookup_contest(name);

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -35,8 +35,8 @@
 #include "score.h"
 #include "tlf.h"
 
-/* contests where multiplier get determined from comment field can not be
- shown in bandmap works also for modes with no multiplier at all */
+/* No Multiplier mark in bandmap for multis determined from comment field;
+ * Code works also for modes with no multiplier at all */
 static bool no_multi(spot *data) {
     return false;
 }

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -26,12 +26,25 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "bandmap.h"
+#include "bands.h"
 #include "focm.h"
 #include "getctydata.h"
 #include "globalvars.h"
 #include "setcontest.h"
 #include "score.h"
 #include "tlf.h"
+
+bool cqww_ismulti(spot *data, int band) {
+
+    if ((zones[data->cqzone] & inxes[band]) == 0
+	    || (countries[data->ctynr] & inxes[band]) == 0) {
+	return true;
+    }
+
+    return false;
+}
+
 
 /* configurations for supported contest */
 contest_config_t config_unknown = {
@@ -66,7 +79,8 @@ contest_config_t config_cqww = {
     .points = {
 	.type = FUNCTION,
 	.fn = score_cqww,
-    }
+    },
+    .is_multi = cqww_ismulti,
 };
 
 contest_config_t config_sprint = {

--- a/src/setcontest.h
+++ b/src/setcontest.h
@@ -28,6 +28,7 @@
 
 extern contest_config_t config_qso;
 
+bool general_ismulti();
 contest_config_t *lookup_contest(char *name);
 void list_contests();
 void setcontest(char *name);

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -211,6 +211,7 @@ typedef enum {
     FUNCTION
 } points_type_t;
 
+
 /** contest configuration
  */
 typedef struct {
@@ -225,6 +226,7 @@ typedef struct {
 	    int (*fn)();
 	};
     }			points;
+    bool (*is_multi)(void *, int);
 
 } contest_config_t;
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -226,7 +226,7 @@ typedef struct {
 	    int (*fn)();
 	};
     }			points;
-    bool (*is_multi)(void *, int);
+    bool (*is_multi)();
 
 } contest_config_t;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -33,7 +33,7 @@ char *find_available(char *filename) {
 	path = g_strdup(filename);
     } else {
 	path = g_strconcat(PACKAGE_DATA_DIR, G_DIR_SEPARATOR_S,
-			       filename, NULL);
+			   filename, NULL);
 	if (g_access(path, R_OK) != 0) {
 	    g_free(path);
 	    path = g_strdup("");

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -9,6 +9,7 @@
 
 // OBJECT ../src/addcall.o
 // OBJECT ../src/addmult.o
+// OBJECT ../src/addpfx.o
 // OBJECT ../src/bands.o
 // OBJECT ../src/dxcc.o
 // OBJECT ../src/focm.o
@@ -26,10 +27,6 @@
 
 
 /* these are missing from globalvars */
-
-int add_pfx(char *call) {
-    return 0;
-}
 
 int pacc_pa(void) {
     return 0;

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -10,8 +10,10 @@
 #include <unistd.h>
 
 // OBJECT ../src/addmult.o
+// OBJECT ../src/addpfx.o
 // OBJECT ../src/bands.o
 // OBJECT ../src/dxcc.o
+// OBJECT ../src/getpx.o
 // OBJECT ../src/setcontest.o
 // OBJECT ../src/score.o
 // OBJECT ../src/utils.o

--- a/test/test_addpfx.c
+++ b/test/test_addpfx.c
@@ -8,6 +8,9 @@
 
 extern int pfxmultab;
 
+int find_worked_pfx(char *prefix);
+
+
 int setup_default(void **state) {
     pfxmultab = 0;
     InitPfx();
@@ -23,6 +26,44 @@ void test_initPfx(void **state) {
     for (i = 0; i < NBANDS; i++)
 	temp += GetNrOfPfx_OnBand(i);
     assert_int_equal(temp, 0);
+}
+
+void add_some_prefixes(void) {
+    add_pfx("DL0",BANDINDEX_80);
+    add_pfx("UA3",BANDINDEX_80);
+    add_pfx("UA3",BANDINDEX_20);
+    add_pfx("UA2",BANDINDEX_20);
+}
+
+void test_any_pfx_is_new_if_empty(void **state) {
+    assert_int_equal(pfx_is_new("DL1"),1);
+    assert_int_equal(pfx_is_new("UA3"),1);
+}
+
+void test_pfx_is_new(void **state) {
+    add_some_prefixes();
+    assert_int_equal(pfx_is_new("DL1"),1);
+}
+
+void test_pfx_is_not_new(void **state) {
+    add_some_prefixes();
+    assert_int_equal(!pfx_is_new("DL0"),1);
+    assert_int_equal(!pfx_is_new("UA2"),1);
+}
+
+void test_pfx_is_new_on_band(void **state) {
+    add_some_prefixes();
+    assert_int_equal(pfx_is_new_on("DL0", BANDINDEX_40),1);
+    assert_int_equal(pfx_is_new_on("UA2", BANDINDEX_40),1);
+    assert_int_equal(pfx_is_new_on("OE4", BANDINDEX_40),1);
+}
+
+void test_pfx_not_new_on_band(void **state) {
+    add_some_prefixes();
+    assert_int_equal(!pfx_is_new_on("DL0", BANDINDEX_80),1);
+    assert_int_equal(!pfx_is_new_on("UA2", BANDINDEX_20),1);
+    assert_int_equal(!pfx_is_new_on("UA3", BANDINDEX_80),1);
+    assert_int_equal(!pfx_is_new_on("UA3", BANDINDEX_20),1);
 }
 
 void test_outOfBand(void **state) {

--- a/test/test_contest.c
+++ b/test/test_contest.c
@@ -5,9 +5,10 @@
 #include "../src/setcontest.h"
 
 
-
+// OBJECT ../src/addpfx.o
 // OBJECT ../src/bands.o
 // OBJECT ../src/dxcc.o
+// OBJECT ../src/getpx.o
 // OBJECT ../src/setcontest.o
 // OBJECT ../src/score.o
 

--- a/test/test_contest.c
+++ b/test/test_contest.c
@@ -6,6 +6,7 @@
 
 
 
+// OBJECT ../src/bands.o
 // OBJECT ../src/dxcc.o
 // OBJECT ../src/setcontest.o
 // OBJECT ../src/score.o

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -9,6 +9,7 @@
 
 #include "../src/getctydata.h"
 
+// OBJECT ../src/addpfx.o
 // OBJECT ../src/bands.o
 // OBJECT ../src/dxcc.o
 // OBJECT ../src/getctydata.o

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -9,6 +9,7 @@
 
 #include "../src/getctydata.h"
 
+// OBJECT ../src/bands.o
 // OBJECT ../src/dxcc.o
 // OBJECT ../src/getctydata.o
 // OBJECT ../src/getpx.o

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -17,6 +17,7 @@
 #include "../src/set_tone.h"
 #include "../src/cabrillo_utils.h"
 
+// OBJECT ../src/bands.o
 // OBJECT ../src/parse_logcfg.o
 // OBJECT ../src/get_time.o
 // OBJECT ../src/getpx.o

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -17,6 +17,7 @@
 #include "../src/set_tone.h"
 #include "../src/cabrillo_utils.h"
 
+// OBJECT ../src/addpfx.o
 // OBJECT ../src/bands.o
 // OBJECT ../src/parse_logcfg.o
 // OBJECT ../src/get_time.o

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -8,6 +8,7 @@
 
 #include "../src/globalvars.h"
 
+// OBJECT ../src/addpfx.o
 // OBJECT ../src/score.o
 // OBJECT ../src/addmult.o
 // OBJECT ../src/bands.o

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -8,9 +8,11 @@
 #include "../src/setcontest.h"
 #include "../src/dxcc.h"
 
+// OBJECT ../src/addpfx.o
 // OBJECT ../src/addmult.o
 // OBJECT ../src/bands.o
 // OBJECT ../src/get_time.o
+// OBJECT ../src/getpx.o
 // OBJECT ../src/log_utils.o
 // OBJECT ../src/searchlog.o
 // OBJECT ../src/zone_nr.o
@@ -53,10 +55,6 @@ void clusterinfo() {
 
 // splitscreen.c
 void refresh_splitlayout() {
-}
-
-// getpx.c
-void getpx(char *checkcall) {
 }
 
 // dxcc.c


### PR DESCRIPTION
Supports all builtin contests besides WPX, PACC_PA and FOC.

* Evaluates worked zones and countries 
* Honor DX_&_SECTIONS, COUNTRY_MULT, ITUMULT and WAZMULT keyword for other contests.

Multi based on exchange field (e.g. worked sections) can not be checked for bandmap display. 


Do not check in the code yet. I will add WPX and PACC shortly (next days).
Please test and give feedback. 