### PR TITLE
Fix auto-cq stopping on terminal resize

### DIFF
--- a/src/autocq.c
+++ b/src/autocq.c
@@ -79,7 +79,7 @@ int auto_cq(void) {
 		usleep(message_time * 100);
 		time_update();
 		const int inchar = key_poll();
-		if (inchar > 0) {
+		if (inchar > 0 && inchar != KEY_RESIZE) {
 		    key = inchar;
 		}
 	    }
@@ -95,7 +95,7 @@ int auto_cq(void) {
 	    time_update();
 
 	    const int inchar = key_poll();
-	    if (inchar > 0) {
+	    if (inchar > 0 && inchar != KEY_RESIZE) {
 		key = inchar;
 	    }
 	}


### PR DESCRIPTION
Terminal resize was taken as a real keypress.