### PR TITLE
Add exchange width for contest

### DIFF
--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -43,7 +43,7 @@ void cleanup(void) {
     mvaddstr(12, 29, spaces(12));
 
     attron(COLOR_PAIR(C_WINDOW));
-    mvaddstr(12, 54, spaces(24));
+    mvaddstr(12, 54, spaces(contest->exchange_width));
 
     attron(COLOR_PAIR(C_LOG | A_STANDOUT));
     for (int k = 1; k <= 5; k++) {

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -34,6 +34,7 @@
 #include "get_time.h"
 #include "getwwv.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "logit.h"
 #include "muf.h"
 #include "printcall.h"
 #include "qsonr_to_str.h"
@@ -142,20 +143,11 @@ void clear_display(void) {
 	mvaddstr(12, 49, recvd_rst);
     }
 
-    if (CONTEST_IS(CQWW)) {
-	attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
-	mvaddstr(12, 54, comment);
-    }
-
-    if (CONTEST_IS(ARRLDX_USA)) {
-	attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
-	mvaddstr(12, 54, comment);
-    }
-
     if (searchflg == SEARCHWINDOW)
 	searchlog();
 
     printcall();
+    refresh_comment();
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
     mvaddstr(LINES - 1, 0, backgrnd_str);

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -108,7 +108,6 @@ int getexchange(void) {
     commentfield = 1;
 
     i = strlen(comment);
-
     while (1) {
 
 	refresh_comment();
@@ -316,7 +315,7 @@ int getexchange(void) {
 	if (x >= 'a' && x <= 'z')
 	    x = x - 32;		// Promote to upper case
 
-	if (i < 25) {		/* normal character -> insert if space left */
+	if (i < contest->exchange_width) {  /* normal character -> insert if space left */
 	    if (x >= ' ' && x <= 'Z') {
 		instring[0] = x;
 		addch(x);
@@ -1071,12 +1070,11 @@ void exchange_edit(void) {
 
     l = strlen(comment);
     b = l - 1;
-
     while ((i != ESCAPE) && (b <= strlen(comment))) {
 	attroff(A_STANDOUT);
 	attron(COLOR_PAIR(C_HEADER));
 
-	mvprintw(12, 54, spaces(80 - 54));
+	mvprintw(12, 54, spaces(contest->exchange_width));
 	mvprintw(12, 54, comment);
 	mvprintw(12, 54 + b, "");
 
@@ -1141,7 +1139,7 @@ void exchange_edit(void) {
 	    // Accept printable characters.
 	    if ((i >= ' ') && (i <= 'Z')) {
 
-		if (strlen(comment) <= 24) {
+		if (strlen(comment) < contest->exchange_width) {
 		    /* copy including trailing \0 */
 		    strncpy(comment2, comment + b, strlen(comment) - (b - 1));
 

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -131,7 +131,7 @@ void log_to_disk(int from_lan) {
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));	/* erase comment  field */
 
     if (!from_lan)
-	mvprintw(12, 54, spaces(80 - 54));
+	mvprintw(12, 54, spaces(contest->exchange_width));
 
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     if (!from_lan) {

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -33,6 +33,7 @@
 
 #include "bands.h"
 #include "get_time.h"
+#include "setcontest.h"
 #include "tlf.h"
 
 
@@ -140,7 +141,7 @@ struct qso_t *parse_qso(char *buffer) {
     ptr->rst_r = atoi(strtok_r(NULL, " \t", &sp));
 
     /* comment (exchange) */
-    ptr->comment = g_strndup(buffer + 54, 13);
+    ptr->comment = g_strndup(buffer + 54, contest->exchange_width);
 
     /* tx */
     ptr->tx = (buffer[79] == '*') ? 1 : 0;

--- a/src/logit.c
+++ b/src/logit.c
@@ -207,7 +207,7 @@ void refresh_comment(void) {
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
-    mvprintw(12, 54, spaces(80 - 54));
+    mvprintw(12, 54, spaces(contest->exchange_width));
     mvprintw(12, 54, comment);
 }
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -120,13 +120,15 @@ bool general_ismulti(spot *data) {
 /* configurations for supported contest */
 contest_config_t config_unknown = {
     .id = UNKNOWN,
-    .name = "Unknown"
+    .name = "Unknown",
+    .exchange_width = 14,
 };
 
 contest_config_t config_qso = {
     .id = QSO,
     .name = QSO_MODE,
     .is_multi = no_multi,
+    .exchange_width = 77 - 55 + 1,  // full width
 };
 
 contest_config_t config_dxped = {
@@ -134,6 +136,7 @@ contest_config_t config_dxped = {
     .name = "DXPED",
     .recall_mult = true,
     .is_multi = no_multi,
+    .exchange_width = 77 - 55 + 1,  // full width
 };
 
 contest_config_t config_wpx = {
@@ -144,6 +147,7 @@ contest_config_t config_wpx = {
 	.fn = score_wpx,
     },
     .is_multi = wpx_ismulti,
+    .exchange_width = 5,    // serial nr
 };
 
 contest_config_t config_cqww = {
@@ -155,6 +159,7 @@ contest_config_t config_cqww = {
 	.fn = score_cqww,
     },
     .is_multi = cqww_ismulti,
+    .exchange_width = 3,    // zone nr
 };
 
 contest_config_t config_sprint = {
@@ -165,6 +170,7 @@ contest_config_t config_sprint = {
 	.point = 1,
     },
     .is_multi = no_multi,
+    .exchange_width = 77 - 55 + 1,  // full width
 };
 
 contest_config_t config_arrldx_usa = {
@@ -176,6 +182,7 @@ contest_config_t config_arrldx_usa = {
 	.fn = score_arrldx_usa,
     },
     .is_multi = arrldx_usa_ismulti,
+    .exchange_width = 5,    // 2 or 3 chars
 };
 
 contest_config_t config_arrldx_dx = {
@@ -187,6 +194,7 @@ contest_config_t config_arrldx_dx = {
 	.point = 3,
     },
     .is_multi = no_multi,
+    .exchange_width = 5,    // 2 or 3 chars
 };
 
 contest_config_t config_arrl_ss = {
@@ -198,6 +206,7 @@ contest_config_t config_arrl_ss = {
 	.point = 2,
     },
     .is_multi = no_multi,
+    .exchange_width = 77 - 55 + 1,  // full width
 };
 
 contest_config_t config_arrl_fd = {
@@ -209,6 +218,7 @@ contest_config_t config_arrl_fd = {
 	.fn = score_arrlfd,
     },
     .is_multi = no_multi,
+    .exchange_width = 13,
 };
 
 contest_config_t config_pacc_pa = {
@@ -219,6 +229,7 @@ contest_config_t config_pacc_pa = {
 	.point = 1,
     },
     // .ismulti =
+    .exchange_width = 5,    // province/serial
 };
 
 contest_config_t config_stewperry = {
@@ -229,6 +240,7 @@ contest_config_t config_stewperry = {
 	.fn = score_stewperry
     },
     .is_multi = no_multi,
+    .exchange_width = 5,    // 4 char grid square
 };
 
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -242,6 +242,7 @@ typedef struct {
     char		*name;
     bool		recall_mult;
     bool		exchange_serial;
+    int                 exchange_width;
     struct {
 	points_type_t type;
 	union {

--- a/test/test_adif.c
+++ b/test/test_adif.c
@@ -60,7 +60,7 @@ void keyer_append(const char *string) {
 
 char *error_details;
 
-contest_config_t empty = { };
+contest_config_t empty = { .exchange_width = 10 };
 
 char logline[181];
 char adif_line[400];


### PR DESCRIPTION
To fix #234: a contest defines the max exchange width. Input field in then limited to this width.

![image](https://user-images.githubusercontent.com/15141948/112881633-38774200-90cc-11eb-81db-a596eb6ec575.png)

Tried to come up with reasonable values for the built-in contest.

As the existing widths (e.g. the default 14) sometimes may be too short or too much, they have to be configurable. Will add it if this one is OK.