### PR TITLE
Use Github Actions for CI build

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,31 @@
+name: CI build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    env:
+      TERM: xterm
+      AM_COLOR_TESTS: always
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Show OS info
+      run: cat /etc/os-release
+    - name: Install dependencies
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install -y libhamlib-dev libxmlrpc-core-c3-dev libcmocka-dev     
+    - name: Autoreconf and basic make
+      run: autoreconf -i && ./configure && make -j2
+    - name: Configure with xmlrpc
+      run: make clean && ./configure --enable-fldigi-xmlrpc && make -j2
+    - name: Run tests
+      run: make check; rc=$?; cat test/run_*.log; exit $rc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tlf ham radio contest logger
 
-[![Build Status](https://travis-ci.org/Tlf/tlf.svg?branch=master)](https://travis-ci.org/Tlf/tlf)
+[![Build Status](https://github.com/Tlf/tlf/actions/workflows/ci-build.yml/badge.svg)](https://github.com/Tlf/tlf/actions/workflows/ci-build.yml)
 
 ## Summary
 


### PR DESCRIPTION
Some time after closing down travis.org I migrated my account to travis.com. Builds continued to work as before. Travis' free plan grants 1000 minutes and once they're used up there's no automatic extension, one has to request it via email.
Recently Tlf builds error out claiming that cmocka.org's certificate has expired which it in fact did not.
So, instead of debugging what's wrong at Travis I looked into Github Actions and figured out that the migration from Travis is quite straightforward. The default Linux instance uses Ubuntu 20, so it has the right cmocka anyway.

Details about billing for Actions can be found here
https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions

Unlike at Travis it's clearly stated that 2000 minutes are granted per month.
As one Tlf build takes ~1 minute it'll take a long way to run into this limit.
