### PR TITLE
Add Prince Edward Island to arrlsections

### DIFF
--- a/share/arrlsections
+++ b/share/arrlsections
@@ -52,6 +52,7 @@ ONS
 OR
 ORG
 PAC
+PE
 PR
 QC
 RI


### PR DESCRIPTION
Now there are 84 ARRL/RAC sections for ARRL Sweepstakes (CW & SSB), 160
meter, and Field Day events.