### PR TITLE
Fix clearing info line by keyer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,16 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libhamlib-dev
   - sudo apt-get install -y libxmlrpc-core-c3-dev
-  - wget https://cmocka.org/files/1.0/cmocka-1.0.1.tar.xz
-  - tar -xvf cmocka-1.0.1.tar.xz
-  - cd cmocka-1.0.1
+  - wget https://cmocka.org/files/1.1/cmocka-1.1.5.tar.xz
+  - tar -xvf cmocka-1.1.5.tar.xz
+  - cd cmocka-1.1.5
   - mkdir build
   - cd build
   - cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug ..
   - make
   - sudo make install
   - cd ../..
-  - rm -rf cmocka-1.0.1 cmocka-1.0.1.tar.xz
+  - rm -rf cmocka-1.1.5 cmocka-1.1.5.tar.xz
   
 script: 
   - autoreconf -i && ./configure && make

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -108,7 +108,7 @@ void calledit(void) {
 		hiscall[j] = hiscall[j + 1];	/* move to left incl. \0 */
 	    }
 
-	    showinfo(getctydata_pfx(hiscall));
+	    show_call_info(hiscall);
 
 	    if (cnt > 1)
 		searchlog();
@@ -126,7 +126,7 @@ void calledit(void) {
 		    hiscall[j] = hiscall[j + 1];
 		}
 
-		showinfo(getctydata_pfx(hiscall));
+		show_call_info(hiscall);
 
 		if (cnt > 1)
 		    searchlog();
