### PR TITLE
Convert own callsign to upper case

### DIFF
--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -296,11 +296,13 @@ static int cfg_call(const cfg_arg_t arg) {
 	return PARSE_WRONG_PARAMETER;
     }
 
+    for (char *p = my.call; *p; ++p) {
+	*p = g_ascii_toupper(*p);
+    }
+
     /* as other code parts rely on a trailing NL on the call
      * we add it back for now */
     strcat(my.call, "\n");
-
-    // TODO: look it up cty database and set lat/lon
 
     return PARSE_OK;
 }

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -656,7 +656,7 @@ void test_fkey_header(void **state) {
 }
 
 void test_call(void **state) {
-    int rc = call_parse_logcfg("CALL = AB1CD\r\n");
+    int rc = call_parse_logcfg("CALL = AB1cd\r\n");
     assert_int_equal(rc, PARSE_OK);
     assert_string_equal(my.call, "AB1CD\n");  // FIXME line end...
 }


### PR DESCRIPTION
Just in case one writes it in lower case... Search in cty.dat works for upcase only.