### PR TITLE
use qso_t in addmult()

### DIFF
--- a/src/addcall.c
+++ b/src/addcall.c
@@ -70,6 +70,7 @@ struct qso_t *collect_qso_data(void) {
     qso->call = g_strdup(hiscall);
     qso->mode = trxmode;
     qso->bandindex = bandinx;
+    qso->freq = freq;
     qso->timestamp = get_time();
     qso->comment = g_strdup(comment);
     return qso;
@@ -213,7 +214,7 @@ int addcall(struct qso_t *qso) {
 	}
     }
 
-    addmult();			/* for wysiwyg */
+    addmult(current_qso);       /* for wysiwyg */
 
     return cty;
 }
@@ -346,7 +347,7 @@ int addcall2(void) {
 	}
     }
 
-    addmult2();	/* for wysiwyg from LAN */
+    addmult_lan();	/* for wysiwyg from LAN */
 
     free_qso(qso);
     qso = NULL;

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -42,15 +42,14 @@ GPtrArray *mults_possible;
 enum { ALL_BAND, PER_BAND };
 
 
-int addmult(void) {
-    int found = 0;
+void addmult(struct qso_t *qso) {
     int i;
     int matching_len = 0, idx = -1;
     char *stripped_comment;
 
     new_mult = -1;
 
-    stripped_comment = strdup(comment);
+    stripped_comment = strdup(qso->comment);
     g_strchomp(stripped_comment);
 
     // --------------------------- arrlss ------------------------------------
@@ -139,23 +138,20 @@ int addmult(void) {
 
     /* -------------- unique call multi -------------- */
     if (unique_call_multi == UNIQUECALL_ALL) {
-	new_mult = remember_multi(hiscall, bandinx, ALL_BAND);
+	new_mult = remember_multi(qso->call, bandinx, ALL_BAND);
     }
 
     if (unique_call_multi == UNIQUECALL_BAND) {
-	new_mult = remember_multi(hiscall, bandinx, PER_BAND);
+	new_mult = remember_multi(qso->call, bandinx, PER_BAND);
     }
 
     free(stripped_comment);
-
-    return (found);
 }
 
 
 /* -------------------------------------------------------------------*/
 
-int addmult2(void) {
-    int found = 0;
+void addmult_lan(void) {
     int i;
     int matching_len = 0, idx = -1;
     char ssexchange[21];
@@ -209,8 +205,6 @@ int addmult2(void) {
 	new_mult = remember_multi(multi_call, bandinx, PER_BAND);
     }
 
-
-    return (found);
 }
 
 

--- a/src/addmult.h
+++ b/src/addmult.h
@@ -23,6 +23,8 @@
 
 #include <glib.h>
 
+#include "tlf.h"
+
 /** possible multi
  *
  * name of possible multiplier and
@@ -33,8 +35,8 @@ typedef struct {
 } possible_mult_t;
 
 
-int addmult(void);
-int addmult2(void);
+void addmult(struct qso_t *qso);
+void addmult_lan(void);
 char *get_mult(int n);
 int get_mult_count(void);
 unsigned int get_matching_length(char *str, unsigned int n);

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -28,7 +28,7 @@
 // OBJECT ../src/zone_nr.o
 
 void addmult() {}
-void addmult2() {}
+void addmult_lan() {}
 int pacc_pa(void) {
     return 0;
 }
@@ -93,7 +93,7 @@ int setup_addcall_pfxnum_notinList(void **state) {
 }
 
 /* collect_qso_data */
-void test_collect (void **state) {
+void test_collect(void **state) {
     struct qso_t *qso;
     strcpy(hiscall, "LZ1AB");
     strcpy(comment, "Hi");

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -27,7 +27,7 @@
 // OBJECT ../src/utils.o
 // OBJECT ../src/zone_nr.o
 
-void addmult() {}
+void addmult(struct qso_t qso) {}
 void addmult_lan() {}
 int pacc_pa(void) {
     return 0;

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -2,12 +2,12 @@
 
 #include "../src/tlf.h"
 #include "../src/addmult.h"
+#include "../src/addcall.h"
 #include "../src/dxcc.h"
 #include "../src/globalvars.h"
 #include "../src/bands.h"
 #include "../src/setcontest.h"
-#include <stdio.h>
-#include <unistd.h>
+#include "../src/log_utils.h"
 
 // OBJECT ../src/addmult.o
 // OBJECT ../src/addpfx.o
@@ -17,6 +17,12 @@
 // OBJECT ../src/setcontest.o
 // OBJECT ../src/score.o
 // OBJECT ../src/utils.o
+// OBJECT ../src/log_utils.o
+// OBJECT ../src/addcall.o
+// OBJECT ../src/get_time.o
+// OBJECT ../src/searchcallarray.o
+// OBJECT ../src/paccdx.o
+// OBJECT ../src/zone_nr.o
 
 
 /* dummies */
@@ -30,6 +36,7 @@ int getctydata(char *checkcall) {
 
 
 contest_config_t config_focm;
+struct qso_t *this_qso;
 
 
 char *testfile = "mults";
@@ -85,7 +92,19 @@ int setup_default(void **state) {
     return 0;
 }
 
-/* tewst initialization of 'multis' */
+void set_this_qso(char *exchange) {
+    strcpy(comment, exchange);
+    this_qso = collect_qso_data();
+}
+
+
+int teardown_default(void **state) {
+    free_qso(this_qso);
+    this_qso = NULL;
+    return 0;
+}
+
+/* test initialization of 'multis' */
 void test_init_mults(void **state) {
     nr_multis = 2;
     strcpy(multis[0].name, "abc");
@@ -249,31 +268,35 @@ void test_match_length_match_alias2(void **state) {
 /* addmult tests */
 void test_wysiwyg_once(void **state) {
     wysiwyg_once = 1;
-    strcpy(comment, "WAC   ");
-    assert_int_equal(addmult(), 0);
+    set_this_qso("WAC   ");
+    addmult(this_qso);
+    assert_true(new_mult >= 0);
     assert_string_equal(multis[0].name, "WAC");
     assert_int_equal(new_mult, 0);
 }
 
 void test_wysiwyg_multi(void **state) {
     wysiwyg_multi = 1;
-    strcpy(comment, "WAC   ");
-    assert_int_equal(addmult(), 0);
+    set_this_qso("WAC   ");
+    addmult(this_qso);
+    assert_true(new_mult >= 0);
     assert_string_equal(multis[0].name, "WAC");
     assert_int_equal(new_mult, 0);
 }
 
 void test_wysiwyg_multi_empty(void **state) {
     wysiwyg_multi = 1;
-    strcpy(comment, "   ");
-    addmult();
+    set_this_qso("   ");
+    addmult(this_qso);
     assert_int_equal(new_mult, -1);
 }
 
 void test_serial_grid4(void **state) {
     serial_grid4_mult = 1;
     strcpy(section, "JO60LX");
-    assert_int_equal(addmult(), 0);
+    set_this_qso("");   // NOTE: section is not part of qso_t
+    addmult(this_qso);
+    assert_true(new_mult >= 0);
     assert_string_equal(multis[0].name, "JO60");
     assert_int_equal(new_mult, 0);
 }
@@ -281,7 +304,8 @@ void test_serial_grid4(void **state) {
 
 void test_serial_grid4_empty(void **state) {
     serial_grid4_mult = 1;
-    addmult();
+    set_this_qso("");   // NOTE: section is not part of qso_t
+    addmult(this_qso);
     assert_int_equal(new_mult, -1);
 }
 
@@ -290,13 +314,14 @@ void test_arrlss(void **state) {
 
     setup_multis("SC\nSCV\n");
     strcpy(ssexchange, "SCV");
-    addmult();
+    set_this_qso("");   // NOTE: ssexchange is not part of qso_t
+    addmult(this_qso);
     strcpy(ssexchange, "97A23SCV");
-    addmult();
+    addmult(this_qso);
     strcpy(ssexchange, "KL");
-    addmult();
+    addmult(this_qso);
     strcpy(ssexchange, "SC");
-    addmult();
+    addmult(this_qso);
     assert_int_equal(nr_multis, 2);
     assert_string_equal(multis[0].name, "SCV");
     assert_string_equal(multis[1].name, "SC");
@@ -306,13 +331,14 @@ void test_serial_section_mult(void **state) {
     serial_section_mult = 1;
     setup_multis("NE\nONE\n");
     strcpy(ssexchange, "ONE");
-    addmult();
+    set_this_qso("");   // NOTE: ssexchange is not part of qso_t
+    addmult(this_qso);
     strcpy(ssexchange, "023");
-    addmult();
+    addmult(this_qso);
     strcpy(ssexchange, "NE");
-    addmult();
+    addmult(this_qso);
     strcpy(ssexchange, "SC");
-    addmult();
+    addmult(this_qso);
     assert_int_equal(nr_multis, 2);
 }
 
@@ -321,18 +347,19 @@ void test_dx_arrlsections(void **state) {
     countrynr = w_cty;
     setup_multis("NE\nONE\n");
     strcpy(ssexchange, "ONE");
-    addmult();
+    set_this_qso("");   // NOTE: ssexchange is not part of qso_t
+    addmult(this_qso);
     strcpy(ssexchange, "97A23SCV");
-    addmult();
+    addmult(this_qso);
     strcpy(ssexchange, "NE");
-    addmult();
+    addmult(this_qso);
     strcpy(ssexchange, "SC");
-    addmult();
+    addmult(this_qso);
     assert_int_equal(nr_multis, 2);
 }
 
 
-/* addmult2 tests */
+/* addmult_lan tests */
 char logline[] =
     " 20CW  08-Feb-11 17:06 0025  W3ND           599  599   95 A 12 SCV            2 ";
 
@@ -344,13 +371,13 @@ void test_arrlss_2(void **state) {
 
     setup_multis("SC\nSCV\n");
     strcpy(lan_logline, logline);
-    addmult2();
+    addmult_lan();
     memcpy(lan_logline + 54, " 97 A 23 SCV", 12);
-    addmult2();
+    addmult_lan();
     memcpy(lan_logline + 63, "KL ", 3);
-    addmult2();
+    addmult_lan();
     memcpy(lan_logline + 63, "SC ", 3);
-    addmult2();
+    addmult_lan();
     assert_int_equal(nr_multis, 2);
     assert_string_equal(multis[0].name, "SCV");
     assert_string_equal(multis[1].name, "SC");
@@ -359,7 +386,8 @@ void test_arrlss_2(void **state) {
 void test_wysiwyg_once_2(void **state) {
     wysiwyg_once = 1;
     strcpy(lan_logline, logline_2);
-    assert_int_equal(addmult2(), 0);
+    addmult_lan();
+    assert_true(new_mult >= 0);
     assert_string_equal(multis[0].name, "WAC");
     assert_int_equal(new_mult, 0);
 }
@@ -368,7 +396,8 @@ void test_wysiwyg_once_2(void **state) {
 void test_wysiwyg_multi_2(void **state) {
     wysiwyg_multi = 1;
     strcpy(lan_logline, logline_2);
-    assert_int_equal(addmult2(), 0);
+    addmult_lan();
+    assert_true(new_mult >= 0);
     assert_string_equal(multis[0].name, "WAC");
     assert_int_equal(new_mult, 0);
 }


### PR DESCRIPTION
A non-functional change: propagating the use of `qso_t` instead of global variables. This allows adding a cleaner multiplier handling in the plugin branch.
`addmult2()` was not changed, apart from renaming to `addmult_lan()`. It should be the same as `addmult()`, to be fixed once we come to review the network code.