@@ -173,7 +173,7 @@ void calledit(void) {
 		else
 		    break;
 
-		showinfo(getctydata_pfx(hiscall));
+		show_call_info(hiscall);
 
 		searchlog();
 

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -26,6 +26,7 @@
 
 #include <string.h>
 
+#include "callinput.h"
 #include "getctydata.h"
 #include "globalvars.h"
 #include "keystroke_names.h"
@@ -108,7 +109,7 @@ void calledit(void) {
 		hiscall[j] = hiscall[j + 1];	/* move to left incl. \0 */
 	    }
 
-	    show_call_info(hiscall);
+	    update_info_line();
 
 	    if (cnt > 1)
 		searchlog();
@@ -126,7 +127,7 @@ void calledit(void) {
 		    hiscall[j] = hiscall[j + 1];
 		}
 
-		show_call_info(hiscall);
+		update_info_line();
 
 		if (cnt > 1)
 		    searchlog();
@@ -143,11 +144,9 @@ void calledit(void) {
 	} else if (i != ESCAPE) {
 
 	    // Promote lower case to upper case.
-	    if ((i >= 97) && (i <= 122))
-		i = i - 32;
+	    i = g_ascii_toupper(i);
 
-	    // Accept A-Z or / and 1-9
-	    if (((i >= 65) && (i <= 90)) || ((i >= 47) && (i <= 57))) {
+	    if (valid_call_char(i)) {
 
 		call2[0] = '\0';
 
@@ -173,7 +172,7 @@ void calledit(void) {
 		else
 		    break;
 
-		show_call_info(hiscall);
+		update_info_line();
 
 		searchlog();
 

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -200,7 +200,7 @@ int callinput(void) {
 		    grab.state = REACHED;
 		    grab.spotfreq = freq;
 
-		    showinfo(getctydata_pfx(hiscall));
+		    show_call_info(hiscall);
 		    printcall();
 		    searchlog();
 		    freqstore = 0;
@@ -222,7 +222,7 @@ int callinput(void) {
 		hiscall[0] = '\0';
 		printcall();
 		HideSearchPanel();
-		showinfo(SHOWINFO_DUMMY);
+		show_call_info(hiscall);
 	    }
 
 
@@ -635,7 +635,7 @@ int callinput(void) {
 		    hiscall[strlen(hiscall) - 1] = '\0';
 
 		    if (atoi(hiscall) < 1800) {	/*  no frequency */
-			showinfo(getctydata_pfx(hiscall));
+			show_call_info(hiscall);
 			searchlog();
 			refreshp();
 		    }
@@ -855,9 +855,9 @@ int callinput(void) {
 
 	    // Ctrl-A (^A), add a spot and share on LAN.
 	    case CTRL_A: {
-		addspot();
+		addspot();      // note: clears call input field
 		HideSearchPanel();
-		showinfo(SHOWINFO_DUMMY);
+		show_call_info(hiscall);
 
 		grab.state = REACHED;
 		grab.spotfreq = freq;
@@ -1010,7 +1010,7 @@ int callinput(void) {
 
 	    if (atoi(hiscall) < 1800) {	/*  no frequency */
 
-		showinfo(getctydata_pfx(hiscall));
+		show_call_info(hiscall);
 		searchlog();
 	    }
 
@@ -1303,7 +1303,7 @@ void handle_memory_operation(memory_op_t op) {
     }
 
     show_header_line();
-    showinfo(getctydata_pfx(hiscall));
+    show_call_info(hiscall);
     searchlog();
     move(12, 29 + strlen(hiscall));
 

--- a/src/callinput.h
+++ b/src/callinput.h
@@ -21,10 +21,13 @@
 #ifndef CALLINPUT_H
 #define CALLINPUT_H
 
+#include <stdbool.h>
+
 #include <hamlib/rig.h>
 
 int callinput(void);
 void play_file(char *audiofile);
 void send_bandswitch(freq_t freq);
+bool valid_call_char(int ch);
 
 #endif /* CALLINPUT_H */

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -151,9 +151,7 @@ void clear_display(void) {
     printcall();
     refresh_comment();
 
-    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-    mvaddstr(LINES - 1, 0, backgrnd_str);
-    wwv_show_footer();
+    show_call_info(hiscall);
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
     move(cury, curx);
@@ -180,9 +178,4 @@ void displayit(void) {
     mvprintw(5, 0, "");
 
     clear_display();
-
-    // show DX info if available
-    if (strlen(hiscall) >= 3) {
-	showinfo(getctydata_pfx(hiscall));
-    }
 }

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -32,6 +32,7 @@
 #include "cw_utils.h"
 #include "change_rst.h"
 #include "get_time.h"
+#include "getctydata.h"
 #include "getwwv.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "logit.h"
@@ -40,6 +41,7 @@
 #include "qsonr_to_str.h"
 #include "searchlog.h"		// Includes glib.h
 #include "setcontest.h"
+#include "showinfo.h"
 #include "showscore.h"
 #include "time_update.h"
 #include "tlf.h"
@@ -178,4 +180,9 @@ void displayit(void) {
     mvprintw(5, 0, "");
 
     clear_display();
+
+    // show DX info if available
+    if (strlen(hiscall) >= 3) {
+	showinfo(getctydata_pfx(hiscall));
+    }
 }

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -151,7 +151,7 @@ void clear_display(void) {
     printcall();
     refresh_comment();
 
-    show_call_info(hiscall);
+    update_info_line();
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
     move(cury, curx);

--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -48,7 +48,7 @@ prefix_data dummy_pfx = {
     0,
     INFINITY,
     INFINITY,
-    NULL,
+    "",
     INFINITY,
     false
 };
@@ -105,7 +105,7 @@ unsigned int prefix_count(void) {
 
 /* give pointer to prefix struct at 'index' */
 prefix_data *prefix_by_index(unsigned int index) {
-    if (index >= prefix_count())
+    if (index < 0 || index >= prefix_count())
 	return &dummy_pfx;
 
     return (prefix_data *)g_ptr_array_index(prefix, index);
@@ -201,7 +201,7 @@ void prefix_add(char *pfxstr) {
 	new_prefix -> timezone = atof(loc + 1);
 	*loc = '\0';
     } else
-	new_prefix -> timezone = INFINITY;
+	new_prefix -> timezone = last_dx->timezone;
 
     loc = strchr(pfxstr, '{');
     if (loc != NULL) {
@@ -211,7 +211,7 @@ void prefix_add(char *pfxstr) {
 	if (loc != NULL)
 	    *loc = '\0';
     } else
-	new_prefix -> continent = NULL;
+	new_prefix -> continent = g_strdup(last_dx->continent);
 
     loc = strchr(pfxstr, '<');
     if (loc != NULL) {
@@ -221,8 +221,10 @@ void prefix_add(char *pfxstr) {
 	    new_prefix -> lon = atof(loc + 1);
 	else
 	    new_prefix -> lon = INFINITY;
-    } else
-	new_prefix -> lat = new_prefix -> lon = INFINITY;
+    } else {
+	new_prefix -> lat = last_dx->lat;
+	new_prefix -> lon = last_dx->lon;
+    }
 
     loc = strchr(pfxstr, '[');
     if (loc != NULL) {

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -172,10 +172,9 @@ int getctynr(char *checkcall) {
  * side effect: set up various global variables
  */
 static int getctydata_internal(char *checkcallptr, bool get_country) {
-    int w = 0, x = 0;
     char *normalized_call = NULL;
 
-    w = getpfxindex(checkcallptr, &normalized_call);
+    int w = getpfxindex(checkcallptr, &normalized_call);
 
     if (CONTEST_IS(WPX) || pfxmult == 1)
 	/* needed for wpx and other pfx contests */
@@ -183,26 +182,19 @@ static int getctydata_internal(char *checkcallptr, bool get_country) {
 
     free(normalized_call);
 
-    if (w >= 0) {
-	x = prefix_by_index(w)->dxcc_index;
-	sprintf(cqzone, "%02d", prefix_by_index(w) -> cq);
-	sprintf(ituzone, "%02d", prefix_by_index(w) -> itu);
-    }
+    // fill global variables
+    prefix_data *pfx = prefix_by_index(w);
+    countrynr = pfx->dxcc_index;
+    sprintf(cqzone, "%02d", pfx->cq);
+    sprintf(ituzone, "%02d", pfx->itu);
+    DEST_Lat = pfx->lat;
+    DEST_Long = pfx->lon;
+    strcpy(zone_export, itumult ? ituzone : cqzone);
 
-    if (itumult != 1)
-	strcpy(zone_export, cqzone);
-    else
-	strcpy(zone_export, ituzone);
+    g_strlcpy(continent, pfx->continent, 3);
 
-    countrynr = x;
-    if (prefix_by_index(w) -> continent != NULL)
-	g_strlcpy(continent, prefix_by_index(w) -> continent, 3);
-    else
-	g_strlcpy(continent, dxcc_by_index(countrynr) -> continent, 3);
 
-    if (get_country)
-	return (x);
-    return w;
+    return get_country ? countrynr : w;
 }
 
 int getctydata(char *checkcallptr) {

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -71,6 +71,9 @@ int getpfxindex(char *checkcallptr, char **normalized_call) {
     char checkcall[17] = "";
     char strippedcall[17] = "";
 
+    if (checkcallptr == NULL) {
+	return -1;
+    }
 
     int w = 0, abnormal_call = 0;
     size_t loc;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -251,3 +251,6 @@ extern bool debugflag;
 extern bool trx_control;
 extern bool nopacket;
 extern bool verbose;
+
+extern double DEST_Lat;
+extern double DEST_Long;

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -91,7 +91,7 @@ static freq_t execute_grab(spot *data) {
 
     strcpy(hiscall, data->call);
 
-    showinfo(getctydata_pfx(hiscall));
+    show_call_info(hiscall);
     searchlog();
 
     /* if in CQ mode switch to S&P and remember QRG */

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -91,16 +91,11 @@ static freq_t execute_grab(spot *data) {
 
     strcpy(hiscall, data->call);
 
-    show_call_info(hiscall);
-    searchlog();
-
     /* if in CQ mode switch to S&P and remember QRG */
     if (cqmode == CQ) {
 	memory_store();
 	cqmode = S_P;
     }
-
-    refreshp();
 
     free_spot(data);
 

--- a/src/logit.c
+++ b/src/logit.c
@@ -52,6 +52,16 @@
 void refresh_comment(void);
 void change_mode(void);
 
+static void log_qso() {
+    log_to_disk(false);
+    if (sprint_mode) {
+	change_mode();
+    }
+    HideSearchPanel();
+    clear_display();
+    refreshp();
+}
+
 void logit(void) {
     extern char itustr[];
     extern int defer_store;
@@ -95,7 +105,6 @@ void logit(void) {
 
 		if ((cqmode == CQ) && iscontest
 			&& (defer_store == 0)) {	/* CQ mode */
-
 		    send_standard_message(2);
 		    if (trxmode != CWMODE && trxmode != DIGIMODE) {
 			if (contest->exchange_serial)
@@ -169,23 +178,14 @@ void logit(void) {
 			defer_store = 0;
 		    }
 
-		    log_to_disk(false);
-		    if (sprint_mode == 1) {
-			change_mode();
-		    }
-		    HideSearchPanel();
-
+		    log_qso();
 		}
 	    }
 
 	    if ((callreturn == BACKSLASH) && (*hiscall != '\0')) {
 		defer_store = 0;
 
-		log_to_disk(false);
-		if (sprint_mode == 1) {
-		    change_mode();
-		}
-		HideSearchPanel();
+		log_qso();
 	    }
 
 	    if (callreturn == CTRL_K || callreturn == 44) {	/*  CTRL K  */

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -35,10 +35,6 @@
 
 #define LINELENGTH 80
 
-static pthread_mutex_t showinfo_mutex = PTHREAD_MUTEX_INITIALIZER;
-
-static bool showing_country = false;    // false: empty or showing WWV info
-
 /** Show infos for selected country on bottom of screen
  *
  * Prepares info string for the selected country and shows it on the
@@ -52,7 +48,6 @@ static void showinfo_internal(int pfx_index) {
     int cury, curx;
     double bearing;
     double range;
-
     char timebuff[80];
 
     prefix_data *pfx = prefix_by_index(pfx_index);
@@ -64,7 +59,6 @@ static void showinfo_internal(int pfx_index) {
     mvaddstr(LINES - 1, 0, backgrnd_str);
 
     if (pfx->dxcc_index > 0) {
-	showing_country = true;
 	mvprintw(LINES - 1, 0, " %s  %s", dx->pfx, dx->countryname);
 
 	mvprintw(LINES - 1, 26, " %s %02d", pfx->continent, pfx->cq);
@@ -76,7 +70,6 @@ static void showinfo_internal(int pfx_index) {
 	format_time_with_offset(timebuff, sizeof(timebuff), TIME_FORMAT, pfx->timezone);
 	mvprintw(LINES - 1, LINELENGTH - 17, "   DX time: %s", timebuff);
     } else {
-	showing_country = false;
 	wwv_show_footer();
     }
 
@@ -85,16 +78,7 @@ static void showinfo_internal(int pfx_index) {
 }
 
 void update_info_line() {
-    int pfx_index  = getctydata_pfx(hiscall);
-    pthread_mutex_lock(&showinfo_mutex);
+    int pfx_index = getctydata_pfx(hiscall);
     showinfo_internal(pfx_index);
-    pthread_mutex_unlock(&showinfo_mutex);
 }
 
-void show_wwv_info_line() {
-    pthread_mutex_lock(&showinfo_mutex);
-    if (!showing_country) {
-	showinfo_internal(-1);
-    }
-    pthread_mutex_unlock(&showinfo_mutex);
-}

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -31,11 +31,6 @@
  */
 
 
-#include <assert.h>
-#include <math.h>
-#include <stdio.h>
-#include <string.h>
-
 #include "dxcc.h"
 #include "getwwv.h"
 #include "get_time.h"
@@ -49,86 +44,30 @@
 #define LINELENGTH 80
 
 void showinfo(int x) {
-
-    extern double DEST_Lat;
-    extern double DEST_Long;
-    extern char itustr[];
-
     int cury, curx;
-    char pxstr[16];
-    char countrystr[26];
-    char zonestr[3];
-    char contstr[3];
     double bearing;
     double range;
 
     char timebuff[80];
 
-    dxcc_data *dx;
-    prefix_data *pfx;
-    double d;
-
-    if (x == SHOWINFO_DUMMY)
-	pfx = prefix_by_index(prefix_count());
-    else
-	pfx = prefix_by_index(x);
-    dx = dxcc_by_index(pfx -> dxcc_index);
-
-    strcpy(pxstr, dx->pfx);
-    strcpy(countrystr, dx->countryname);	/* country */
-
-    if (strlen(cqzone) < 2) {
-	if (dx->cq > MAX_ZONES) dx->cq = MAX_ZONES;
-	snprintf(zonestr, sizeof(zonestr), "%02d", dx->cq); 	/* cqzone */
-	strcpy(cqzone, zonestr);
-    } else {
-	strncpy(zonestr, cqzone, 2);
-	zonestr[2] = '\0';
-    }
-
-    if (strlen(ituzone) < 2) {
-	sprintf(itustr, "%02d", dx->itu);	/* itu zone */
-    } else {
-	strncpy(itustr, ituzone, 2);
-	itustr[2] = '\0';
-    }
-
-    if (pfx->timezone != INFINITY)
-	d = pfx->timezone;
-    else
-	d = dx->timezone;				/* GMT difference */
-
-    format_time_with_offset(timebuff, sizeof(timebuff), TIME_FORMAT, d);
-
-    if (pfx->lat != INFINITY)
-	DEST_Lat = pfx->lat;
-    else
-	DEST_Lat = dx->lat;				/* where is he? */
-    if (pfx->lon != INFINITY)
-	DEST_Long = pfx->lon;
-    else
-	DEST_Long = dx->lon;
-
-    if (pfx->continent != NULL)
-	strncpy(contstr, pfx->continent, 2);	/* continent */
-    else
-	strncpy(contstr, dx->continent, 2);	/* continent */
-    contstr[2] = '\0';
+    prefix_data *pfx = prefix_by_index(x);
+    dxcc_data *dx = dxcc_by_index(pfx -> dxcc_index);
 
     getyx(stdscr, cury, curx);
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 
     mvaddstr(LINES - 1, 0, backgrnd_str);
 
-    if (contstr[0] != '-') {
-	mvprintw(LINES - 1, 0, " %s  %s", pxstr, countrystr);
+    if (pfx->dxcc_index > 0) {
+	mvprintw(LINES - 1, 0, " %s  %s", dx->pfx, dx->countryname);
 
-	mvprintw(LINES - 1, 26, " %s %s", contstr, zonestr);
+	mvprintw(LINES - 1, 26, " %s %02d", pfx->continent, pfx->cq);
 
 	if (x != 0 && x != my.countrynr && 0 == get_qrb(&range, &bearing)) {
 	    mvprintw(LINES - 1, 35, "%.0f km/%.0f deg ", range, bearing);
 	}
 
+	format_time_with_offset(timebuff, sizeof(timebuff), TIME_FORMAT, pfx->timezone);
 	mvprintw(LINES - 1, LINELENGTH - 17, "   DX time: %s", timebuff);
     } else {
 	wwv_show_footer();

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -84,13 +84,14 @@ static void showinfo_internal(int pfx_index) {
     move(cury, curx);
 }
 
-void show_call_info(char *call) {
+void update_info_line() {
+    int pfx_index  = getctydata_pfx(hiscall);
     pthread_mutex_lock(&showinfo_mutex);
-    showinfo_internal(getctydata_pfx(call));
+    showinfo_internal(pfx_index);
     pthread_mutex_unlock(&showinfo_mutex);
 }
 
-void show_wwv_info() {
+void show_wwv_info_line() {
     pthread_mutex_lock(&showinfo_mutex);
     if (!showing_country) {
 	showinfo_internal(-1);

--- a/src/showinfo.h
+++ b/src/showinfo.h
@@ -21,8 +21,7 @@
 #ifndef SHOWINFO_H
 #define SHOWINFO_H
 
-#define SHOWINFO_DUMMY	-1
-
-void showinfo(int x);
+void show_call_info(char *call);
+void show_wwv_info();
 
 #endif /* end of include guard: SHOWINFO_H */

--- a/src/showinfo.h
+++ b/src/showinfo.h
@@ -22,6 +22,5 @@
 #define SHOWINFO_H
 
 void update_info_line();
-void show_wwv_info_line();
 
 #endif /* end of include guard: SHOWINFO_H */

--- a/src/showinfo.h
+++ b/src/showinfo.h
@@ -21,7 +21,7 @@
 #ifndef SHOWINFO_H
 #define SHOWINFO_H
 
-void show_call_info(char *call);
-void show_wwv_info();
+void update_info_line();
+void show_wwv_info_line();
 
 #endif /* end of include guard: SHOWINFO_H */

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -156,7 +156,7 @@ void time_update(void) {
 	static time_t prev_wwv_time = 0;
 	if (lastwwv_time > prev_wwv_time) { // is there a newer WWV message?
 	    prev_wwv_time = lastwwv_time;
-	    show_wwv_info_line();   // show it unless already showing country info
+	    update_info_line(); // show it unless already showing country info
 	}
 
 	int currentterm = miniterm;

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -156,7 +156,7 @@ void time_update(void) {
 	static time_t prev_wwv_time = 0;
 	if (lastwwv_time > prev_wwv_time) { // is there a newer WWV message?
 	    prev_wwv_time = lastwwv_time;
-	    show_wwv_info();    // show it unless already showing country info
+	    show_wwv_info_line();   // show it unless already showing country info
 	}
 
 	int currentterm = miniterm;

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -38,6 +38,7 @@
 #include "printcall.h"
 #include "setcontest.h"
 #include "showscore.h"
+#include "showinfo.h"
 #include "tlf_curses.h"
 #include "trx_memory.h"
 #include "ui_utils.h"
@@ -155,9 +156,7 @@ void time_update(void) {
 	static time_t prev_wwv_time = 0;
 	if (lastwwv_time > prev_wwv_time) { // is there a newer WWV message?
 	    prev_wwv_time = lastwwv_time;
-	    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-	    mvprintw(LINES - 1, 0, backgrnd_str);
-	    wwv_show_footer();              // print WWV info
+	    show_wwv_info();    // show it unless already showing country info
 	}
 
 	int currentterm = miniterm;

--- a/test/test_dxcc.c
+++ b/test/test_dxcc.c
@@ -66,14 +66,35 @@ void test_add_prefix_check_count(void **state) {
     assert_int_equal(2, prefix_count());
 }
 
-void test_add_prefix_check_parsed(void **state) {
+void test_add_prefix_check_defaults(void **state) {
     prefix_data *pfx;
     prefix_add("HW");
     pfx = prefix_by_index(0);
     assert_string_equal(pfx->pfx, "HW");
     assert_int_equal(pfx->dxcc_index, dxcc_count() - 1);
-    assert_int_equal(pfx->cq, dxcc_by_index(dxcc_count() - 1)->cq);
-    assert_int_equal(pfx->itu, dxcc_by_index(dxcc_count() - 1)->itu);
+    dxcc_data *mydx = dxcc_by_index(dxcc_count() - 1);
+    assert_int_equal(pfx->cq, mydx->cq);
+    assert_int_equal(pfx->itu, mydx->itu);
+    assert_string_equal(pfx->continent, mydx->continent);
+    assert_float_equal(pfx->lat, mydx->lat, 1e-6);
+    assert_float_equal(pfx->lon, mydx->lon, 1e-6);
+    assert_float_equal(pfx->timezone, mydx->timezone, 1e-6);
 }
 
+void test_add_prefix_check_overrides(void **state) {
+    prefix_data *pfx;
+    // NOTE: overrides must be in the order below
+    char *input = g_strdup("HW(11)[22]<33.3/44.4>{OC}~5.5~");
+    prefix_add(input);
+    g_free(input);
+    pfx = prefix_by_index(0);
+    assert_string_equal(pfx->pfx, "HW");
+    assert_int_equal(pfx->dxcc_index, dxcc_count() - 1);
+    assert_int_equal(pfx->cq, 11);
+    assert_int_equal(pfx->itu, 22);
+    assert_string_equal(pfx->continent, "OC");
+    assert_float_equal(pfx->lat, 33.3, 1e-6);
+    assert_float_equal(pfx->lon, 44.4, 1e-6);
+    assert_float_equal(pfx->timezone, 5.5, 1e-6);
+}
 

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -151,6 +151,7 @@ void test_location_unknown(void **state) {
 }
 
 void test_suffix_empty(void **state) {
+    assert_int_equal(getpfxindex(NULL, NULL), -1);
     assert_int_equal(getpfxindex("", NULL), -1);
     assert_int_equal(getctynr(""), 0);
     assert_int_equal(getctydata(""), 0);


### PR DESCRIPTION
A fix for #266
Sending messages calls `displayit()` down the line and it then calls `clear_display()` in turn.
Simply added re-displaying DX info to `displayit()`. Not sure if it's the best fix, though.
Also added clearing display after logging a QSO so that a new one starts with a fresh view.
