### PR TITLE
Fix when using a call with slash (e.g. portable)

### DIFF
--- a/src/cabrillo_utils.c
+++ b/src/cabrillo_utils.c
@@ -472,10 +472,8 @@ void write_cabrillo_header(FILE *fp) {
 
     // set CALLSIGN
     cbr_field_t *call = find_cabrillo_field(CBR_CALLSIGN);
-    strcpy(buffer, my.call);
-    g_strstrip(buffer);     // remove trailing NL
     FREE_DYNAMIC_STRING(call->value);
-    call->value = g_strdup(buffer);
+    call->value = g_strdup(my.call);
     call->disabled = false; // always enabled
 
     // set CLAIMED-SCORE unless disabled
@@ -613,3 +611,14 @@ static int process_cabrillo_template_file(const char *file_name) {
 
     return result;
 }
+
+void get_cabrillo_file_name(char *buffer) {
+    strcpy(buffer, my.call);
+    for (char *p = buffer; *p; p++) {
+	if (*p == '/') {    // convert '/' to '_'
+	    *p = '_';
+	}
+    }
+    strcat(buffer, ".cbr");
+}
+

--- a/src/cabrillo_utils.h
+++ b/src/cabrillo_utils.h
@@ -116,4 +116,6 @@ cbr_field_t *find_cabrillo_field(const char *name);
 int get_cabrillo_field_value(const cbr_field_t *field, char *buffer, int size);
 int add_cabrillo_field(const char *name, const char *value);
 
+void get_cabrillo_file_name(char *buffer);
+
 #endif

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -315,10 +315,6 @@ int getclusterinfo(void) {
 
     int i;
     int si;
-    char calldupe[12];
-
-    strcpy(calldupe, my.call);
-    calldupe[strlen(my.call) - 1] = '\0';
 
     for (si = 0; si < (MAX_SPOTS - 2); si++)
 	spotarray[si] = -1;
@@ -332,7 +328,7 @@ int getclusterinfo(void) {
 	    spotarray[si] = i;
 	    si++;
 
-	} else if (strstr(spot_ptr[i], calldupe) != NULL) {
+	} else if (strstr(spot_ptr[i], my.call) != NULL) {
 	    if ((announcefilter <= 2)) {
 		spotarray[si] = i;
 		si++;

--- a/src/getmessages.c
+++ b/src/getmessages.c
@@ -32,13 +32,14 @@
 void getstationinfo() {
     dxcc_data *mydx;
 
-    my.countrynr = getctydata(my.call);	/* whoami? */
+    my.countrynr = getctydata(my.call);        /* whoami? */
+
     mydx = dxcc_by_index(my.countrynr);
 
     my.cqzone = mydx -> cq;
     strcpy(my.continent, mydx->continent);
 
-    /* whereami? use QRA is possible */
+    /* whereami? use QRA if possible */
     if (RIG_OK == locator2longlat(&my.Long, &my.Lat, my.qra)) {
 	my.Long = -my.Long;     // W <-> E fix
     } else {
@@ -52,14 +53,10 @@ void show_station_info(void) {
 
     getstationinfo();
 
-    printw("\n     Call = ");
-    printw(my.call);
-
+    printw("\n     Call = %s\n", my.call);
     printw("     My Zone = %d", my.cqzone);
-
-    printw("     My Continent = ");
-    printw(my.continent);
-
+    printw("     My Continent = %s", my.continent);
     printw("\n\n");
+
     refreshp();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -965,8 +965,8 @@ int main(int argc, char *argv[]) {
 
     if (convert_cabrillo) {
 	char *tstring =
-	    g_strdup_printf("Converting Cabrillo for contest %s from file %s.cbr",
-			    whichcontest, g_strstrip(my.call));
+	    g_strdup_printf("Converting Cabrillo for contest %s for %s",
+			    whichcontest, my.call);
 	showmsg(tstring);
 	g_free(tstring);
 	showmsg("");

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -285,7 +285,7 @@ static int cfg_tlfcolor(const cfg_arg_t arg) {
 
 static int cfg_call(const cfg_arg_t arg) {
     int rc = cfg_string((cfg_arg_t) {
-	.char_p = my.call, .size = 20 - 1, // keep space for NL
+	.char_p = my.call, .size = sizeof(my.call),
 	.strip = true, .string_type = STATIC
     });
     if (rc != PARSE_OK) {
@@ -299,10 +299,6 @@ static int cfg_call(const cfg_arg_t arg) {
     for (char *p = my.call; *p; ++p) {
 	*p = g_ascii_toupper(*p);
     }
-
-    /* as other code parts rely on a trailing NL on the call
-     * we add it back for now */
-    strcat(my.call, "\n");
 
     return PARSE_OK;
 }

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -432,9 +432,10 @@ int readcabrillo(int mode) {
 
     strcpy(temp_logfile, logfile);
 
-    strcpy(input_logfile, my.call);
-    g_strchomp(input_logfile); /* drop \n */
-    strcat(input_logfile, ".cbr");
+    get_cabrillo_file_name(input_logfile);
+    tempstrp = g_strdup_printf("Reading from %s", input_logfile);
+    show_readcab_msg(mode, tempstrp);
+    g_free(tempstrp);
 
     strcpy(output_logfile, "IMPORT_");
     strcat(output_logfile, logfile);

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -169,14 +169,11 @@ void ExpandMacro(void) {
     extern int noleadingzeros;
 
     int i;
-    static char comstr[BUFSIZE] = "";
     static char qsonroutput[5] = "";
     static char rst_out[4] = "";
 
 
-    strcpy(comstr, my.call);
-    comstr[strlen(my.call) - 1] = '\0'; // skip trailing \n
-    replace_all(buffer, BUFSIZE, "%", comstr);   /* mycall */
+    replace_all(buffer, BUFSIZE, "%", my.call);   /* mycall */
 
 
     if (NULL != strstr(buffer, "@")) {

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -634,7 +634,7 @@ void addtext(char *s) {
     }
 
     // Cluster private spotting interface
-    if (strncmp(s, my.call, strlen(my.call) - 1) == 0
+    if (strncmp(s, my.call, strlen(my.call)) == 0
 	    && strlen(s) < 81 && strchr(s, '>') == NULL) {
 
 	mvprintw(LINES - 1, 0, backgrnd_str);

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -306,7 +306,8 @@ static gchar *get_sent_exchage(int qso_nr) {
 
 /* format QSO: or QTC: line according to Cabrillo format description
  * and put it into buffer */
-void prepare_line(struct linedata_t *qso, struct cabrillo_desc *desc, char *buf) {
+void prepare_line(struct linedata_t *qso, struct cabrillo_desc *desc,
+		  char *buf) {
 
     freq_t freq;
     int i;
@@ -360,8 +361,7 @@ void prepare_line(struct linedata_t *qso, struct cabrillo_desc *desc, char *buf)
 		add_lpadded(buf, tmp, item->len);
 		break;
 	    case MYCALL:
-		strcpy(tmp, my.call);
-		add_rpadded(buf, g_strchomp(tmp), item->len);
+		add_rpadded(buf, my.call, item->len);
 		break;
 	    case HISCALL:
 		add_rpadded(buf, qso->call, item->len);
@@ -457,7 +457,7 @@ static void set_exchange_format() {
 int write_cabrillo(void) {
 
     struct cabrillo_desc *cabdesc;
-    char cabrillo_tmp_name[80];
+    char cabrillo_file_name[80];
     char buffer[4000] = "";
 
     FILE *fp1, *fp2, *fpqtcrec = NULL, *fpqtcsent = NULL;
@@ -483,10 +483,6 @@ int write_cabrillo(void) {
     }
 
     /* open logfile and create a Cabrillo file */
-    strcpy(cabrillo_tmp_name, my.call);
-    g_strstrip(cabrillo_tmp_name); /* drop \n */
-    strcat(cabrillo_tmp_name, ".cbr");
-
     if ((fp1 = fopen(logfile, "r")) == NULL) {
 	info("Can't open logfile.");
 	sleep(2);
@@ -516,7 +512,9 @@ int write_cabrillo(void) {
 	    }
 	}
     }
-    if ((fp2 = fopen(cabrillo_tmp_name, "w")) == NULL) {
+
+    get_cabrillo_file_name(cabrillo_file_name);
+    if ((fp2 = fopen(cabrillo_file_name, "w")) == NULL) {
 	info("Can't create Cabrillo file.");
 	sleep(2);
 	free_cabfmt(cabdesc);
@@ -654,7 +652,7 @@ void write_adif_header(FILE *fp) {
      fp);
 
     format_time(timebuf, sizeof(timebuf), CREATED_DATE_TIME_FORMAT);
-    fprintf(fp, "Created %s for %s\n", timebuf, my.call);
+    fprintf(fp, "Created %s for %s\n\n", timebuf, my.call);
 
     /* Write contest name */
     fprintf(fp, "Contest Name: %s\n", whichcontest);

--- a/test/test_clusterinfo.c
+++ b/test/test_clusterinfo.c
@@ -96,7 +96,7 @@ static void put_short_line(char *p, int index) {
 }
 
 int setup_default(void **state) {
-    strcpy(my.call, "N0CALL\n"); 		// !!! do not forget trailing \n
+    strcpy(my.call, "N0CALL");
 
     xplanet = MARKER_NONE;
 

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -164,15 +164,18 @@ void test_location_unknown_used(void **state) {
 
 /* getctynr */
 void test_suffix_getctynr(void **state) {
-    assert_int_not_equal(getctynr("LA3BB"), 0);
-    assert_int_not_equal(getctynr("LA3BB/QRP"), 0);
-    assert_int_equal(getctynr("LA3BB/QRP"), getctynr("LA3BB"));
+    int cty_la = getctynr("LA3BB");
+    assert_int_not_equal(cty_la, 0);
+    assert_int_equal(getctynr("LA3BB/QRP"), cty_la);
+    assert_int_equal(getctynr("LA3BB/P"), cty_la);
 }
 
 /* getctydata */
 void test_suffix_getctydata(void **state) {
-    assert_int_not_equal(getctydata("LA3BB"), 0);
-    assert_int_not_equal(getctydata("LA3BB/QRP"), 0);
+    int cty_la = getctydata("LA3BB");
+    assert_int_not_equal(cty_la, 0);
+    assert_int_equal(getctydata("LA3BB/QRP"), cty_la);
+    assert_int_equal(getctydata("LA3BB/P"), cty_la);
 }
 
 void test_someidea(void **data) {

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -658,7 +658,7 @@ void test_fkey_header(void **state) {
 void test_call(void **state) {
     int rc = call_parse_logcfg("CALL = AB1cd\r\n");
     assert_int_equal(rc, PARSE_OK);
-    assert_string_equal(my.call, "AB1CD\n");  // FIXME line end...
+    assert_string_equal(my.call, "AB1CD");
 }
 
 void test_cabrillo(void **state) {

--- a/test/test_sendbuf.c
+++ b/test/test_sendbuf.c
@@ -87,7 +87,7 @@ int setup_default(void **state) {
     trxmode = CWMODE;
     cwkeyer = 1;
     digikeyer = 1;
-    strcpy(my.call, "dl1jbe\n"); 		// !!! do not forget trailing \n
+    strcpy(my.call, "dl1jbe");
     strcpy(hiscall, "lz1ab");
     strcpy(sent_rst, "579");
     shortqsonr = LONGCW;
@@ -191,12 +191,12 @@ void test_expandHisNr(void **state) {
 /* Tests sendSPcall() */
 void test_prepareSPcallCWnoDeMode(void **state) {
     demode = 0;
-    assert_string_equal(SPcall = PrepareSPcall(), "dl1jbe\n");
+    assert_string_equal(SPcall = PrepareSPcall(), "dl1jbe");
 }
 
 void test_prepareSPcallCWDeMode(void **state) {
     demode = 1;
-    assert_string_equal(SPcall = PrepareSPcall(), "DE dl1jbe\n");
+    assert_string_equal(SPcall = PrepareSPcall(), "DE dl1jbe");
 }
 
 void test_prepareSPcallDIGInoDeMode(void **state) {

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -461,7 +461,8 @@ Write Cabrillo file according to specified format (see
 statement in the
 .B RULES
 section). The file is created in the current directory as
-.IR YOURCALL.cbr .
+.I YOURCALL.cbr
+(with slashes converted to underscore).
 .
 .SH KEYS
 .


### PR DESCRIPTION
Having a call containing a slash causes two issues:

1. Cabrillo file can't be saved (or imported) as '/' is not a valid file name character.
2. Lookup of own call fails on startup. Trailing NL interferes somehow.

The fix drops the legacy trailing NL and in Cabrillo file name slash is replaced by underscore.