### PR TITLE
Warn if terminal size to small

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -522,10 +522,10 @@ void ui_init() {
 				   for refreshp() to work */
 
     getmaxyx(stdscr, ymax, xmax);
-    if ((ymax < 25) || (xmax < 80)) {
+    if ((ymax < 22) || (xmax < 80)) {
 	char c;
 
-	showmsg("!! TLF needs at least 25 lines and 80 columns !!");
+	showmsg("!! TLF works best with at least 22 lines and 80 columns !!");
 	showmsg("   Continue anyway? Y/(N) ");
 	c = toupper(key_get());
 	if (c != 'Y') {


### PR DESCRIPTION
Adapt recommendations for screensize to needed values. Make the warning go away for often used 24x80 terminal size.