### PR TITLE
Parse line

### DIFF
--- a/src/cabrillo_utils.h
+++ b/src/cabrillo_utils.h
@@ -42,7 +42,7 @@ extern cbr_field_t cabrillo_fields[];
 #define CBR_LOCATOR     "GRID-LOCATOR"
 
 
-/* represents different parts of a qso/qtc logline */
+/* represents different parts of a qso logline */
 struct linedata_t {
     char *logline;
     int band;

--- a/src/cabrillo_utils.h
+++ b/src/cabrillo_utils.h
@@ -42,8 +42,8 @@ extern cbr_field_t cabrillo_fields[];
 #define CBR_LOCATOR     "GRID-LOCATOR"
 
 
-/* represents different parts of a qso logline */
-struct qso_t {
+/* represents different parts of a qso/qtc logline */
+struct linedata_t {
     char *logline;
     int band;
     int mode;

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -20,6 +20,11 @@
 *    util functions to work with lines from log
 *
 ---------------------------------------------------------------------------*/
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <ctype.h>
 #include <glib.h>
 #include <stdlib.h>
@@ -27,6 +32,9 @@
 #include <stdbool.h>
 
 #include "bands.h"
+#include "get_time.h"
+#include "tlf.h"
+
 
 /* for the following code we assume that we have well formatted log lines,
  * which has to be checked separately if needed */
@@ -78,3 +86,82 @@ int log_get_points(const char *logline) {
     return atoi(tmpbuf);
 }
 
+
+struct qso_t *parse_qso(char *buffer) {
+    char *tmp;
+    char *sp;
+    struct qso_t *ptr;
+    struct tm date_n_time;
+
+    ptr = g_malloc0(sizeof(struct qso_t));
+
+    /* remember whole line */
+    ptr->logline = g_strdup(buffer);
+    ptr->qsots = 0;
+
+    /* split buffer into parts for linedata_t record and parse
+     * them accordingly */
+    tmp = strtok_r(buffer, " \t", &sp);
+
+    /* band */
+    ptr->band = atoi(tmp);
+
+
+    /* mode */
+    if (strcasestr(tmp, "CW"))
+	ptr->mode = CWMODE;
+    else if (strcasestr(tmp, "SSB"))
+	ptr->mode = SSBMODE;
+    else
+	ptr->mode = DIGIMODE;
+
+    /* date & time */
+    memset(&date_n_time, 0, sizeof(struct tm));
+
+    strptime(strtok_r(NULL, " \t", &sp), DATE_FORMAT, &date_n_time);
+    strptime(strtok_r(NULL, " \t", &sp), TIME_FORMAT, &date_n_time);
+
+    ptr->year = date_n_time.tm_year + 1900;	/* convert to
+						   1968..2067 */
+    ptr->month = date_n_time.tm_mon + 1;	/* tm_mon = 0..11 */
+    ptr->day   = date_n_time.tm_mday;
+
+    ptr->hour  = date_n_time.tm_hour;
+    ptr->min   = date_n_time.tm_min;
+
+    /* qso number */
+    ptr->qso_nr = atoi(strtok_r(NULL, " \t", &sp));
+
+    /* his call */
+    ptr->call = g_strdup(strtok_r(NULL, " \t", &sp));
+
+    /* RST send and received */
+    ptr->rst_s = atoi(strtok_r(NULL, " \t", &sp));
+    ptr->rst_r = atoi(strtok_r(NULL, " \t", &sp));
+
+    /* comment (exchange) */
+    ptr->comment = g_strndup(buffer + 54, 13);
+
+    /* tx */
+    ptr->tx = (buffer[79] == '*') ? 1 : 0;
+
+    /* frequency (kHz) */
+    ptr->freq = atof(buffer + 80) * 1000.0;
+    if (freq2band(ptr->freq) == BANDINDEX_OOB) {
+	ptr->freq = 0.;
+    }
+
+    return ptr;
+}
+
+
+/** free qso record pointed to by ptr */
+void free_qso(struct qso_t *ptr) {
+
+    if (ptr != NULL) {
+	g_free(ptr->comment);
+	g_free(ptr->logline);
+	g_free(ptr->call);
+	g_free(ptr);
+    }
+}

--- a/src/log_utils.h
+++ b/src/log_utils.h
@@ -29,5 +29,7 @@ bool log_is_comment(const char *buffer);
 int log_get_band(const char *logline);
 int log_get_mode(const char *logline);
 int log_get_points(const char *logline);
+struct qso_t *parse_qso(char * buffer);
+void free_qso(struct qso_t *ptr);
 
 #endif

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -23,6 +23,8 @@
 
 #include <stdbool.h>
 
+#include "hamlib/rig.h"
+
 enum {
     NO_KEYER,
     NET_KEYER,
@@ -181,6 +183,27 @@ typedef struct {
     int countrynr;
     int qsos[NBANDS];
 } pfxnummulti_t;
+
+
+/* represents different parts of a qso line */
+struct qso_t {
+    char *logline;
+    int band;
+    int mode;
+    char day;
+    char month;
+    int year;
+    int hour;
+    int min;
+    int qso_nr;
+    char *call;
+    int rst_s;
+    int rst_r;
+    char *comment;
+    freq_t freq;
+    int tx;
+    int qsots;
+};
 
 
 void refreshp();

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -49,10 +49,7 @@ void free_linedata(struct linedata_t *ptr);
 
 
 struct linedata_t *parse_logline(char *buffer) {
-    char *tmp;
-    char *sp;
     struct linedata_t *ptr;
-    struct tm date_n_time;
 
     ptr = g_malloc0(sizeof(struct linedata_t));
 
@@ -61,58 +58,26 @@ struct linedata_t *parse_logline(char *buffer) {
     ptr->qtcdirection = 0;
     ptr->qsots = 0;
 
-    /* split buffer into parts for linedata_t record and parse
-     * them accordingly */
-    tmp = strtok_r(buffer, " \t", &sp);
 
-    /* band */
-    ptr->band = atoi(tmp);
+    struct qso_t *qso = parse_qso(buffer);
 
+    ptr-> band = qso->band;
+    ptr-> mode = qso->mode;
+    ptr-> day  = qso->day;
+    ptr-> month = qso->month;
+    ptr-> year = qso->year;
+    ptr-> hour = qso->hour;
+    ptr-> min = qso->min;
+    ptr-> qso_nr = qso->qso_nr;
+    ptr-> call = qso->call;
+    ptr-> rst_s = qso->rst_s;
+    ptr-> rst_r = qso->rst_r;
+    ptr-> comment = qso->comment;
+    ptr-> freq = qso->freq;
+    ptr-> tx = qso->tx;
 
-    /* mode */
-    if (strcasestr(tmp, "CW"))
-	ptr->mode = CWMODE;
-    else if (strcasestr(tmp, "SSB"))
-	ptr->mode = SSBMODE;
-    else
-	ptr->mode = DIGIMODE;
-
-    /* date & time */
-    memset(&date_n_time, 0, sizeof(struct tm));
-
-    strptime(strtok_r(NULL, " \t", &sp), DATE_FORMAT, &date_n_time);
-    strptime(strtok_r(NULL, " \t", &sp), TIME_FORMAT, &date_n_time);
-
-    ptr->year = date_n_time.tm_year + 1900;	/* convert to
-						   1968..2067 */
-    ptr->month = date_n_time.tm_mon + 1;	/* tm_mon = 0..11 */
-    ptr->day   = date_n_time.tm_mday;
-
-    ptr->hour  = date_n_time.tm_hour;
-    ptr->min   = date_n_time.tm_min;
-
-    /* qso number */
-    ptr->qso_nr = atoi(strtok_r(NULL, " \t", &sp));
-
-    /* his call */
-    ptr->call = g_strdup(strtok_r(NULL, " \t", &sp));
-
-    /* RST send and received */
-    ptr->rst_s = atoi(strtok_r(NULL, " \t", &sp));
-    ptr->rst_r = atoi(strtok_r(NULL, " \t", &sp));
-
-    /* comment (exchange) */
-    ptr->comment = g_strndup(buffer + 54, 13);
-
-    /* tx */
-    ptr->tx = (buffer[79] == '*') ? 1 : 0;
-
-    /* frequency (kHz) */
-    ptr->freq = atof(buffer + 80) * 1000.0;
-    if (freq2band(ptr->freq) == BANDINDEX_OOB) {
-	ptr->freq = 0.;
-    }
-
+    g_free(qso);	/* free qso_t struct but not the
+			   allocated string copies */
     return ptr;
 }
 

--- a/test/test_adif.c
+++ b/test/test_adif.c
@@ -14,9 +14,9 @@
 // OBJECT ../src/utils.o
 
 /* test stubs and dummies */
-struct qso_t *parse_logline(char *buffer);
-void prepare_adif_line(char *buffer, struct qso_t *qso);
-void free_qso(struct qso_t *ptr);
+struct linedata_t *parse_logline(char *buffer);
+void prepare_adif_line(char *buffer, struct linedata_t *qso);
+void free_linedata(struct linedata_t *ptr);
 void free_cabfmt();
 void add_adif_field(char *adif_line, char *field, char *value);
 
@@ -87,18 +87,18 @@ void test_keep_old_format(void **state) {
 
     strcpy(exchange, "14");
 
-    struct qso_t *qso;
+    struct linedata_t *qso;
     strcpy(buffer, LOGLINE1);
     qso = parse_logline(buffer);
     prepare_adif_line(buffer, qso);
     assert_string_equal(buffer, RESULT1);
-    free_qso(qso);
+    free_linedata(qso);
 
     strcpy(buffer, LOGLINE2);
     qso = parse_logline(buffer);
     prepare_adif_line(buffer, qso);
     assert_string_equal(buffer, RESULT2);
-    free_qso(qso);
+    free_linedata(qso);
 }
 
 /* test add_adif_field and co */

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -84,7 +84,8 @@ int starts_with(char *line, char *start);
 void cab_qso_to_tlf(char *line, struct cabrillo_desc *cabdesc);
 extern struct read_qtc_t qtc_line;	/* make global for testability */
 gchar *get_nth_token(gchar *str, int n, const char *separator);
-void prepare_line(struct qso_t *qso, struct cabrillo_desc *desc, char *buf);
+void prepare_line(struct linedata_t *qso,
+	struct cabrillo_desc *desc, char *buf);
 
 /* Test of helper functions */
 void test_starts_with_succeed(void **state) {
@@ -198,7 +199,7 @@ void test_prepare_line_universal(void **state) {
     desc = read_cabrillo_format(formatfile, "UNIVERSAL");
     assert_non_null(desc);
 
-    struct qso_t qso = {
+    struct linedata_t qso = {
 	.year = 2021, .month = 1, .day = 2, .hour = 8, .min = 42,
 	.qso_nr = 711, .mode = CWMODE,
 	.call = "A2XYZ", .freq = 21012845.6,
@@ -220,7 +221,7 @@ void test_prepare_line_agcw(void **state) {
     assert_non_null(desc);
     assert_string_equal(desc->exchange_separator, "/");
 
-    struct qso_t qso = {
+    struct linedata_t qso = {
 	.year = 2021, .month = 1, .day = 2, .hour = 8, .min = 42,
 	.qso_nr = 711, .mode = CWMODE,
 	.call = "A2XYZ", .freq = 21012845.6,
@@ -242,7 +243,7 @@ void test_prepare_line_agcw3(void **state) {
     assert_non_null(desc);
     assert_string_equal(desc->exchange_separator, " /");
 
-    struct qso_t qso = {
+    struct linedata_t qso = {
 	.year = 2021, .month = 1, .day = 2, .hour = 8, .min = 42,
 	.qso_nr = 711, .mode = CWMODE,
 	.call = "A2XYZ", .freq = 21012845.6,


### PR DESCRIPTION
Introduce a parse function for QSO line entries which returns a clean struct without unneeded parts.
Use it to implement the already existing parse_logline() function.