### PR TITLE
Evaluate on start

### DIFF
--- a/src/addcall.c
+++ b/src/addcall.c
@@ -62,6 +62,19 @@ int excl_add_veto;
  * addcall2() is need to separate the points and multipliers.
  */
 
+
+/* collect all relevant data for the actual QSO into a qso_t structure */
+struct qso_t *collect_qso_data(void) {
+    struct qso_t *qso = g_malloc0(sizeof(struct qso_t));
+    qso->call = g_strdup(hiscall);
+    qso->mode = trxmode;
+    qso->bandindex = bandinx;
+    qso->timestamp = get_time();
+    qso->comment = g_strdup(comment);
+    return qso;
+}
+
+
 int addcall(void) {
 
     int cty, zone = 0;

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -119,7 +119,7 @@ int lookup_country_in_pfxnummult_array(int n) {
 int addcall(struct qso_t *qso) {
 
     int cty, zone = 0;
-    int add_ok;
+    bool add_ok;
     int pfxnumcntidx = -1;
     int pxnr = 0;
 
@@ -145,18 +145,18 @@ int addcall(struct qso_t *qso) {
 	}
     }
 
-    add_ok = 1;			/* look if certain calls are excluded */
+    add_ok = true;			/* look if certain calls are excluded */
 
     if (CONTEST_IS(ARRLDX_USA)
 	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
-	add_ok = 0;
+	add_ok = false;
 
     if (country_mult == 1 && iscontest)
-	add_ok = 1;
+	add_ok = true;
 
     if ((dx_arrlsections == 1)
 	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
-	add_ok = 0;
+	add_ok = false;
 
     if (CONTEST_IS(PACC_PA))
 	add_ok = pacc_pa();
@@ -177,7 +177,7 @@ int addcall(struct qso_t *qso) {
 
     excl_add_veto |= check_veto(cty);
     if (excl_add_veto) {
-	add_ok = 0;
+	add_ok = false;
 	new_cty = 0;
 	addcallarea = 0;
     }
@@ -188,7 +188,7 @@ int addcall(struct qso_t *qso) {
 	qsos_per_band[qso->bandindex]++;
 
 
-    if (add_ok == 1) {
+    if (add_ok) {
 	worked[station].band |= inxes[qso->bandindex];	/* worked on band */
 
 	if (pfxnumcntidx < 0) {
@@ -223,7 +223,7 @@ int addcall(struct qso_t *qso) {
 int addcall2(void) {
 
     int cty, zone = 0;
-    int add_ok;
+    bool add_ok;
     char lancopy[6];
 
     char comment[40];
@@ -257,13 +257,13 @@ int addcall2(void) {
 	    zone = zone_nr(comment);
     }
 
-    add_ok = 1;			/* look if certain calls are excluded */
+    add_ok = true;			/* look if certain calls are excluded */
 
     /* 	     if ((arrldx_usa ==1) && ((cty == w_cty) || (cty == ve_cty)))
      	     	add_ok = 0;
     */
     if ((country_mult == 1) && iscontest)
-	add_ok = 1;
+	add_ok = true;
 
     if (CONTEST_IS(PACC_PA))
 	/* FIXME: Does not work for LAN qso's as pacc_pa uses global variables
@@ -277,7 +277,7 @@ int addcall2(void) {
 	pxnr = districtnumber(wpx_prefix);
 
 	pfxnumcntidx = lookup_country_in_pfxnummult_array(cty);
-	add_ok = 1;
+	add_ok = true;
     }
 
 
@@ -289,12 +289,12 @@ int addcall2(void) {
 
     excl_add_veto |= check_veto(cty);
     if (excl_add_veto) {
-	add_ok = 0;
+	add_ok = false;
 	new_cty = 0;
 	addcallarea = 0;
     }
 
-    if (add_ok == 1) {
+    if (add_ok) {
 
 	qsos_per_band[bandinx]++;
 

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -99,7 +99,7 @@ bool check_veto(int countrynr) {
 
 // lookup the current country 'n' from the outer loop
 // pfxnummulti[I].countrynr contains the country codes,
-// I:=[0..pfxnummultinr]
+// I:=[0..pfxnummultinr-1]
 // according to the order of prefixes in rules, eg:
 // PFX_NUM_MULTIS=W,VE,VK,ZL,ZS,JA,PY,UA9
 // pfxnummulti[0].countrynr will be nr of USA

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -2,6 +2,7 @@
  * Tlf - contest logging program for amateur radio operators
  * Copyright (C) 2001-2002-2003 Rein Couperus <pa0rct@amsat.org>
  *               2013           Ervin Hegedüs - HA2OS <airween@gmail.com>
+ *               2015-2021	Thomas Beierlein <dl1jbe@darc.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -182,8 +183,14 @@ int addcall(struct qso_t *qso) {
 	addcallarea = 0;
     }
 
+    /* qso's per band  */
+    if (!(CONTEST_IS(ARRLDX_USA)
+	    && ((countrynr == w_cty) || (countrynr == ve_cty))))
+	qsos_per_band[qso->bandindex]++;
+
+
     if (add_ok == 1) {
-	worked[station].band |= inxes[qso->bandindex];	/* worked on this band */
+	worked[station].band |= inxes[qso->bandindex];	/* worked on band */
 
 	switch (qso->bandindex) {
 

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -192,52 +192,25 @@ int addcall(struct qso_t *qso) {
     if (add_ok == 1) {
 	worked[station].band |= inxes[qso->bandindex];	/* worked on band */
 
-	switch (qso->bandindex) {
-
-	    case BANDINDEX_160:
-	    case BANDINDEX_80:
-	    case BANDINDEX_40:
-	    case BANDINDEX_20:
-	    case BANDINDEX_15:
-	    case BANDINDEX_10:
-
-		if (pfxnumcntidx < 0) {
-		    if (cty != 0 && (countries[cty] & inxes[qso->bandindex]) == 0) {
-			countries[cty] |= inxes[qso->bandindex];
-			countryscore[qso->bandindex]++;
-			new_cty = cty;
-		    }
-		    if (zone != 0 && (zones[zone] & inxes[qso->bandindex]) == 0) {
-			zones[zone] |= inxes[qso->bandindex];
-			zonescore[qso->bandindex]++;
-			new_zone = zone;
-		    }
-		} else {
-		    if ((pfxnummulti[pfxnumcntidx].qsos[pxnr] & inxes[qso->bandindex])
-			    == 0) {
-			pfxnummulti[pfxnumcntidx].qsos[pxnr] |= inxes[qso->bandindex];
-			addcallarea = 1;
-			countryscore[qso->bandindex]++;
-			zonescore[qso->bandindex]++;
-		    }
-		}
-		break;
-
-
-	    case BANDINDEX_12:
-	    case BANDINDEX_17:
-	    case BANDINDEX_30:
-
-		if (cty != 0 && (countries[cty] & inxes[qso->bandindex]) == 0) {
-		    countries[cty] |= inxes[qso->bandindex];
-		    new_cty = cty;
-		}
-		if (zone != 0 && (zones[zone] & inxes[qso->bandindex]) == 0) {
-		    zones[zone] |= inxes[qso->bandindex];
-		    new_zone = zone;
-		}
-		break;
-
+	if (pfxnumcntidx < 0) {
+	    if (cty != 0 && (countries[cty] & inxes[qso->bandindex]) == 0) {
+		countries[cty] |= inxes[qso->bandindex];
+		countryscore[qso->bandindex]++;
+		new_cty = cty;
+	    }
+	    if (zone != 0 && (zones[zone] & inxes[qso->bandindex]) == 0) {
+		zones[zone] |= inxes[qso->bandindex];
+		zonescore[qso->bandindex]++;
+		new_zone = zone;
+	    }
+	} else {
+	    if ((pfxnummulti[pfxnumcntidx].qsos[pxnr] & inxes[qso->bandindex])
+		    == 0) {
+		pfxnummulti[pfxnumcntidx].qsos[pxnr] |= inxes[qso->bandindex];
+		addcallarea = 1;
+		countryscore[qso->bandindex]++;
+		zonescore[qso->bandindex]++;
+	    }
 	}
     }
 
@@ -330,48 +303,24 @@ int addcall2(void) {
 
 	if (excl_add_veto == 0) {
 
-	    switch (bandinx) {
-
-		case BANDINDEX_160:
-		case BANDINDEX_80:
-		case BANDINDEX_40:
-		case BANDINDEX_20:
-		case BANDINDEX_15:
-		case BANDINDEX_10:
-
-		    if (pfxnumcntidx < 0) {
-			if (cty != 0 && (countries[cty] & inxes[bandinx]) == 0) {
-			    countries[cty] |= inxes[bandinx];
-			    countryscore[bandinx]++;
-//                              new_cty = cty;
-			}
-			if (zone != 0 && (zones[zone] & inxes[bandinx]) == 0) {
-			    zones[zone] |= inxes[bandinx];
-			    zonescore[bandinx]++;
-//                              new_zone = zone;
-			}
-		    } else {
-			if ((pfxnummulti[pfxnumcntidx].qsos[pxnr] & BAND10) == 0) {
-			    pfxnummulti[pfxnumcntidx].qsos[pxnr] |= inxes[bandinx];
-			    addcallarea = 1;
-			    zonescore[bandinx]++;
-			    countryscore[bandinx]++;
-			}
-		    }
-		    break;
-
-		case BANDINDEX_30:
-		case BANDINDEX_17:
-		case BANDINDEX_12:
-
-		    if (cty != 0 && (countries[cty] & inxes[bandinx]) == 0) {
-			countries[cty] |= inxes[bandinx];
-		    }
-		    if (zone != 0 && (zones[zone] & inxes[bandinx]) == 0) {
-			zones[zone] |= inxes[bandinx];
-		    }
-		    break;
-
+	    if (pfxnumcntidx < 0) {
+		if (cty != 0 && (countries[cty] & inxes[bandinx]) == 0) {
+		    countries[cty] |= inxes[bandinx];
+		    countryscore[bandinx]++;
+//                  new_cty = cty;
+	    }
+		if (zone != 0 && (zones[zone] & inxes[bandinx]) == 0) {
+		    zones[zone] |= inxes[bandinx];
+		    zonescore[bandinx]++;
+//                  new_zone = zone;
+		}
+	    } else {
+		if ((pfxnummulti[pfxnumcntidx].qsos[pxnr] & inxes[bandinx]) == 0) {
+		    pfxnummulti[pfxnumcntidx].qsos[pxnr] |= inxes[bandinx];
+		    addcallarea = 1;
+		    zonescore[bandinx]++;
+		    countryscore[bandinx]++;
+		}
 	    }
 	}
     }

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -75,7 +75,7 @@ struct qso_t *collect_qso_data(void) {
 }
 
 
-int addcall(void) {
+int addcall(struct qso_t *qso) {
 
     int cty, zone = 0;
     int add_ok;
@@ -84,19 +84,15 @@ int addcall(void) {
 
     excl_add_veto = 0;
 
-    int station = lookup_or_add_worked(hiscall);
-    worked[station].qsotime[trxmode][bandinx] = get_time();
+    int station = lookup_or_add_worked(qso->call);
+    update_worked(station, qso);
 
-    if (strlen(comment) >= 1) {		/* remember last exchange */
-	g_strlcpy(worked[station].exchange, comment,
-		sizeof(worked[0].exchange));
-    }
 
     // can we get the ctydata from countrynr?
-    cty = getctydata(hiscall);
+    cty = getctydata(qso->call);
 
 
-    if (strlen(comment) >= 1) {		/* remember last exchange */
+    if (strlen(qso->comment) >= 1) {		/* remember last exchange */
 	if (CONTEST_IS(CQWW) || wazmult == 1 || itumult == 1) {
 	    /*
 	    			if (strlen(zone_fix) > 1) {
@@ -104,7 +100,7 @@ int addcall(void) {
 	    			} else
 	    				zone = zone_nr(zone_export);
 	    */
-	    zone = zone_nr(comment);
+	    zone = zone_nr(qso->comment);
 	}
     }
 
@@ -126,7 +122,7 @@ int addcall(void) {
 
     // if pfx number as multiplier
     if (pfxnummultinr > 0) {
-	getpx(hiscall);
+	getpx(qso->call);
 	pxnr = districtnumber(wpx_prefix);
 
 	int pfxi = 0;
@@ -168,9 +164,9 @@ int addcall(void) {
     }
 
     if (add_ok == 1) {
-	worked[station].band |= inxes[bandinx];	/* worked on this band */
+	worked[station].band |= inxes[qso->bandindex];	/* worked on this band */
 
-	switch (bandinx) {
+	switch (qso->bandindex) {
 
 	    case BANDINDEX_160:
 	    case BANDINDEX_80:
@@ -180,23 +176,23 @@ int addcall(void) {
 	    case BANDINDEX_10:
 
 		if (pfxnumcntidx < 0) {
-		    if (cty != 0 && (countries[cty] & inxes[bandinx]) == 0) {
-			countries[cty] |= inxes[bandinx];
-			countryscore[bandinx]++;
+		    if (cty != 0 && (countries[cty] & inxes[qso->bandindex]) == 0) {
+			countries[cty] |= inxes[qso->bandindex];
+			countryscore[qso->bandindex]++;
 			new_cty = cty;
 		    }
-		    if (zone != 0 && (zones[zone] & inxes[bandinx]) == 0) {
-			zones[zone] |= inxes[bandinx];
-			zonescore[bandinx]++;
+		    if (zone != 0 && (zones[zone] & inxes[qso->bandindex]) == 0) {
+			zones[zone] |= inxes[qso->bandindex];
+			zonescore[qso->bandindex]++;
 			new_zone = zone;
 		    }
 		} else {
-		    if ((pfxnummulti[pfxnumcntidx].qsos[pxnr] & inxes[bandinx])
+		    if ((pfxnummulti[pfxnumcntidx].qsos[pxnr] & inxes[qso->bandindex])
 			    == 0) {
-			pfxnummulti[pfxnumcntidx].qsos[pxnr] |= inxes[bandinx];
+			pfxnummulti[pfxnumcntidx].qsos[pxnr] |= inxes[qso->bandindex];
 			addcallarea = 1;
-			countryscore[bandinx]++;
-			zonescore[bandinx]++;
+			countryscore[qso->bandindex]++;
+			zonescore[qso->bandindex]++;
 		    }
 		}
 		break;
@@ -206,12 +202,12 @@ int addcall(void) {
 	    case BANDINDEX_17:
 	    case BANDINDEX_30:
 
-		if (cty != 0 && (countries[cty] & inxes[bandinx]) == 0) {
-		    countries[cty] |= inxes[bandinx];
+		if (cty != 0 && (countries[cty] & inxes[qso->bandindex]) == 0) {
+		    countries[cty] |= inxes[qso->bandindex];
 		    new_cty = cty;
 		}
-		if (zone != 0 && (zones[zone] & inxes[bandinx]) == 0) {
-		    zones[zone] |= inxes[bandinx];
+		if (zone != 0 && (zones[zone] & inxes[qso->bandindex]) == 0) {
+		    zones[zone] |= inxes[qso->bandindex];
 		    new_zone = zone;
 		}
 		break;

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -307,7 +307,7 @@ int addcall2(void) {
 		    countries[cty] |= inxes[bandinx];
 		    countryscore[bandinx]++;
 //                  new_cty = cty;
-	    }
+		}
 		if (zone != 0 && (zones[zone] & inxes[bandinx]) == 0) {
 		    zones[zone] |= inxes[bandinx];
 		    zonescore[bandinx]++;

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -74,14 +74,16 @@ int addcall(void) {
     int station = lookup_or_add_worked(hiscall);
     worked[station].qsotime[trxmode][bandinx] = get_time();
 
+    if (strlen(comment) >= 1) {		/* remember last exchange */
+	g_strlcpy(worked[station].exchange, comment,
+		sizeof(worked[0].exchange));
+    }
+
     // can we get the ctydata from countrynr?
     cty = getctydata(hiscall);
 
 
     if (strlen(comment) >= 1) {		/* remember last exchange */
-	g_strlcpy(worked[station].exchange, comment,
-		sizeof(worked[0].exchange));
-
 	if (CONTEST_IS(CQWW) || wazmult == 1 || itumult == 1) {
 	    /*
 	    			if (strlen(zone_fix) > 1) {
@@ -90,7 +92,6 @@ int addcall(void) {
 	    				zone = zone_nr(zone_export);
 	    */
 	    zone = zone_nr(comment);
-
 	}
     }
 

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -116,7 +116,6 @@ int lookup_country_in_pfxnummult_array(int n) {
 }
 
 
-
 int addcall(struct qso_t *qso) {
 
     int cty, zone = 0;

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -74,6 +74,28 @@ struct qso_t *collect_qso_data(void) {
     return qso;
 }
 
+
+bool check_veto(int countrynr) {
+    bool veto = false;
+
+    if (!continentlist_only &&
+	    exclude_multilist_type == EXCLUDE_CONTINENT) {
+	if (is_in_continentlist(dxcc_by_index(countrynr)->continent)) {
+	    veto = true;
+	}
+    }
+
+    if (exclude_multilist_type == EXCLUDE_COUNTRY) {
+	if (is_in_countrylist(countrynr)) {
+	    veto = true;
+	}
+    }
+
+    return veto;
+}
+
+
+
 // lookup the current country 'n' from the outer loop
 // pfxnummulti[I].countrynr contains the country codes,
 // I:=[0..pfxnummultinr]
@@ -148,31 +170,16 @@ int addcall(struct qso_t *qso) {
     }
 
     if (continentlist_only) {
-	if (!is_in_continentlist(continent)) {
-	    add_ok = 0;
-	    new_cty = 0;
-	    addcallarea = 0;
+	if (!is_in_continentlist(dxcc_by_index(cty)->continent)) {
 	    excl_add_veto = 1;
 	}
     }
 
-    if (!continentlist_only
-	    && exclude_multilist_type == EXCLUDE_CONTINENT) {
-	if (is_in_continentlist(continent)) {
-	    add_ok = 0;
-	    new_cty = 0;
-	    addcallarea = 0;
-	    excl_add_veto = 1;
-	}
-    }
-
-    if (exclude_multilist_type == EXCLUDE_COUNTRY) {
-	if (is_in_countrylist(cty)) {
-	    add_ok = 0;
-	    new_cty = 0;
-	    addcallarea = 0;
-	    excl_add_veto = 1;
-	}
+    excl_add_veto |= check_veto(cty);
+    if (excl_add_veto) {
+	add_ok = 0;
+	new_cty = 0;
+	addcallarea = 0;
     }
 
     if (add_ok == 1) {
@@ -305,17 +312,11 @@ int addcall2(void) {
 	}
     }
 
-    if (!continentlist_only
-	    && exclude_multilist_type == EXCLUDE_CONTINENT) {
-	if (is_in_continentlist(dxcc_by_index(cty)->continent)) {
-	    excl_add_veto = 1;
-	}
-    }
-
-    if (exclude_multilist_type == EXCLUDE_COUNTRY) {
-	if (is_in_countrylist(cty)) {
-	    excl_add_veto = 1;
-	}
+    excl_add_veto |= check_veto(cty);
+    if (excl_add_veto) {
+	add_ok = 0;
+	new_cty = 0;
+	addcallarea = 0;
     }
 
     if (add_ok == 1) {

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -74,6 +74,25 @@ struct qso_t *collect_qso_data(void) {
     return qso;
 }
 
+// lookup the current country 'n' from the outer loop
+// pfxnummulti[I].countrynr contains the country codes,
+// I:=[0..pfxnummultinr]
+// according to the order of prefixes in rules, eg:
+// PFX_NUM_MULTIS=W,VE,VK,ZL,ZS,JA,PY,UA9
+// pfxnummulti[0].countrynr will be nr of USA
+// pfxnummulti[1].countrynr will be nr of Canada
+int lookup_country_in_pfxnummult_array(int n) {
+    int found = -1;
+    for (int i = 0; i < pfxnummultinr; i++) {
+	if (pfxnummulti[i].countrynr == n) {
+	    found = i;
+	    break;
+	}
+    }
+    return found;
+}
+
+
 
 int addcall(struct qso_t *qso) {
 
@@ -125,14 +144,7 @@ int addcall(struct qso_t *qso) {
 	getpx(qso->call);
 	pxnr = districtnumber(wpx_prefix);
 
-	int pfxi = 0;
-	while (pfxi < pfxnummultinr) {
-	    if (pfxnummulti[pfxi].countrynr == cty) {
-		pfxnumcntidx = pfxi;
-		break;
-	    }
-	    pfxi++;
-	}
+	pfxnumcntidx = lookup_country_in_pfxnummult_array(cty);
     }
 
     if (continentlist_only) {
@@ -282,14 +294,7 @@ int addcall2(void) {
 			       job */
 	pxnr = districtnumber(wpx_prefix);
 
-	int pfxi = 0;
-	while (pfxi < pfxnummultinr) {
-	    if (pfxnummulti[pfxi].countrynr == cty) {
-		pfxnumcntidx = pfxi;
-		break;
-	    }
-	    pfxi++;
-	}
+	pfxnumcntidx = lookup_country_in_pfxnummult_array(cty);
 	add_ok = 1;
     }
 

--- a/src/addcall.h
+++ b/src/addcall.h
@@ -25,6 +25,7 @@
 extern int excl_add_veto;
 
 struct qso_t *collect_qso_data(void);
+int lookup_country_in_pfxnummult_array(int n);
 int addcall(struct qso_t *qso);
 int addcall2(void);
 int get_band(char *logline);

--- a/src/addcall.h
+++ b/src/addcall.h
@@ -25,7 +25,7 @@
 extern int excl_add_veto;
 
 struct qso_t *collect_qso_data(void);
-int addcall(void);
+int addcall(struct qso_t *qso);
 int addcall2(void);
 int get_band(char *logline);
 

--- a/src/addcall.h
+++ b/src/addcall.h
@@ -22,9 +22,12 @@
 #ifndef ADDCALL_H
 #define ADDCALL_H
 
+#include "tlf.h"
+
 extern int excl_add_veto;
 
 struct qso_t *collect_qso_data(void);
+bool check_veto(int countrynr);
 int lookup_country_in_pfxnummult_array(int n);
 int addcall(struct qso_t *qso);
 int addcall2(void);

--- a/src/addcall.h
+++ b/src/addcall.h
@@ -24,6 +24,7 @@
 
 extern int excl_add_veto;
 
+struct qso_t *collect_qso_data(void);
 int addcall(void);
 int addcall2(void);
 int get_band(char *logline);

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -334,7 +334,7 @@ int getexchange(void) {
 		CONTEST_IS(CQWW) ||
 		CONTEST_IS(STEWPERRY)) {
 
-	    x = checkexchange(x);
+	    checkexchange(comment);
 	}
 
 	/* <Enter>, <Tab>, Ctl-K, '\' */
@@ -490,7 +490,7 @@ char zone_fix[3] = "";
 
 /* ------------------------------------------------------------------------ */
 
-int checkexchange(int x) {
+void checkexchange(char *comment) {
 
     char precedent[] = " ";
     char serial[5] = "    ";
@@ -670,12 +670,11 @@ int checkexchange(int x) {
 
 		    mvprintw(12, 29, "       ");
 		    mvprintw(12, 29, "%s", hiscall);
-		    mvprintw(12, 54, "%s", comment);
 		}
 	    }
 	}
 
-	return (x);
+	return;
     }
 
     // ---------------------------arrls------------------------------
@@ -766,7 +765,6 @@ int checkexchange(int x) {
 
 			mvprintw(12, 29, "       ");
 			mvprintw(12, 29, "%s", hiscall);
-			mvprintw(12, 54, "%s", comment);
 		    }
 
 		}
@@ -832,10 +830,7 @@ int checkexchange(int x) {
 	strcat(ssexchange, " ");
 	strcat(ssexchange, section);
 
-	mvprintw(12, 54, comment);
-	refreshp();
-
-	return (x);		// end arrlss
+	return;		// end arrlss
     }
 
     // ----------------------serial+section--------------------------
@@ -866,7 +861,6 @@ int checkexchange(int x) {
 		    snprintf(check, sizeof(check), "%2d",
 			     atoi(comment + hr + 2));
 		}
-
 	    }
 
 	    // get section
@@ -978,7 +972,6 @@ int checkexchange(int x) {
 
 		    mvprintw(12, 29, "       ");
 		    mvprintw(12, 29, "%s", hiscall);
-		    mvprintw(12, 54, "%s", comment);
 		}
 
 	    }
@@ -996,14 +989,6 @@ int checkexchange(int x) {
     	}
     */
     strcat(ssexchange, section);
-
-    // ---------------------------end mults --------------------------
-    if (x >= 0) {   // don't show comment when called from readcabrillo.c
-	mvprintw(12, 54, comment);
-	refreshp();
-    }
-
-    return x;
 }
 
 

--- a/src/getexchange.h
+++ b/src/getexchange.h
@@ -23,7 +23,7 @@
 
 extern int call_update;
 
-int checkexchange(int x);
+void checkexchange(char *comment);
 char *getgrid(char *comment);
 int getexchange(void);
 

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -46,6 +46,8 @@ extern char logfile[];
 extern bool iscontest;
 
 extern int country_mult;
+
+extern struct qso_t *current_qso;
 extern char hiscall[20];
 extern char hiscall_sent[20];
 extern int total;

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -34,6 +34,7 @@
 #include "gettxinfo.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "lancode.h"
+#include "log_utils.h"
 #include "makelogline.h"
 #include "scroll_log.h"
 #include "score.h"
@@ -84,7 +85,8 @@ void log_to_disk(int from_lan) {
 
 	restart_band_timer();
 
-	addcall();		/* add call to dupe list */
+	current_qso = collect_qso_data();
+	addcall(current_qso);		/* add call to dupe list */
 
 	score_qso();
 	makelogline();
@@ -99,6 +101,7 @@ void log_to_disk(int from_lan) {
 				   no need to ask for frequency */
 
 	cleanup_qso();		/* reset qso related parameters */
+	free_qso(current_qso);
     } else {			/* qso from lan */
 
 	/* LOGENTRY contains 82 characters (node,command and logline */

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -105,6 +105,7 @@ struct qso_t *parse_qso(char *buffer) {
 
     /* band */
     ptr->band = atoi(tmp);
+    ptr->bandindex = bandnr2index(ptr->band);
 
 
     /* mode */
@@ -120,6 +121,7 @@ struct qso_t *parse_qso(char *buffer) {
 
     strptime(strtok_r(NULL, " \t", &sp), DATE_FORMAT, &date_n_time);
     strptime(strtok_r(NULL, " \t", &sp), TIME_FORMAT, &date_n_time);
+    ptr->timestamp = timegm(&date_n_time);
 
     ptr->year = date_n_time.tm_year + 1900;	/* convert to
 						   1968..2067 */
@@ -140,7 +142,8 @@ struct qso_t *parse_qso(char *buffer) {
     ptr->rst_r = atoi(strtok_r(NULL, " \t", &sp));
 
     /* comment (exchange) */
-    ptr->comment = g_strndup(buffer + 54, 13);
+    ptr->comment = g_strchomp(g_strndup(buffer + 54, 13));
+
 
     /* tx */
     ptr->tx = (buffer[79] == '*') ? 1 : 0;

--- a/src/main.c
+++ b/src/main.c
@@ -989,10 +989,11 @@ int main(int argc, char *argv[]) {
     lan_init();
     keyer_init();
 
-    nr_qsos = readcalls();	/* read the logfile for score and dupe */
+    nr_qsos = readcalls(logfile);   /* read the logfile and rebuild
+				       point and multiplier scoring */
 
-    scroll_log();		/* read the last 5  log lines and set the next serial number */
-
+    scroll_log();		/* show the last 5  log lines and
+				   set the next serial number */
     show_station_info();
 
     clearmsg_wait();

--- a/src/main.c
+++ b/src/main.c
@@ -247,6 +247,8 @@ char qtc_cap_calls[40] = "";
 int qtc_auto_filltime = 0;
 int qtc_recv_lazy = 0;
 
+struct qso_t *current_qso;
+
 char hiscall[20];			/**< call of other station */
 char hiscall_sent[20] = "";		/**< part which was sent during early
 					  start */

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -83,12 +83,12 @@ void write_log_fm_cabr() {
 	strcpy(section, getgrid(comment));
     }
 
-    checkexchange(-1);
+    checkexchange(comment);
     dupe = is_dupe(hiscall, bandinx, trxmode);
     current_qso = collect_qso_data();
-    addcall(current_qso);		/* add call to worked list and check it for dupe */
+    addcall(current_qso);   /* add call to worked list and check it for dupe */
     score_qso();
-    makelogline();	/* format logline */
+    makelogline();	    /* format logline */
     store_qso(logline4);
     cleanup_qso();
     qsoflags_for_qtc[nr_qsos - 1] = 0;

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -35,6 +35,7 @@
 #include "get_time.h"
 #include "globalvars.h"
 #include "log_to_disk.h"
+#include "log_utils.h"
 #include "makelogline.h"
 #include "qtc_log.h"
 #include "readcabrillo.h"
@@ -84,12 +85,14 @@ void write_log_fm_cabr() {
 
     checkexchange(-1);
     dupe = is_dupe(hiscall, bandinx, trxmode);
-    addcall();		/* add call to worked list and check it for dupe */
+    current_qso = collect_qso_data();
+    addcall(current_qso);		/* add call to worked list and check it for dupe */
     score_qso();
     makelogline();	/* format logline */
     store_qso(logline4);
     cleanup_qso();
     qsoflags_for_qtc[nr_qsos - 1] = 0;
+    free_qso(current_qso);
 }
 
 /* write a new line to the qtc log */

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -96,25 +96,6 @@ void show_progress(int linenr) {
 }
 
 
-bool check_veto() {
-    bool veto = false;
-
-    if (!continentlist_only &&
-	    exclude_multilist_type == EXCLUDE_CONTINENT) {
-	if (is_in_continentlist(continent)) {
-	    veto = true;
-	}
-    }
-
-    if (exclude_multilist_type == EXCLUDE_COUNTRY) {
-	if (is_in_countrylist(countrynr)) {
-	    veto = true;
-	}
-    }
-
-    return veto;
-}
-
 /* pick up multi string from logline
  *
  * ATTENTION! return value needs to be freed
@@ -326,7 +307,7 @@ int readcalls(const char *logfile) {
 	    add_ok = true;
 	}
 
-	veto = check_veto();
+	veto = check_veto(countrynr);
 
 	if (add_ok) {
 

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -192,7 +192,7 @@ void count_contest_bands(int check, int *count) {
 
 
 
-int readcalls(void) {
+int readcalls(const char *logfile) {
 
     char inputbuffer[LOGLINELEN + 1];
     char checkcall[20];
@@ -448,7 +448,7 @@ int log_read_n_score() {
     int nr_qsolines;
 
     total = 0;
-    nr_qsolines = readcalls();
+    nr_qsolines = readcalls(logfile);
     if (qtcdirection > 0) {
 	readqtccalls();
     }

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -251,6 +251,26 @@ int readcalls(const char *logfile) {
 
 	countrynr = getctydata(presentcall);
 
+	/*  lookup worked stations, add if new */
+	int station = lookup_or_add_worked(presentcall);
+
+	/* and fill in according entry */
+	g_strlcpy(worked[station].exchange, inputbuffer + 54, 12);
+	g_strchomp(worked[station].exchange);	/* strip trailing spaces */
+
+	qsomode = log_get_mode(inputbuffer);
+	if (qsomode == -1) {
+	    shownr("Invalid line format in line %d.\n", linenr);
+	    refreshp();
+	    sleep(2);
+	    exit(1);
+	}
+
+	/* calculate QSO timestamp from logline */
+	worked[station].qsotime[qsomode][bandindex] =
+	    parse_time(inputbuffer + 7,	DATE_TIME_FORMAT);
+
+
 	if (continentlist_only) {
 	    if (!is_in_continentlist(continent)) {
 		qsos_per_band[bandindex]++;
@@ -284,24 +304,6 @@ int readcalls(const char *logfile) {
 	    }
 	}
 
-	/*  lookup worked stations, add if new */
-	int station = lookup_or_add_worked(presentcall);
-
-	/* and fill in according entry */
-	g_strlcpy(worked[station].exchange, inputbuffer + 54, 12);
-	g_strchomp(worked[station].exchange);	/* strip trailing spaces */
-
-	qsomode = log_get_mode(inputbuffer);
-	if (qsomode == -1) {
-	    shownr("Invalid line format in line %d.\n", linenr);
-	    refreshp();
-	    sleep(2);
-	    exit(1);
-	}
-
-	/* calculate QSO timestamp from logline */
-	worked[station].qsotime[qsomode][bandindex] =
-	    parse_time(inputbuffer + 7,	DATE_TIME_FORMAT);
 
 
 	if (pfxmultab == 1) {

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #include <time.h>
 
+#include "addcall.h"
 #include "addmult.h"
 #include "addpfx.h"
 #include "bands.h"
@@ -94,24 +95,6 @@ void show_progress(int linenr) {
     }
 }
 
-
-// lookup the current country 'n' from the outer loop
-// pfxnummulti[I].countrynr contains the country codes,
-// I:=[0..pfxnummultinr]
-// according to the order of prefixes in rules, eg:
-// PFX_NUM_MULTIS=W,VE,VK,ZL,ZS,JA,PY,UA9
-// pfxnummulti[0].countrynr will be nr of USA
-// pfxnummulti[1].countrynr will be nr of Canada
-int lookup_country_in_pfxnummult_array(int n) {
-    int found = -1;
-    for (int i = 0; i < pfxnummultinr; i++) {
-	if (pfxnummulti[i].countrynr == n) {
-	    found = i;
-	    break;
-	}
-    }
-    return found;
-}
 
 bool check_veto() {
     bool veto = false;

--- a/src/readcalls.h
+++ b/src/readcalls.h
@@ -23,7 +23,7 @@
 #define READCALLS_H
 
 int lookup_country_in_pfxnummult_array(int n);
-int readcalls(void);
+int readcalls(const char *logfile);
 int log_read_n_score();
 int synclog(char *synclogfile);
 

--- a/src/score.c
+++ b/src/score.c
@@ -347,13 +347,6 @@ int score() {
 	return points;
     }
 
-    qsos_per_band[bandinx]++;	/* qso's per band  */
-
-    if (CONTEST_IS(ARRLDX_USA)
-	    && ((countrynr == w_cty) || (countrynr == ve_cty)))
-	qsos_per_band[bandinx]--;
-
-
     if (contest->points.type == FUNCTION) {
 	return contest->points.fn();
     }

--- a/src/searchcallarray.c
+++ b/src/searchcallarray.c
@@ -133,4 +133,13 @@ bool is_dupe(char *call, int bandindex, int mode) {
 
 }
 
+/* update exchange and last worked time for given station */
+void update_worked(int station, struct qso_t *qso) {
+    if (strlen(qso->comment) > 0) {
+	g_strlcpy(worked[station].exchange, qso->comment,
+		sizeof(worked[0].exchange));
+	g_strchomp(worked[station].exchange);
+    }
+    worked[station].qsotime[qso->mode][qso->bandindex] = qso->timestamp;
+}
 

--- a/src/searchcallarray.h
+++ b/src/searchcallarray.h
@@ -30,5 +30,6 @@ int lookup_worked(char *call);
 int lookup_or_add_worked(char *call);
 bool worked_in_current_minitest_period(int found);
 bool is_dupe(char *call, int bandindex, int mode);
+void update_worked(int station, struct qso_t *qso);
 
 #endif /* SEARCHCALLARRAY_H */

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -22,6 +22,7 @@
 #define TLF_H
 
 #include <stdbool.h>
+#include <time.h>
 
 #include "hamlib/rig.h"
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -189,12 +189,14 @@ typedef struct {
 struct qso_t {
     char *logline;
     int band;
+    int bandindex;
     int mode;
     char day;
     char month;
     int year;
     int hour;
     int min;
+    time_t timestamp;
     int qso_nr;
     char *call;
     int rst_s;

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -163,7 +163,7 @@ typedef struct {
  * contains all informations about an already worked station */
 typedef struct {
     char call[20]; 		/**< call of the station */
-    char exchange[13]; 		/**< the last exchange */
+    char exchange[24]; 		/**< the last exchange */
     int band; 			/**< bitmap for worked bands */
     int country; 		/**< its country number */
     long qsotime[3][NBANDS];	/**< last timestamp of qso in gmtime

--- a/test/data.c
+++ b/test/data.c
@@ -220,6 +220,7 @@ int qtcdirection = 0;
 
 int minitest = 0;
 
+struct qso_t *current_qso;
 char hiscall[20];			/**< call of other station */
 char hiscall_sent[20] = "";		/**< part which was sent during early
 					  start */

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -5,6 +5,7 @@
 #include "../src/dxcc.h"
 #include "../src/getctydata.h"
 #include "../src/globalvars.h"
+#include "../src/log_utils.h"
 #include "../src/searchcallarray.h"
 #include "../src/score.h"
 #include "../src/setcontest.h"
@@ -92,11 +93,34 @@ int setup_addcall_pfxnum_notinList(void **state) {
     return setup_addcall_pfxnum_inList(state);
 }
 
+/* collect_qso_data */
+void test_collect (void **state) {
+    struct qso_t *qso;
+    strcpy(hiscall, "LZ1AB");
+    strcpy(comment, "Hi");
+    time_t now = time(NULL);
+    bandinx = BANDINDEX_80;
+    trxmode = CWMODE;
+
+    qso = collect_qso_data();
+    assert_non_null(qso);
+
+    assert_string_equal(qso->call, hiscall);
+    assert_string_equal(qso->comment, comment);
+    assert_int_equal(qso->bandindex, bandinx);
+    assert_int_equal(qso->mode, CWMODE);
+    assert_in_range(qso->timestamp, now, now + 1);
+
+    free_qso(qso);
+}
+
+
+/* addcall */
 void test_add_to_worked(void **state) {
     strcpy(hiscall, "LZ1AB");
     bandinx = BANDINDEX_10;
-    time_t now = time(NULL);
     strcpy(comment, "Hi");
+    time_t now = time(NULL);
 
     addcall();
 

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -11,7 +11,6 @@
 #include "../src/setcontest.h"
 
 // OBJECT ../src/addcall.o
-// OBJECT ../src/addmult.o
 // OBJECT ../src/addpfx.o
 // OBJECT ../src/bands.o
 // OBJECT ../src/dxcc.o
@@ -28,12 +27,12 @@
 // OBJECT ../src/utils.o
 // OBJECT ../src/zone_nr.o
 
-
-/* these are missing from globalvars */
-
+void addmult() {}
+void addmult2() {}
 int pacc_pa(void) {
     return 0;
 }
+
 
 /* setups */
 int setup_default(void **state) {
@@ -122,7 +121,8 @@ void test_add_to_worked(void **state) {
     strcpy(comment, "Hi");
     time_t now = time(NULL);
 
-    addcall();
+    current_qso = collect_qso_data();
+    addcall(current_qso);
 
     assert_int_equal(nr_worked, 1);
     assert_string_equal(worked[0].exchange, "Hi");
@@ -137,10 +137,14 @@ void test_add_to_worked_continentlistonly(void **state) {
     strcpy(hiscall, "LZ1AB");
     bandinx = BANDINDEX_10;
     strcpy(comment, "Hi");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
 
     strcpy(hiscall, "PY2BBB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
 
     assert_int_equal(nr_worked, 2);
     assert_string_equal(worked[0].call, "LZ1AB");
@@ -149,7 +153,10 @@ void test_add_to_worked_continentlistonly(void **state) {
 
 void test_addcall_nopfxnum(void **state) {
     strcpy(hiscall, "LZ1AB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(addcallarea, 0);
 }
 
@@ -159,7 +166,10 @@ void test_addcall_pfxnum_inList(void **state) {
     strcpy(hiscall, "LZ1AB");
     time_t now = time(NULL);
 
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(addcallarea, 1);
     assert_int_equal(pfxnummulti[1].qsos[1], BAND10);
     assert_int_equal(countryscore[BANDINDEX_10], 1);
@@ -172,37 +182,58 @@ void test_addcall_pfxnum_inList(void **state) {
 
 void test_addcall_pfxnum_notinList(void **state) {
     strcpy(hiscall, "HA2BNL");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(addcallarea, 0);
 }
 
 void test_addcall_continentlistonly(void **state) {
     continentlist_only = true;
     strcpy(hiscall, "LZ1AB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(excl_add_veto, false);
     strcpy(hiscall, "PY2BBB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(excl_add_veto, true);
 }
 
 void test_addcall_exclude_continent(void **state) {
     exclude_multilist_type = EXCLUDE_CONTINENT;
     strcpy(hiscall, "LZ1AB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(excl_add_veto, true);
     strcpy(hiscall, "PY2BBB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(excl_add_veto, false);
 }
 
 void test_addcall_exclude_country(void **state) {
     exclude_multilist_type = EXCLUDE_COUNTRY;
     strcpy(hiscall, "LZ1AB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(excl_add_veto, false);
     strcpy(hiscall, "DL1AAA");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(excl_add_veto, true);
 }
 
@@ -265,7 +296,10 @@ void test_addcall2_pfxnum_notinList(void **state) {
 void test_add_unknown_country(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "12345");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(countryscore[bandinx], 0);
     assert_int_equal(countries[getctynr("LZ1AB")], 0);
 }
@@ -273,7 +307,10 @@ void test_add_unknown_country(void **state) {
 void test_add_country(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "LZ1AB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(countryscore[bandinx], 1);
     assert_int_equal(countries[getctynr("LZ0AA")], BAND10);
 }
@@ -281,10 +318,16 @@ void test_add_country(void **state) {
 void test_add_country_2_band(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "LZ1AB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     bandinx = BANDINDEX_15;
     strcpy(hiscall, "LZ1AB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(countryscore[BANDINDEX_10], 1);
     assert_int_equal(countryscore[BANDINDEX_15], 1);
     assert_int_equal(countries[getctynr("LZ0AA")], BAND10 | BAND15);
@@ -293,9 +336,15 @@ void test_add_country_2_band(void **state) {
 void test_add_country_2_stations(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "LZ1AB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     strcpy(hiscall, "LZ3CD");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(countryscore[bandinx], 1);
     assert_int_equal(countries[getctynr("LZ0AA")], BAND10);
 }
@@ -303,9 +352,15 @@ void test_add_country_2_stations(void **state) {
 void test_add_2_countries(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "LZ1AB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     strcpy(hiscall, "DL1YZ");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(countryscore[BANDINDEX_10], 2);
     assert_int_equal(countries[getctynr("LZ0AA")], BAND10);
     assert_int_equal(countries[getctynr("DL0ABC")], BAND10);
@@ -316,7 +371,10 @@ void test_add_unknown_zone(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "12345");
     strcpy(comment, "0");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(zonescore[bandinx], 0);
     assert_int_equal(zones[15], 0);
 }
@@ -325,7 +383,10 @@ void test_add_zone(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "LZ1AB");
     strcpy(comment, "15");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(zonescore[bandinx], 1);
     assert_int_equal(zones[15], BAND10);
 }
@@ -334,10 +395,16 @@ void test_add_zone_2_band(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "LZ1AB");
     strcpy(comment, "15");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     bandinx = BANDINDEX_15;
     strcpy(hiscall, "LZ1AB");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(zonescore[BANDINDEX_10], 1);
     assert_int_equal(zonescore[BANDINDEX_15], 1);
     assert_int_equal(zones[15], BAND10 | BAND15);
@@ -347,9 +414,15 @@ void test_add_zone_2_stations(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "LZ1AB");
     strcpy(comment, "15");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     strcpy(hiscall, "LZ3CD");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(zonescore[bandinx], 1);
     assert_int_equal(zones[15], BAND10);
 }
@@ -358,10 +431,16 @@ void test_add_2_zones(void **state) {
     bandinx = BANDINDEX_10;
     strcpy(hiscall, "LZ1AB");
     strcpy(comment, "15");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     strcpy(hiscall, "DL1YZ");
     strcpy(comment, "14");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(zonescore[BANDINDEX_10], 2);
     assert_int_equal(zones[14], BAND10);
     assert_int_equal(zones[15], BAND10);
@@ -467,7 +546,10 @@ void test_add_warc(void **state) {
     bandinx = BANDINDEX_12;
     strcpy(hiscall, "LZ1AB");
     strcpy(comment, "15");
-    addcall();
+
+    current_qso = collect_qso_data();
+    addcall(current_qso);
+
     assert_int_equal(countries[getctynr("LZ0AA")], BAND12);
     assert_int_equal(new_cty, getctynr("LZ1AB"));
     assert_int_equal(zones[15], BAND12);

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -113,6 +113,30 @@ void test_collect (void **state) {
     free_qso(qso);
 }
 
+/* test check_veto() */
+void test_veto_exclude_none(void **state) {
+    assert_int_equal(check_veto(getctynr("HB9ABC")), false);
+}
+
+void test_veto_exclude_country(void **state) {
+    exclude_multilist_type = EXCLUDE_COUNTRY;
+    assert_int_equal(check_veto(getctynr("HB9ABC")), false);
+    assert_int_equal(check_veto(getctynr("DL1AAA")), true);
+}
+
+void test_veto_exclude_continent_contlist_only(void **state) {
+    continentlist_only = true;
+    exclude_multilist_type = EXCLUDE_CONTINENT;
+    assert_int_equal(check_veto(getctynr("DL1AAA")), false);
+    assert_int_equal(check_veto(getctynr("3B8AA")), false);
+}
+
+void test_veto_exclude_continent(void **state) {
+    exclude_multilist_type = EXCLUDE_CONTINENT;
+    assert_int_equal(check_veto(getctynr("DL1AAA")), true);
+    assert_int_equal(check_veto(getctynr("3B8AA")), false);
+}
+
 
 /* addcall */
 void test_add_to_worked(void **state) {

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -22,7 +22,8 @@ struct tm time_ptr_cabrillo;
 
 int qsoflags_for_qtc[MAX_QSOS];
 
-void addcall() { }
+struct qso_t *collect_qso_data() { return NULL; }
+void addcall(struct qso_t *qso) { }
 void store_qso() { nr_qsos++; }
 void cleanup_qso() { }
 void make_qtc_logline(struct read_qtc_t qtc_line, char *fname) { }

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -108,36 +108,6 @@ void test_lookup_in_pfxnummult(void **state) {
 }
 
 
-/* test check_veto() */
-void test_veto_eclude_none(void **state) {
-    assert_int_equal(check_veto(), false);
-}
-
-void test_veto_exclude_country(void **state) {
-    exclude_multilist_type = EXCLUDE_COUNTRY;
-    countrynr = getctynr("HB9ABC");
-    assert_int_equal(check_veto(), false);
-    countrynr = getctynr("DL1AAA");
-    assert_int_equal(check_veto(), true);
-}
-
-void test_veto_exclude_continent_contlist_only(void **state) {
-    continentlist_only = true;
-    exclude_multilist_type = EXCLUDE_CONTINENT;
-    strcpy(continent, "EU");
-    assert_int_equal(check_veto(), false);
-    strcpy(continent, "AF");
-    assert_int_equal(check_veto(), false);
-}
-
-void test_veto_exclude_continent(void **state) {
-    exclude_multilist_type = EXCLUDE_CONTINENT;
-    strcpy(continent, "EU");
-    assert_int_equal(check_veto(), true);
-    strcpy(continent, "AF");
-    assert_int_equal(check_veto(), false);
-}
-
 /* test readcalls */
 void test_add_to_worked(void **state) {
     write_log(LOGFILE);

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -7,6 +7,7 @@
 #include "../src/readctydata.h"
 #include "../src/globalvars.h"
 #include "../src/getctydata.h"
+#include "../src/get_time.h"
 #include "../src/readcalls.h"
 #include "../src/setcontest.h"
 
@@ -113,6 +114,10 @@ void test_add_to_worked(void **state) {
     write_log(LOGFILE);
     readcalls(LOGFILE);
     assert_int_equal(nr_worked, 1);
+    assert_string_equal(worked[0].call, "PY9BBB");
+    assert_string_equal(worked[0].exchange, "15");
+    time_t ts = parse_time(QSO1+7, DATE_TIME_FORMAT);
+    assert_int_equal(worked[0].qsotime[SSBMODE][BANDINDEX_40], ts);
 }
 
 void test_add_to_worked_continentlistonly(void **state) {
@@ -120,4 +125,5 @@ void test_add_to_worked_continentlistonly(void **state) {
     write_log(LOGFILE);
     readcalls(LOGFILE);
     assert_int_equal(nr_worked, 1);
+    assert_string_equal(worked[0].exchange, "15");
 }

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -11,6 +11,7 @@
 #include "../src/setcontest.h"
 
 // OBJECT ../src/log_utils.o
+// OBJECT ../src/addcall.o
 // OBJECT ../src/addmult.o
 // OBJECT ../src/addpfx.o
 // OBJECT ../src/bands.o


### PR DESCRIPTION
This is a first part to fix issue #248.

Besides some cleanup, simplification and restructuring it changes addcall() to accept a qso_t record of relevant 
information. That gets collected by a new function collect_qso_data() from the bunch of global variables.
Long term goal is to use the same addcall() function for evaluation of newly made QSOs and of contacts red from the log file during readcalls().

Furthermore the patch uses parse_qso() to get these information from QSOs coming in from LAN (in addcall2() ) or from reading the already written log file (in readcalls() ).

Next steps will be the use of the qso_t record for addmult() and maybe makelogline(). Furthermore the parsed qso_t struct and the evaluation results for all qsos should be kept in memory instead( or in complement) of the actual qsos[] array which stores only the plain log lines and needs a reevalution every time some value is needed from them.