### PR TITLE
Fix wrong field size for pfxnummulti[]

### DIFF
--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -80,7 +80,7 @@ void init_scoring(void) {
 
     if (pfxnummultinr > 0) {
 	for (int i = 0; i < pfxnummultinr; i++) {
-	    for (int n = 0; n < NBANDS; n++) {
+	    for (int n = 0; n < PFXNUMBERS; n++) {
 		pfxnummulti[i].qsos[n] = 0;
 	    }
 	}

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -179,9 +179,10 @@ typedef struct {
 
 
 #define MAXPFXNUMMULT 30
+#define PFXNUMBERS 10
 typedef struct {
     int countrynr;
-    int qsos[NBANDS];
+    int qsos[PFXNUMBERS];
 } pfxnummulti_t;
 
 


### PR DESCRIPTION
Field size corresponsd to number of possible prefix numbers (0..9), not the number of bands.