### PR TITLE
Fix mvprintw warnings

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -70,7 +70,7 @@ void do_record(int message_nr) {
 
     mvprintw(15, 20, "recording %s", ph_message[message_nr]);
     mvprintw(16, 20, "ESC to exit");
-    mvprintw(17, 20, "");
+    move(17, 20);
     refreshp();
     strcpy(commands, "rec -r 8000 ");	//G4KNO
     strcat(commands, ph_message[message_nr]);
@@ -217,7 +217,7 @@ void record(void) {
 		    mvprintw(i, 0,
 			     "                                                                                ");
 
-		mvprintw(4, 10, "");
+		move(4, 10);
 
 		for (i = 10; i < 81; i += 10) {
 		    soundfilename = readdir(sounddir);
@@ -263,7 +263,7 @@ void record(void) {
 		    strcat(commands, ".au");
 		}
 		mvprintw(16, 20, "Use Ctrl-c to stop and return to tlf");
-		mvprintw(18, 20, "");
+		move(18, 20);
 		refreshp();
 		IGNORE(system(commands));;
 		runnit = 0;

--- a/src/autocq.c
+++ b/src/autocq.c
@@ -68,7 +68,7 @@ int auto_cq(void) {
 
 	send_standard_message(11);
 
-	mvprintw(12, 29, "");
+	move(12, 29);
 
 	attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
@@ -101,7 +101,7 @@ int auto_cq(void) {
 	}
 
 	mvprintw(12, 29, "%s", spaces(13));
-	mvprintw(12, 29, "");
+	move(12, 29);
 	refreshp();
     }
 

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -56,7 +56,7 @@ void calledit(void) {
 
 	mvprintw(12, 29, "            ");
 	mvprintw(12, 29, "%s", hiscall);
-	mvprintw(12, 29 + b, "");
+	move(12, 29 + b);
 	/* no refreshp() here as getch() calls wrefresh() for the
 	 * panel with last output (whre the cursor should go */
 
@@ -251,7 +251,7 @@ int insert_char(int curposition) {
 
 	mvprintw(12, 29, "%s", hiscall);
 	curposition++;
-	mvprintw(12, 29 + curposition, "");
+	move(12, 29 + curposition);
 	refreshp();
 
     }

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -531,7 +531,7 @@ int callinput(void) {
 		attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
 		mvprintw(12, 29, "%s", spaces(12));
-		mvprintw(12, 29, "");
+		move(12, 29);
 		refreshp();
 		break;
 	    }
@@ -624,7 +624,7 @@ int callinput(void) {
 		if (*hiscall != '\0') {
 		    getyx(stdscr, cury, curx);
 		    mvprintw(cury, curx - 1, " ");
-		    mvprintw(cury, curx - 1, "");
+		    move(cury, curx - 1);
 		    hiscall[strlen(hiscall) - 1] = '\0';
 		}
 		break;
@@ -716,7 +716,7 @@ int callinput(void) {
 		    k_ptt = 1;
 		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 		    mvprintw(0, 2, "PTT on   ");
-		    mvprintw(12, 29, "");
+		    move(12, 29);
 		    refreshp();
 		    netkeyer(K_PTT, "1");	// ptt on
 		    x = key_get();	// any character to stop tuning
@@ -735,7 +735,7 @@ int callinput(void) {
 	    case ALT_T: {
 		attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 		mvprintw(0, 2, "Tune     ");
-		mvprintw(12, 29, "");
+		move(12, 29);
 		refreshp();
 
 		tune();

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -512,7 +512,7 @@ int changepars(void) {
 
 	    attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
-	    mvprintw(12, 29 + strlen(hiscall), "");
+	    move(12, 29 + strlen(hiscall));
 	    break;
 
 	}
@@ -664,7 +664,7 @@ int changepars(void) {
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
     mvprintw(12, 29, "            ");
-    mvprintw(12, 29, "");
+    move(12, 29);
     refreshp();
     hiscall[0] = '\0';
 

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -175,7 +175,7 @@ void displayit(void) {
     strcpy(terminal3, terminal4);
     strcpy(terminal4, term2buf);
     termbuf[0] = '\0';
-    mvprintw(5, 0, "");
+    move(5, 0);
 
     clear_display();
 }

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -61,7 +61,7 @@ void clusterinfo(void) {
     /* cluster and bandmap display */
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
-    mvprintw(12, 0, "");
+    move(12, 0);
 
     if (cluster == NOCLUSTER) {
 	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -49,7 +49,7 @@ static void highlight_line(int row, char *line, int column) {
     g_strlcpy(ln, line, NR_COLS + 1);
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
     mvprintw(7 + row, 0, "%s", ln);
-    mvprintw(7 + row, column, "");
+    move(7 + row, column);
     refreshp();
 }
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -290,7 +290,7 @@ int getexchange(void) {
 	    }
 	    case ',':		// Keyboard Morse
 	    case CTRL_K: {	// Ctrl-K
-		mvprintw(5, 0, "");
+		move(5, 0);
 		keyer();
 		x = 0;
 		break;
@@ -1061,7 +1061,7 @@ void exchange_edit(void) {
 
 	mvprintw(12, 54, "%s", spaces(contest->exchange_width));
 	mvprintw(12, 54, "%s", comment);
-	mvprintw(12, 54 + b, "");
+	move(12, 54 + b);
 
 	i = key_get();
 

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -214,8 +214,8 @@ void keyer(void) {
 
 		case ALT_W: {	// Alt-W, set weight
 		    mvprintw(1, 0, "Weight=   ");
-		    mvprintw(1, 7, "");
 		    refreshp();
+		    move(1, 7);
 		    echo();
 		    getnstr(weightbuf, 2);
 		    noecho();
@@ -241,9 +241,9 @@ void keyer(void) {
 
 		case KEY_F(1): {
 		    getyx(stdscr, cury, curx);
-		    mvprintw(5, 0, "");
+		    move(5, 0);
 		    send_keyer_message(0);	/* F1 */
-		    mvprintw(cury, curx, "");
+		    move(cury, curx);
 		    break;
 		}
 		case KEY_F(2): {

--- a/src/logit.c
+++ b/src/logit.c
@@ -190,9 +190,9 @@ void logit(void) {
 
 	    if (callreturn == CTRL_K || callreturn == 44) {	/*  CTRL K  */
 		getyx(stdscr, cury, curx);
-		mvprintw(5, 0, "");
+		move(5, 0);
 		keyer();
-		mvprintw(cury, curx, "");
+		move(cury, curx);
 	    }
 
 	} else {	/* user entered frequency -> clear input field */

--- a/src/messagechange.c
+++ b/src/messagechange.c
@@ -48,7 +48,7 @@ static void enter_message(int bufnr) {
     refreshp();
 
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-    mvprintw(16, 4, "");
+    move(16, 4);
 
     echo();
     getnstr(printbuf, 60);

--- a/src/nicebox.c
+++ b/src/nicebox.c
@@ -57,7 +57,7 @@ void ask(char *buffer, char *what) {
     mvprintw(15, 1, "%s", spaces(78));
     nicebox(14, 0, 1, 78, what);
     attron(A_STANDOUT);
-    mvprintw(15, 1, "");
+    move(15, 1);
 
     echo();
     getnstr(buffer, 78);

--- a/src/note.c
+++ b/src/note.c
@@ -46,7 +46,7 @@ int include_note(void) {
 	     "                                                                              ");
     nicebox(14, 0, 1, 78, "Note");
     attron(A_STANDOUT);
-    mvprintw(15, 1, "");
+    move(15, 1);
 
     echo();
     getnstr(buffer, 78);

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -1105,7 +1105,7 @@ void qtc_main_panel(int direction) {
 	    // Comma or Ctrl-K (^K), keyboard window
 	    case ',':
 	    case 11:
-		mvprintw(5, 0, "");
+		move(5, 0);
 		keyer();
 		x = 0;
 		break;

--- a/src/set_tone.c
+++ b/src/set_tone.c
@@ -42,7 +42,7 @@ void set_tone(void) {
     nicebox(4, 40, 1, 6, "Tone");
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     mvprintw(5, 41, "      ");
-    mvprintw(5, 42, "");
+    move(5, 42);
     echo();
     getnstr(tonestr, 3);
     noecho();


### PR DESCRIPTION
Part 2 of the mvprintw cleanup. 

* Drops one unused parameter
* Replaces 'mvprintw(y, x, "")' with a simple 'move(y, x)' to position the cursor.