### PR TITLE
Convert mvprintw to mvaddstr or clear_line

### DIFF
--- a/src/addspot.c
+++ b/src/addspot.c
@@ -74,7 +74,7 @@ void addspot(void) {
 
 	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
-	mvprintw(13, 20, "freq.: ");
+	mvaddstr(13, 20, "freq.: ");
 	echo();
 	getnstr(frequency, 7);
 	noecho();

--- a/src/audio.c
+++ b/src/audio.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "clear_display.h"
 #include "ignore_unused.h"
 #include "keystroke_names.h"
 #include "tlf.h"
@@ -47,15 +48,15 @@ void recordmenue(void) {
     attron(modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
 
     for (j = 0; j <= 24; j++)
-	mvprintw(j, 0, "%s", backgrnd_str);
+	clear_line(j);
 
-    mvprintw(1, 20, "--- TLF SOUND RECORDER UTILITY ---");
-    mvprintw(6, 20, "F1 ... F12, S, C: Record Messages");
+    mvaddstr(1, 20, "--- TLF SOUND RECORDER UTILITY ---");
+    mvaddstr(6, 20, "F1 ... F12, S, C: Record Messages");
 
-    mvprintw(9, 20, "1.: Enable contest recorder");
-    mvprintw(10, 20, "2.: Disable contest recorder");
-    mvprintw(11, 20, "3.: List and Play contest file");
-    mvprintw(13, 20, "ESC: Exit sound recorder function");
+    mvaddstr(9, 20, "1.: Enable contest recorder");
+    mvaddstr(10, 20, "2.: Disable contest recorder");
+    mvaddstr(11, 20, "3.: List and Play contest file");
+    mvaddstr(13, 20, "ESC: Exit sound recorder function");
 
     refreshp();
 
@@ -69,7 +70,7 @@ void do_record(int message_nr) {
     char commands[80] = "";
 
     mvprintw(15, 20, "recording %s", ph_message[message_nr]);
-    mvprintw(16, 20, "ESC to exit");
+    mvaddstr(16, 20, "ESC to exit");
     move(17, 20);
     refreshp();
     strcpy(commands, "rec -r 8000 ");	//G4KNO
@@ -176,7 +177,7 @@ void record(void) {
 		IGNORE(system
 		       ("cd ~/tlf/soundlogs; soundlog  > /dev/null 2> /dev/null &"));
 
-		mvprintw(15, 20, "Contest recording enabled...");
+		mvaddstr(15, 20, "Contest recording enabled...");
 		refreshp();
 		sleep(1);
 		runnit = 0;
@@ -184,7 +185,7 @@ void record(void) {
 
 	    // Stop contest recording.
 	    case '2':
-		mvprintw(15, 20, "Contest recording disabled...");
+		mvaddstr(15, 20, "Contest recording disabled...");
 		refreshp();
 		sleep(1);
 		IGNORE(system("rm ~/.VRlock"));;
@@ -208,7 +209,7 @@ void record(void) {
 		if (sounddir == NULL) {
 		    if (errno != 0) {
 			mvprintw(22, 1, "%s: %s", strerror(errno), path);
-			mvprintw(23, 1, "Press ESC to exit this screen");
+			mvaddstr(23, 1, "Press ESC to exit this screen");
 		    }
 		    break;
 		}
@@ -230,7 +231,7 @@ void record(void) {
 				j++;
 			    }
 			    g_strlcpy(printname, soundfilename->d_name, 7);
-			    mvprintw(j, i, "%s", printname);
+			    mvaddstr(j, i, printname);
 			    refreshp();
 
 			} else if (i >= 10)
@@ -242,7 +243,7 @@ void record(void) {
 
 	    // Play back contest recording.
 	    case '4':
-		mvprintw(15, 20, "Play back file (ddhhmmxx): ");
+		mvaddstr(15, 20, "Play back file (ddhhmmxx): ");
 		refreshp();
 
 		echo();
@@ -262,7 +263,7 @@ void record(void) {
 		    strcat(commands, playbackfile);
 		    strcat(commands, ".au");
 		}
-		mvprintw(16, 20, "Use Ctrl-c to stop and return to tlf");
+		mvaddstr(16, 20, "Use Ctrl-c to stop and return to tlf");
 		move(18, 20);
 		refreshp();
 		IGNORE(system(commands));;

--- a/src/autocq.c
+++ b/src/autocq.c
@@ -100,7 +100,7 @@ int auto_cq(void) {
 	    }
 	}
 
-	mvprintw(12, 29, "%s", spaces(13));
+	mvaddstr(12, 29, spaces(13));
 	move(12, 29);
 	refreshp();
     }
@@ -112,7 +112,7 @@ int auto_cq(void) {
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
-    mvprintw(12, 29, "%s", spaces(13));
+    mvaddstr(12, 29, spaces(13));
     printcall();
 
     return toupper(key);

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -97,7 +97,7 @@ void bmdata_write_file() {
 
     if ((fp = fopen(".bmdata.dat", "w")) == NULL) {
 	attron(modify_attr(COLOR_PAIR(CB_DUPE) | A_BOLD));
-	mvprintw(13, 29, "can't open bandmap data file!");
+	mvaddstr(13, 29, "can't open bandmap data file!");
 	refreshp();
 	return;
     }
@@ -519,7 +519,7 @@ void bm_show_info() {
     mvprintw(LASTLINE - 2, 67, " onl.ml: %s", bm_config.onlymults ? "yes" : "no");
 
     attrset(COLOR_PAIR(CB_NEW) | A_BOLD);
-    mvprintw(LASTLINE - 1, 67, " NEW");
+    mvaddstr(LASTLINE - 1, 67, " NEW");
 
     attrset(COLOR_PAIR(CB_NORMAL));
     printw(" SPOT");
@@ -528,7 +528,7 @@ void bm_show_info() {
     printw(" OLD");
 
     attrset(COLOR_PAIR(CB_DUPE) | A_BOLD);
-    mvprintw(LASTLINE, 67, " dupe");
+    mvaddstr(LASTLINE, 67, " dupe");
 
     attrset(COLOR_PAIR(CB_NORMAL));
     printw(" M");
@@ -897,7 +897,7 @@ void bm_menu() {
     getyx(stdscr, cury, curx);		/* remember cursor */
 
     attrset(COLOR_PAIR(C_LOG) | A_STANDOUT);
-    mvprintw(13, 0, "  Toggle <B>and, <M>ode, <D>upes or <O>nly multi filter");
+    mvaddstr(13, 0, "  Toggle <B>and, <M>ode, <D>upes or <O>nly multi filter");
     printw(" | any other - leave ");
 
     c = toupper(key_get());

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -54,8 +54,8 @@ void calledit(void) {
 	attroff(A_STANDOUT);
 	attron(COLOR_PAIR(C_HEADER));
 
-	mvprintw(12, 29, "            ");
-	mvprintw(12, 29, "%s", hiscall);
+	mvaddstr(12, 29, "            ");
+	mvaddstr(12, 29, hiscall);
 	move(12, 29 + b);
 	/* no refreshp() here as getch() calls wrefresh() for the
 	 * panel with last output (whre the cursor should go */
@@ -188,8 +188,8 @@ void calledit(void) {
     attroff(A_STANDOUT);
     attron(COLOR_PAIR(C_HEADER));
 
-    mvprintw(12, 29, "            ");
-    mvprintw(12, 29, "%s", hiscall);
+    mvaddstr(12, 29, "            ");
+    mvaddstr(12, 29, hiscall);
     refreshp();
 
     attron(A_STANDOUT);
@@ -249,7 +249,7 @@ int insert_char(int curposition) {
 	attroff(A_STANDOUT);
 	attron(COLOR_PAIR(C_HEADER));
 
-	mvprintw(12, 29, "%s", hiscall);
+	mvaddstr(12, 29, hiscall);
 	curposition++;
 	move(12, 29 + curposition);
 	refreshp();

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -364,7 +364,7 @@ int callinput(void) {
 		char weightbuf[5] = "";
 		char *end;
 
-		mvprintw(12, 29, "Wght: -50..50");
+		mvaddstr(12, 29, "Wght: -50..50");
 
 		nicebox(1, 1, 2, 12, "Cw");
 		attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
@@ -373,7 +373,7 @@ int callinput(void) {
 		refreshp();
 
 		usleep(800000);
-		mvprintw(3, 10, "   ");
+		mvaddstr(3, 10, "   ");
 
 		echo();
 		mvgetnstr(3, 10, weightbuf, 3);
@@ -439,8 +439,8 @@ int callinput(void) {
 		    rst_sent_up();
 
 		    if (!no_rst)
-			mvprintw(12, 44, "%s", sent_rst);
-		    mvprintw(12, 29, "%s", hiscall);
+			mvaddstr(12, 44, sent_rst);
+		    mvaddstr(12, 29, hiscall);
 
 		} else {	// change cw speed
 		    speedup();
@@ -460,8 +460,8 @@ int callinput(void) {
 		    rst_sent_down();
 
 		    if (!no_rst)
-			mvprintw(12, 44, "%s", sent_rst);
-		    mvprintw(12, 29, "%s", hiscall);
+			mvaddstr(12, 44, sent_rst);
+		    mvaddstr(12, 29, hiscall);
 
 		} else {
 
@@ -528,12 +528,12 @@ int callinput(void) {
 		attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
 		for (j = 13; j <= 23; j++) {
-		    mvprintw(j, 0, "%s", backgrnd_str);
+		    clear_line(j);
 		}
 
 		attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
-		mvprintw(12, 29, "%s", spaces(12));
+		mvaddstr(12, 29, spaces(12));
 		move(12, 29);
 		refreshp();
 		break;
@@ -626,7 +626,7 @@ int callinput(void) {
 	    case KEY_BACKSPACE: {
 		if (*hiscall != '\0') {
 		    getyx(stdscr, cury, curx);
-		    mvprintw(cury, curx - 1, " ");
+		    mvaddstr(cury, curx - 1, " ");
 		    move(cury, curx - 1);
 		    hiscall[strlen(hiscall) - 1] = '\0';
 		}
@@ -718,7 +718,7 @@ int callinput(void) {
 		if (k_ptt == 0) {
 		    k_ptt = 1;
 		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-		    mvprintw(0, 2, "PTT on   ");
+		    mvaddstr(0, 2, "PTT on   ");
 		    move(12, 29);
 		    refreshp();
 		    netkeyer(K_PTT, "1");	// ptt on
@@ -737,7 +737,7 @@ int callinput(void) {
 	    // Alt-t (M-t), tune xcvr via cwdaemon.
 	    case ALT_T: {
 		attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-		mvprintw(0, 2, "Tune     ");
+		mvaddstr(0, 2, "Tune     ");
 		move(12, 29);
 		refreshp();
 
@@ -767,7 +767,7 @@ int callinput(void) {
 
 	    // Alt-x (M-x), Exit
 	    case ALT_X: {
-		mvprintw(13, 29, "Do you want to leave Tlf? (y/n): ");
+		mvaddstr(13, 29, "Do you want to leave Tlf? (y/n): ");
 		while (x != 'N') {
 
 		    x = toupper(key_get());
@@ -916,17 +916,17 @@ int callinput(void) {
 		if (lan_active) {
 
 		    for (t = 0; t <= 5; t++)
-			mvprintw(14 + t, 1, "%s", spaces(60));
+			mvaddstr(14 + t, 1, spaces(60));
 
 		    for (t = 0; t <= 4; t++)
-			mvprintw(15 + t, 1, "%s", talkarray[t]);
+			mvaddstr(15 + t, 1, talkarray[t]);
 		    nicebox(14, 0, 5, 59, "Messages");
 
 		    refreshp();
 		    key_get();
 		    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 		    for (t = 0; t <= 6; t++)
-			mvprintw(14 + t, 0, "%s", spaces(61));
+			mvaddstr(14 + t, 0, spaces(61));
 
 		    clear_display();
 		}
@@ -945,7 +945,7 @@ int callinput(void) {
 		cqdelay++;
 
 		attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-		mvprintw(0, 19, "  ");
+		mvaddstr(0, 19, "  ");
 		mvprintw(0, 19, "%i", cqdelay);
 	    }
 
@@ -962,7 +962,7 @@ int callinput(void) {
 		cqdelay--;
 
 		attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-		mvprintw(0, 19, "  ");
+		mvaddstr(0, 19, "  ");
 		mvprintw(0, 19, "%i", cqdelay);
 	    }
 
@@ -1255,7 +1255,7 @@ void handle_bandswitch(int direction) {
     }
 
     attron(COLOR_PAIR(C_WINDOW) | A_STANDOUT);
-    mvprintw(12, 0, "%s", band[bandinx]);
+    mvaddstr(12, 0, band[bandinx]);
 
     if (trx_control) {
 	freq = bandfrequency[bandinx]; // TODO: is this needed?

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -138,10 +138,10 @@ int changepars(void) {
 
     attroff(A_STANDOUT);
     attron(COLOR_PAIR(C_HEADER));
-    mvprintw(12, 29, "PARAMETER?  ");
+    mvaddstr(12, 29, "PARAMETER?  ");
     refreshp();
     usleep(400000);
-    mvprintw(12, 29, "            ");
+    mvaddstr(12, 29, "            ");
 
     echo();
     mvgetnstr(12, 29, parameterstring, 19);
@@ -307,11 +307,11 @@ int changepars(void) {
 		trxmode = CWMODE;
 
 	    if (trxmode == CWMODE) {
-		mvprintw(13, 29, "TRXMODE = CW");
+		mvaddstr(13, 29, "TRXMODE = CW");
 	    } else if (trxmode == SSBMODE)
-		mvprintw(13, 29, "TRXMODE = SSB");
+		mvaddstr(13, 29, "TRXMODE = SSB");
 	    else
-		mvprintw(13, 29, "TRXMODE = DIG");
+		mvaddstr(13, 29, "TRXMODE = DIG");
 	    refreshp();
 	    sleep(1);
 
@@ -348,9 +348,9 @@ int changepars(void) {
 
 	    }
 	    if (rit == RITCLEAR) {
-		mvprintw(13, 29, "RIT clear on");
+		mvaddstr(13, 29, "RIT clear on");
 	    } else {
-		mvprintw(13, 29, "RIT clear off");
+		mvaddstr(13, 29, "RIT clear off");
 	    }
 	    refreshp();
 	    sleep(1);
@@ -361,9 +361,9 @@ int changepars(void) {
 	    trx_control = !trx_control;
 
 	    if (trx_control) {
-		mvprintw(13, 29, "TRX control on");
+		mvaddstr(13, 29, "TRX control on");
 	    } else {
-		mvprintw(13, 29, "TRX control off");
+		mvaddstr(13, 29, "TRX control off");
 	    }
 	    refreshp();
 	    sleep(1);
@@ -416,7 +416,7 @@ int changepars(void) {
 			"The simulator only works in TRmode. Switching to TRmode");
 		    ctcomp = 0;
 		} else {
-		    mvprintw(13, 29, "Simulator on");
+		    mvaddstr(13, 29, "Simulator on");
 		    refreshp();
 		    sleep(1);
 		}
@@ -431,7 +431,7 @@ int changepars(void) {
 		}
 	    } else {
 		simulator = false;
-		mvprintw(13, 29, "Simulator off");
+		mvaddstr(13, 29, "Simulator off");
 		refreshp();
 		sleep(1);
 
@@ -471,7 +471,7 @@ int changepars(void) {
 	}
 
 	case 39: {		/* CQDELAY */
-	    mvprintw(12, 29, "CQD: pgup/dwn");
+	    mvaddstr(12, 29, "CQD: pgup/dwn");
 	    refreshp();
 
 	    x = 1;
@@ -485,7 +485,7 @@ int changepars(void) {
 			if (cqdelay <= 60) {
 			    cqdelay++;
 			    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-			    mvprintw(0, 19, "  ");
+			    mvaddstr(0, 19, "  ");
 			    mvprintw(0, 19, "%i", cqdelay);
 			    break;
 
@@ -498,7 +498,7 @@ int changepars(void) {
 			    cqdelay--;
 			    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 
-			    mvprintw(0, 19, "  ");
+			    mvaddstr(0, 19, "  ");
 			    mvprintw(0, 19, "%i", cqdelay);
 			    break;
 
@@ -538,10 +538,10 @@ int changepars(void) {
 	}
 	case 43: {		/* SCVOLUME - set soundcard volume */
 	    volumebuffer = atoi(sc_volume);
-	    mvprintw(12, 29, "Vol: pgup/dwn");
+	    mvaddstr(12, 29, "Vol: pgup/dwn");
 	    refreshp();
 	    usleep(500000);
-	    mvprintw(12, 29, "Vol:         ");
+	    mvaddstr(12, 29, "Vol:         ");
 	    mvprintw(12, 29, "Vol: %d", volumebuffer);
 
 	    x = 1;
@@ -570,7 +570,7 @@ int changepars(void) {
 		}
 
 		attron(COLOR_PAIR(COLOR_GREEN) | A_STANDOUT);
-		mvprintw(12, 34, "  ");
+		mvaddstr(12, 34, "  ");
 		mvprintw(12, 34, "%d", volumebuffer);
 
 		if (volumebuffer >= 0 && volumebuffer <= 99)
@@ -602,7 +602,7 @@ int changepars(void) {
 	    break;
 	}
 	case 50: {		/* CHARS */
-	    mvprintw(13, 29, "Autosend: (0, 2..5, m)?");
+	    mvaddstr(13, 29, "Autosend: (0, 2..5, m)?");
 	    refreshp();
 	    x = 1;
 
@@ -627,9 +627,9 @@ int changepars(void) {
 			 cwstart);
 	    else {
 		if (cwstart < 0)
-		    mvprintw(13, 29, "Autosend now: Manual   ");
+		    mvaddstr(13, 29, "Autosend now: Manual   ");
 		else
-		    mvprintw(13, 29, "Autosend now: OFF      ");
+		    mvaddstr(13, 29, "Autosend now: OFF      ");
 	    }
 	    refreshp();
 	    break;
@@ -639,9 +639,9 @@ int changepars(void) {
 	    if (digikeyer == FLDIGI) {
 		if (fldigi_toggle()) {
 		    fldigi_clear_connerr();
-		    mvprintw(13, 29, "FLDIGI ON");
+		    mvaddstr(13, 29, "FLDIGI ON");
 		} else {
-		    mvprintw(13, 29, "FLDIGI OFF");
+		    mvaddstr(13, 29, "FLDIGI OFF");
 		}
 		refreshp();
 	    }
@@ -653,7 +653,7 @@ int changepars(void) {
     }
 
     if (nopar != 1) {
-	mvprintw(12, 29, "OK !        ");
+	mvaddstr(12, 29, "OK !        ");
     } else {
 	if (!nopacket && packetinterface > 0)
 	    packet();
@@ -663,7 +663,7 @@ int changepars(void) {
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
-    mvprintw(12, 29, "            ");
+    mvaddstr(12, 29, "            ");
     move(12, 29);
     refreshp();
     hiscall[0] = '\0';
@@ -678,14 +678,14 @@ void networkinfo(void) {
     wipe_display();
 
     if (lan_active)
-	mvprintw(1, 10, "Network status: on");
+	mvaddstr(1, 10, "Network status: on");
     else
-	mvprintw(1, 10, "Network status: off");
+	mvaddstr(1, 10, "Network status: off");
 
     mvprintw(3, 28, "Packets rcvd: %d | %d", recv_packets, recv_error);
 
     for (int i = 0; i < nodes; i++) {
-	mvprintw(4 + i, 10, "%s", bc_hostaddress[i]);
+	mvaddstr(4 + i, 10, bc_hostaddress[i]);
 	mvprintw(4 + i, 28, "Packets sent: %d | %d ",
 		 send_packets[i], send_error[i]);
     }
@@ -702,9 +702,9 @@ void networkinfo(void) {
     mvprintw(10 + nodes, 10, "TNCport    : %s", tncportname);
     mvprintw(11 + nodes, 10, "RIGport    : %s", rigportname);
     if (use_bandoutput == 1)
-	mvprintw(12 + nodes, 10, "Band output: on");
+	mvaddstr(12 + nodes, 10, "Band output: on");
     else
-	mvprintw(12 + nodes, 10, "Band output: off");
+	mvaddstr(12 + nodes, 10, "Band output: off");
 
     mvprintw(13 + nodes, 10, "callmaster : %s",
 	     (callmaster_version[0] != 0 ? callmaster_version : "n/a"));
@@ -713,7 +713,7 @@ void networkinfo(void) {
 
     refreshp();
 
-    mvprintw(23, 22, " --- Press a key to continue --- ");
+    mvaddstr(23, 22, " --- Press a key to continue --- ");
     refreshp();
 
     (void)key_get();
@@ -736,7 +736,7 @@ void multiplierinfo(void) {
 	char chmult[6];
 	char ch2mult[6];
 
-	mvprintw(2, 20, "ARRL SWEEPSTAKES -- REMAINING SECTIONS");
+	mvaddstr(2, 20, "ARRL SWEEPSTAKES -- REMAINING SECTIONS");
 	cnt = 0;
 	for (vert = 9; vert < 18; vert++) {
 
@@ -766,7 +766,7 @@ void multiplierinfo(void) {
 		attron(modify_attr(attributes));
 
 		g_strlcpy(mprint, get_mult(cnt), 5);
-		mvprintw(vert, hor * 4, "%s", mprint);
+		mvaddstr(vert, hor * 4, mprint);
 
 		cnt++;
 	    }
@@ -778,7 +778,7 @@ void multiplierinfo(void) {
 	char *tmp;
 	int worked_at;
 
-	mvprintw(0, 30, "REMAINING SECTIONS");
+	mvaddstr(0, 30, "REMAINING SECTIONS");
 	cnt = 0;
 	for (vert = 2; vert < LINES - 2; vert++) {
 	    if (cnt >= get_mult_count())
@@ -810,7 +810,7 @@ void multiplierinfo(void) {
 		strcat(mprint, (worked_at & BAND10) ? "*" : "-");
 
 		mprint[11] = '\0';
-		mvprintw(vert, 2 + hor * 11, "%s", mprint);
+		mvaddstr(vert, 2 + hor * 11, mprint);
 
 		cnt++;
 	    }
@@ -819,7 +819,7 @@ void multiplierinfo(void) {
 
     attron(modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
 
-    mvprintw(LINES - 2, 22, " --- Press a key to continue --- ");
+    mvaddstr(LINES - 2, 22, " --- Press a key to continue --- ");
 
     refreshp();
 
@@ -835,5 +835,5 @@ void wipe_display() {
     attron(modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
 
     for (j = 0; j < LINES; j++)
-	mvprintw(j, 0, "%s", backgrnd_str);
+	clear_line(j);
 }

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -179,3 +179,7 @@ void displayit(void) {
 
     clear_display();
 }
+
+void clear_line(int row) {
+    mvaddstr(row, 0, backgrnd_str);
+}

--- a/src/clear_display.h
+++ b/src/clear_display.h
@@ -25,5 +25,6 @@ void init_terminal_strings(void);
 void show_header_line(void);
 void clear_display(void);
 void displayit(void);
+void clear_line(int);
 
 #endif /* CLEAR_DISPLAY_H */

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -32,6 +32,7 @@
 
 #include "bandmap.h"
 #include "bands.h"
+#include "clear_display.h"
 #include "dxcc.h"
 #include "err_utils.h"
 #include "get_time.h"
@@ -67,7 +68,7 @@ void clusterinfo(void) {
 	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
 	for (int i = 14; i < LINES - 1; i++)
-	    mvprintw(i, 0, "%s", backgrnd_str);
+	    clear_line(i);
 	refreshp();
     }
 
@@ -78,7 +79,7 @@ void clusterinfo(void) {
 
     if (cluster == FREQWINDOW) {
 	for (f = 0; f < 8; f++)
-	    mvprintw(15 + f, 4, "                           ");
+	    mvaddstr(15 + f, 4, "                           ");
 
 	if (trx_control)
 	    node_frequencies[thisnode - 'A'] = freq;
@@ -101,7 +102,7 @@ void clusterinfo(void) {
 	g_strlcpy(inputbuffer, backgrnd_str, 79);
 
 	for (j = 15; j <= LINES - 3; j++) {
-	    mvprintw(j, 1, "%s", inputbuffer);
+	    mvaddstr(j, 1, inputbuffer);
 	}
 
 
@@ -134,7 +135,7 @@ void clusterinfo(void) {
 		}
 
 		if (strlen(inputbuffer) > 14) {
-		    mvprintw(j, 1, "%s", inputbuffer);
+		    mvaddstr(j, 1, inputbuffer);
 		}
 	    }
 	}

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -58,7 +58,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
     // clean up received qtcs with same call and mode
     if (qtcdirection & RECV) {
 	if ((qtcfile = open(QTC_RECV_LOG, O_RDWR)) < 0) {
-	    mvprintw(5, 0, "Error opening QTC received logfile.\n");
+	    mvaddstr(5, 0, "Error opening QTC received logfile.\n");
 	    sleep(1);
 	}
 	fstat(qtcfile, &qstatbuf);
@@ -92,7 +92,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
     // clean up sent qtcs with same call and mode
     if (qtcdirection & SEND) {
 	if ((qtcfile = open(QTC_SENT_LOG, O_RDWR)) < 0) {
-	    mvprintw(5, 0, "Error opening QTC sent logfile.\n");
+	    mvaddstr(5, 0, "Error opening QTC sent logfile.\n");
 	    sleep(1);
 	}
 	fstat(qtcfile, &qstatbuf);
@@ -140,7 +140,7 @@ void delete_qso(void) {
     char logline[100];
     char call[15], bandmode[6];
 
-    mvprintw(13, 29, "OK to delete last qso (y/n)?");
+    mvaddstr(13, 29, "OK to delete last qso (y/n)?");
 
     if (toupper(key_get()) == 'Y') {
 
@@ -176,7 +176,7 @@ void delete_qso(void) {
     }
 
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-    mvprintw(13, 29, "                            ");
+    mvaddstr(13, 29, "                            ");
 
     clear_display();
 }

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -48,7 +48,7 @@ static void highlight_line(int row, char *line, int column) {
 
     g_strlcpy(ln, line, NR_COLS + 1);
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-    mvprintw(7 + row, 0, "%s", ln);
+    mvaddstr(7 + row, 0, ln);
     move(7 + row, column);
     refreshp();
 }
@@ -60,7 +60,7 @@ static void unhighlight_line(int row, char *line) {
 
     g_strlcpy(ln, line, NR_COLS + 1);
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-    mvprintw(7 + row, 0, "%s", ln);
+    mvaddstr(7 + row, 0, ln);
 }
 
 

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -91,7 +91,7 @@ void logedit(void) {
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
     for (j = 13; j < LINES - 1; j++) {
-	mvprintw(j, 0, "%s", backgrnd_str);
+	clear_line(j);
     }
     refreshp();
 }

--- a/src/err_utils.c
+++ b/src/err_utils.c
@@ -20,6 +20,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include "clear_display.h"
 #include "err_utils.h"
 #include "tlf.h"
 #include "tlf_curses.h"
@@ -35,8 +36,8 @@ void handle_logging(enum log_lvl lvl, ...) {
     str = g_strdup_vprintf(fmt, args);
     va_end(args);
 
-    mvprintw(LINES - 1, 0, "%s", backgrnd_str);
-    mvprintw(LINES - 1, 0, "%s", str);
+    clear_line(LINES - 1);
+    mvaddstr(LINES - 1, 0, str);
     refreshp();
 
     g_free(str);

--- a/src/focm.c
+++ b/src/focm.c
@@ -211,7 +211,7 @@ int foc_total_score() {
 void foc_show_scoring(int start_column) {
     int points = foc_total_score();
 
-    mvprintw(4, start_column, "%s", " QSO   Cty  Cont    5b    6b  Score");
+    mvaddstr(4, start_column, " QSO   Cty  Cont    5b    6b  Score");
     mvprintw(5, start_column, "%4d   %3d    %2d  %4d  %4d   %4d",
 	     total, cntry * 2, cont * 5,
 	     five_banders * 10, six_banders * 5, points);
@@ -293,7 +293,7 @@ void foc_show_cty() {
 
     g_tree_foreach(tree, (GTraverseFunc)show_it, &pos);
 
-    mvprintw(12, 29, "press a key...");
+    mvaddstr(12, 29, "press a key...");
     refreshp();
 
     key_get();

--- a/src/freq_display.c
+++ b/src/freq_display.c
@@ -59,11 +59,11 @@ void freq_display(void) {
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 
     if (trxmode == CWMODE)
-	mvprintw(18, 41, "CW");
+	mvaddstr(18, 41, "CW");
     else if (trxmode == SSBMODE)
-	mvprintw(19, 41, "SSB");
+	mvaddstr(19, 41, "SSB");
     else
-	mvprintw(19, 41, "DIG");
+	mvaddstr(19, 41, "DIG");
 
     refreshp();
 }
@@ -258,7 +258,7 @@ void print_big_number(int number, int y_position, int x_position,
 void print_dot(int y, int x) {
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-    mvprintw(y, x, " ");
+    mvaddstr(y, x, " ");
 
 }
 
@@ -268,7 +268,7 @@ void clear_freq_display(int y, int x) {
     attron(modify_attr(COLOR_PAIR(C_LOG)));
 
     for (int i = 0; i < 5; ++i) {
-	mvprintw(y + i, x, "%s", spaces(35));
+	mvaddstr(y + i, x, spaces(35));
     }
 
 }

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -267,7 +267,7 @@ int getexchange(void) {
 		    rst_recv_up();
 
 		    if (!no_rst)
-			mvprintw(12, 49, "%s", recvd_rst);
+			mvaddstr(12, 49, recvd_rst);
 
 		} else {	/* speed up */
 		    speedup();
@@ -284,7 +284,7 @@ int getexchange(void) {
 		    rst_recv_down();
 
 		    if (!no_rst)
-			mvprintw(12, 49, "%s", recvd_rst);
+			mvaddstr(12, 49, recvd_rst);
 
 		} else {	/* speed down */
 		    speeddown();
@@ -412,22 +412,22 @@ int getexchange(void) {
 	    }
 
 	    if (CONTEST_IS(ARRL_SS) && (x != TAB) && (strlen(section) < 2)) {
-		mvprintw(13, 54, "section?");
-		mvprintw(12, 54, "%s", comment);
+		mvaddstr(13, 54, "section?");
+		mvaddstr(12, 54, comment);
 		x = 0;
 	    } else if (((serial_section_mult == 1) || (sectn_mult == 1))
 		       && ((x != TAB) && (strlen(section) < 1))) {
 		if (serial_or_section == 0 || (serial_or_section == 1
 					       && country_found(hiscall))) {
-		    mvprintw(13, 54, "section?X");
-		    mvprintw(12, 54, "%s", comment);
+		    mvaddstr(13, 54, "section?X");
+		    mvaddstr(12, 54, comment);
 		    refreshp();
 		}
 		break;
 
 	    } else if (serial_grid4_mult == 1) {
-		//      mvprintw(13,54, "section?");
-		mvprintw(12, 54, "%s", comment);
+		//      mvaddstr(13,54, "section?");
+		mvaddstr(12, 54, comment);
 		refreshp();
 		gridmult = getgrid(comment);
 		strcpy(section, gridmult);
@@ -437,8 +437,8 @@ int getexchange(void) {
 
 	    } else if (CONTEST_IS(STEWPERRY)) {
 		if (check_qra(comment) == 0) {
-		    mvprintw(13, 54, "locator?");
-		    mvprintw(12, 54, "%s", comment);
+		    mvaddstr(13, 54, "locator?");
+		    mvaddstr(12, 54, comment);
 		    break;
 		}
 		refreshp();
@@ -446,8 +446,8 @@ int getexchange(void) {
 	    } else if (CONTEST_IS(CQWW) && trxmode == DIGIMODE && ((countrynr == w_cty)
 		       || (countrynr == ve_cty))) {
 		if (strlen(comment) < 5) {
-		    mvprintw(13, 54, "state/prov?");
-		    mvprintw(12, 54, "%s", comment);
+		    mvaddstr(13, 54, "state/prov?");
+		    mvaddstr(12, 54, comment);
 		    if (x == '\n' || x == KEY_ENTER || x == BACKSLASH) {
 			x = 0;
 		    } else {
@@ -806,8 +806,8 @@ void exchange_edit(void) {
 	attroff(A_STANDOUT);
 	attron(COLOR_PAIR(C_HEADER));
 
-	mvprintw(12, 54, "%s", spaces(contest->exchange_width));
-	mvprintw(12, 54, "%s", comment);
+	mvaddstr(12, 54, spaces(contest->exchange_width));
+	mvaddstr(12, 54, comment);
 	move(12, 54 + b);
 
 	i = key_get();

--- a/src/getwwv.c
+++ b/src/getwwv.c
@@ -110,6 +110,6 @@ void wwv_add(const char *s) {
 //
 void wwv_show_footer() {
     if (lastwwv_time > get_time() - 3 * 60) {
-	mvprintw(LINES - 1, 0, "%s", lastwwv);
+	mvaddstr(LINES - 1, 0, lastwwv);
     }
 }

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -104,7 +104,7 @@ void keyer(void) {
 	for (j = 0; j < KEYER_LINE_WIDTH; j++) {
 	    waddch(win, ' ');
 	}
-	mvwprintw(win, 1, 1, "%s", keyerstring);
+	mvwaddstr(win, 1, 1, keyerstring);
 	refreshp();
 
 	x = key_get();

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -213,7 +213,7 @@ void keyer(void) {
 		}
 
 		case ALT_W: {	// Alt-W, set weight
-		    mvprintw(1, 0, "Weight=   ");
+		    mvaddstr(1, 0, "Weight=   ");
 		    refreshp();
 		    move(1, 7);
 		    echo();

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -31,6 +31,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
+#include "clear_display.h"
 #include "err_utils.h"
 #include "get_time.h"
 #include "globalvars.h"
@@ -331,8 +332,8 @@ void talk(void) {
 
     char talkline[61] = "";
 
-    mvprintw(LINES - 1, 0, "%s", backgrnd_str);
-    mvprintw(LINES - 1, 0, "T>");
+    clear_line(LINES - 1);
+    mvaddstr(LINES - 1, 0, "T>");
     refreshp();
     echo();
     getnstr(talkline, 60);
@@ -344,7 +345,7 @@ void talk(void) {
 
     talkline[0] = '\0';
     attron(COLOR_PAIR(C_HEADER));
-    mvprintw(LINES - 1, 0, "%s", backgrnd_str);
+    clear_line(LINES - 1);
     refreshp();
 }
 

--- a/src/listmessages.c
+++ b/src/listmessages.c
@@ -69,7 +69,7 @@ void listmessages(void) {
     mvprintw(14 + LIST_UPPER + 1, 1, " SPCa: %s", formatMessage(SP_CALL_MSG));
 
     attroff(A_STANDOUT);
-    mvprintw(23, 30,  "Press any key");
+    mvaddstr(23, 30,  "Press any key");
     refreshp();
 
     (void)key_get();
@@ -78,7 +78,7 @@ void listmessages(void) {
 
     attron(COLOR_PAIR(C_LOG)  |  A_STANDOUT);
     for (i = 13 ;  i  <= 23 ; i++) {
-	mvprintw(i, 0, "%s", backgrnd_str);
+	clear_line(i);
     }
 
     refreshp();

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -139,21 +139,21 @@ void log_to_disk(int from_lan) {
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));	/* erase comment  field */
 
     if (!from_lan)
-	mvprintw(12, 54, "%s", spaces(contest->exchange_width));
+	mvaddstr(12, 54, spaces(contest->exchange_width));
 
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     if (!from_lan) {
-	mvprintw(7, 0, "%s", logline0);
-	mvprintw(8, 0, "%s", logline1);
-	mvprintw(9, 0, "%s", logline2);
+	mvaddstr(7, 0, logline0);
+	mvaddstr(8, 0, logline1);
+	mvaddstr(9, 0, logline2);
     }
-    mvprintw(10, 0, "%s", logline3);
-    mvprintw(11, 0, "%s", logline4);
+    mvaddstr(10, 0, logline3);
+    mvaddstr(11, 0, logline4);
     refreshp();
 
     attron(COLOR_PAIR(C_WINDOW));
 
-    mvprintw(12, 23, "%s", qsonrstr);
+    mvaddstr(12, 23, qsonrstr);
 
     if (no_rst) {
 	mvaddstr(12, 44, "   ");

--- a/src/logit.c
+++ b/src/logit.c
@@ -207,8 +207,8 @@ void refresh_comment(void) {
 
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
-    mvprintw(12, 54, "%s", spaces(contest->exchange_width));
-    mvprintw(12, 54, "%s", comment);
+    mvaddstr(12, 54, spaces(contest->exchange_width));
+    mvaddstr(12, 54, comment);
 }
 
 void change_mode(void) {

--- a/src/logview.c
+++ b/src/logview.c
@@ -48,7 +48,7 @@ int logview(void) {
     attron(COLOR_PAIR(C_LOG)  |  A_STANDOUT);
 
     for (j = 13 ;  j  <= 23 ; j++) {
-	mvprintw(j, 0, "%s", backgrnd_str);
+	clear_line(j);
     }
 
     refreshp();

--- a/src/main.c
+++ b/src/main.c
@@ -1007,7 +1007,7 @@ int main(int argc, char *argv[]) {
     clear_display();		/* tidy up the display */
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     for (j = 13; j <= LINES - 1; j++) {	/* wipe lower window */
-	mvprintw(j, 0, "%s", backgrnd_str);
+	clear_line(j);
     }
     refreshp();
 

--- a/src/messagechange.c
+++ b/src/messagechange.c
@@ -78,7 +78,7 @@ void message_change() {
 
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     for (int y = 13; y < LINES - 1; y++) {
-	mvprintw(y, 0, "%s", backgrnd_str);
+	clear_line(y);
     }
 
     nicebox(14, 3, 2, 60, "Enter message (F1-12, C, S)");

--- a/src/muf.c
+++ b/src/muf.c
@@ -370,12 +370,12 @@ void muf(void) {
     wattron(win, modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
 
     for (i = 0; i < LINES; i++)
-	mvwprintw(win, i, 0, "%s", backgrnd_str);
+	mvwaddstr(win, i, 0, backgrnd_str);
 
     mvwprintw(win, 1, 0, "        SSN: %3.0f ", ssn_r);
 
     if (countrynr != 0) {
-	mvwprintw(win, 1, 40, "%s", country);
+	mvwaddstr(win, 1, 40, country);
 	mvwprintw(win, 3, 40, "Dist  : %5.0f km", l);
 	mvwprintw(win, 4, 40, "Azim  :   %3.0f degrees", u);
 	mvwprintw(win, 5, 40, "F-hops:    %2.0f", n);
@@ -403,7 +403,7 @@ void muf(void) {
 	su_min = (int)((sunrise - su) * 60);
 	sd_min = (int)((sundown - sd) * 60);
 
-	mvwprintw(win, 3, 0, "%s", time_buf);
+	mvwaddstr(win, 3, 0, time_buf);
 	mvwprintw(win, 7, 40, "Sun   : %02d:%02d-%02d:%02d UTC", su, su_min, sd,
 		  sd_min);
     }
@@ -423,9 +423,9 @@ void muf(void) {
 	q -= 2.0;
 	row++;
     }
-    mvwprintw(win, 20, 0, "---------------------------");	/* 27 dashes */
-    mvwprintw(win, 21, 0, " 0 2 4 6 8 10  14  18  22 H (UTC)");
-    mvwprintw(win, 4, 30, "MHz");
+    mvwaddstr(win, 20, 0, "---------------------------");	/* 27 dashes */
+    mvwaddstr(win, 21, 0, " 0 2 4 6 8 10  14  18  22 H (UTC)");
+    mvwaddstr(win, 4, 30, "MHz");
 
     if (countrynr != 0) {
 	for (t = 1; t <= 24; t++) {
@@ -446,7 +446,7 @@ void muf(void) {
 	    double ho = t + 1;
 	    if (ve < 4)
 		ve = 4;
-	    mvwprintw(win, (int) ve, (int) ho, "+");
+	    mvwaddstr(win, (int) ve, (int) ho, "+");
 
 	    while (k <= n - 0.25) {
 		interlat();
@@ -460,11 +460,11 @@ void muf(void) {
 	    if (ve > 20)
 		ve = 20;
 
-	    mvwprintw(win, (int) ve, (int) ho, "-");
+	    mvwaddstr(win, (int) ve, (int) ho, "-");
 	}
     }
 
-    mvwprintw(win, 23, 0, " --- Press a key to continue --- ");
+    mvwaddstr(win, 23, 0, " --- Press a key to continue --- ");
     refreshp();
     key_get();
 

--- a/src/nicebox.c
+++ b/src/nicebox.c
@@ -42,7 +42,7 @@ void wnicebox(WINDOW *win, int y, int x, int height, int width, char *boxname) {
     mvwaddch(win, y + height, x + width, ACS_LRCORNER);
     mvwvline(win, y + 1, x + width, ACS_VLINE, height - 1);
     mvwvline(win, y + 1, x, ACS_VLINE, height - 1);
-    mvwprintw(win, y, x + 2, "%s", boxname);
+    mvwaddstr(win, y, x + 2, boxname);
 
     return;
 }

--- a/src/nicebox.c
+++ b/src/nicebox.c
@@ -54,7 +54,7 @@ void nicebox(int y, int x, int height, int width, char *boxname) {
 void ask(char *buffer, char *what) {
 
     attron(A_STANDOUT);
-    mvprintw(15, 1, "%s", spaces(78));
+    mvaddstr(15, 1, spaces(78));
     nicebox(14, 0, 1, 78, what);
     attron(A_STANDOUT);
     move(15, 1);

--- a/src/note.c
+++ b/src/note.c
@@ -85,7 +85,7 @@ int include_note(void) {
     attron(COLOR_PAIR(C_LOG | A_STANDOUT));
 
     for (i = 14; i <= 16; i++)
-	mvprintw(i, 0, "%s", backgrnd_str);
+	clear_line(i);
 
     return (0);
 }

--- a/src/printcall.c
+++ b/src/printcall.c
@@ -39,8 +39,8 @@ void printcall(void) {
 
     attron(COLOR_PAIR(C_INPUT) | attrib);
 
-    mvprintw(12, 29, "            ");
-    mvprintw(12, 29, "%s", hiscall);
+    mvaddstr(12, 29, "            ");
+    mvaddstr(12, 29, hiscall);
     if ((cqmode == CQ) && (cwstart > 0))
 	mvchgat(12, 29 + cwstart, 12 - cwstart,
 		attrib | A_UNDERLINE, C_INPUT, NULL);

--- a/src/qtcutil.c
+++ b/src/qtcutil.c
@@ -58,7 +58,7 @@ void qtc_meta_write() {
 
     qtc_key_list = g_hash_table_get_keys(qtc_store);
     if ((fp = fopen(QTC_META_LOG, "w")) == NULL) {
-	mvprintw(5, 0, "Error opening QTC meta logfile.\n");
+	mvaddstr(5, 0, "Error opening QTC meta logfile.\n");
 	refreshp();
 	sleep(2);
     } else {

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -188,12 +188,12 @@ void draw_qtc_panel(int direction) {
     wbkgd(qtcwin, (chtype)(A_NORMAL | COLOR_PAIR(QTCRECVWINBG)));
 
     wattrset(qtcwin, LINE_INVERTED);
-    mvwprintw(qtcwin, 1, 1, "                                 ");
+    mvwaddstr(qtcwin, 1, 1, "                                 ");
     /* the first visible and used line is the qtc serial and count
      * it differs in RECV and SEND direction, these two lines sets them
      */
     if (direction == RECV) {
-	mvwprintw(qtcwin, 2, 1, "      /                          ");
+	mvwaddstr(qtcwin, 2, 1, "      /                          ");
     }
     if (direction == SEND) {
 	mvwprintw(qtcwin, 2, 1, "     %d/%2d                        ",
@@ -212,7 +212,7 @@ void draw_qtc_panel(int direction) {
     if (direction == RECV) {
 	for (i = 0; i < QTC_LINES; i++) {
 	    wattrset(qtcwin, LINE_INVERTED);
-	    mvwprintw(qtcwin, i + 3, 1, "                                 ");
+	    mvwaddstr(qtcwin, i + 3, 1, "                                 ");
 	    for (j = 0; j < 3; j++) {
 		showfield((i * 3) + j + 3);	// QTC fields...
 	    }
@@ -232,14 +232,14 @@ void draw_qtc_panel(int direction) {
 
 	if (trxmode == DIGIMODE) {
 	    if (qtc_ry_capture == 0) {
-		mvwprintw(qtcwin, 2, 11, "CAPTURE OFF");
+		mvwaddstr(qtcwin, 2, 11, "CAPTURE OFF");
 	    } else {
-		mvwprintw(qtcwin, 2, 11, "CAPTURE ON ");
+		mvwaddstr(qtcwin, 2, 11, "CAPTURE ON ");
 		show_rtty_lines();
 	    }
 	} else {
 	    if (qtcrec_record == 1) {
-		mvwprintw(qtcwin, 2, 11, "RECORD OFF  ");
+		mvwaddstr(qtcwin, 2, 11, "RECORD OFF  ");
 	    }
 	}
 	wattrset(qtcwin, LINE_NORMAL);
@@ -265,7 +265,7 @@ void start_qtc_recording() {
 	strcat(reccommand, qtcrec_record_command[1]);
 	record_run = system(reccommand);
 	if (record_run > -1 && qtcrec_record == 1) {
-	    mvwprintw(qtcwin, 2, 11, "RECORD ON   ");
+	    mvwaddstr(qtcwin, 2, 11, "RECORD ON   ");
 	}
     }
 }
@@ -280,7 +280,7 @@ void stop_qtc_recording() {
 	IGNORE(system(reccommand));;
 	record_run = -1;
 	if (qtcrec_record == 1) {
-	    mvwprintw(qtcwin, 2, 11, "RECORD OFF  ");
+	    mvwaddstr(qtcwin, 2, 11, "RECORD OFF  ");
 	}
     }
 }
@@ -491,7 +491,7 @@ void qtc_main_panel(int direction) {
 			    show_help_msg(activefield);
 			    showfield(0);
 			    wattrset(qtcwin, LINE_CURRINVERTED);
-			    mvwprintw(qtcwin, activefield, 4, "%s", qtclist.qtclines[9].qtc);
+			    mvwaddstr(qtcwin, activefield, 4, qtclist.qtclines[9].qtc);
 			    break;
 			case 2:
 			    activefield = 0;
@@ -502,7 +502,7 @@ void qtc_main_panel(int direction) {
 			    activefield = 2;
 			    showfield(2);
 			    wattrset(qtcwin, LINE_NORMAL);
-			    mvwprintw(qtcwin, activefield + 1, 4, "%s", qtclist.qtclines[0].qtc);
+			    mvwaddstr(qtcwin, activefield + 1, 4, qtclist.qtclines[0].qtc);
 			    break;
 			case 4 ... 12:
 			    show_help_msg(activefield);
@@ -551,7 +551,7 @@ void qtc_main_panel(int direction) {
 			    show_help_msg(activefield);
 			    showfield(2);
 			    wattrset(qtcwin, LINE_CURRINVERTED);
-			    mvwprintw(qtcwin, activefield, 4, "%s", qtclist.qtclines[0].qtc);
+			    mvwaddstr(qtcwin, activefield, 4, qtclist.qtclines[0].qtc);
 			    break;
 			case 3 ... 11:
 			    show_help_msg(activefield);
@@ -566,7 +566,7 @@ void qtc_main_panel(int direction) {
 			case 12:
 			    activefield = 0;
 			    wattrset(qtcwin, LINE_NORMAL);
-			    mvwprintw(qtcwin, 14, 4, "%s", qtclist.qtclines[9].qtc);
+			    mvwaddstr(qtcwin, 14, 4, qtclist.qtclines[9].qtc);
 			    showfield(0);
 			    break;
 		    }
@@ -689,7 +689,7 @@ void qtc_main_panel(int direction) {
 			    sendmessage(tempc);
 			}
 
-			mvwprintw(qtcwin, activefield, 30, "*");
+			mvwaddstr(qtcwin, activefield, 30, "*");
 			qtclist.qtclines[activefield - 3].flag = 1;
 			// scroll down if not at end of qtclist:
 			if (activefield - 3 < *qtccount - 1) {
@@ -703,7 +703,7 @@ void qtc_main_panel(int direction) {
 			}
 			if (*qtccount > 0 && qtclist.totalsent == *qtccount) {
 			    wattrset(qtcwin, LINE_INVERTED);
-			    mvwprintw(qtcwin, 2, 11, "CTRL+S to SAVE!");
+			    mvwaddstr(qtcwin, 2, 11, "CTRL+S to SAVE!");
 			    refreshp();
 			    show_help_msg(6);
 			}
@@ -753,14 +753,14 @@ void qtc_main_panel(int direction) {
 			    tempc[0] = '\0';
 			    replace_spaces(qtclist.qtclines[ql].qtc, tempc);
 			    strcat(tmess, tempc);
-			    mvwprintw(qtcwin, ql + 3, 30, "*");
+			    mvwaddstr(qtcwin, ql + 3, 30, "*");
 			    qtclist.qtclines[ql].flag = 1;
 
 			}
 			keyer_append(tmess);
 			write_keyer();
 			wattrset(qtcwin, LINE_INVERTED);
-			mvwprintw(qtcwin, 2, 11, "CTRL+S to SAVE!");
+			mvwaddstr(qtcwin, 2, 11, "CTRL+S to SAVE!");
 			refreshp();
 			show_help_msg(6);
 
@@ -791,7 +791,7 @@ void qtc_main_panel(int direction) {
 			&& qtclist.totalsent == *qtccount) {
 		    log_sent_qtc_to_disk(nr_qsos);
 		    wattrset(qtcwin, LINE_INVERTED);
-		    mvwprintw(qtcwin, 2, 11, "QTCs have been saved!");
+		    mvwaddstr(qtcwin, 2, 11, "QTCs have been saved!");
 		    prevqtccall[0] = '\0';
 		    qtccallsign[0] = '\0';
 		    refreshp();
@@ -803,7 +803,7 @@ void qtc_main_panel(int direction) {
 		    qtc_ry_capture = 1;
 		    wattr_get(qtcwin, &attributes, &cpair, NULL);
 		    wattrset(qtcwin, LINE_INVERTED);
-		    mvwprintw(qtcwin, 2, 11, "CAPTURE ON ");
+		    mvwaddstr(qtcwin, 2, 11, "CAPTURE ON ");
 		    wattrset(qtcwin, attributes);
 		    showfield(activefield);
 		    refreshp();
@@ -817,7 +817,7 @@ void qtc_main_panel(int direction) {
 		    qtc_ry_capture = 0;
 		    wattr_get(qtcwin, &attributes, &cpair, NULL);
 		    wattrset(qtcwin, LINE_INVERTED);
-		    mvwprintw(qtcwin, 2, 11, "CAPTURE OFF");
+		    mvwaddstr(qtcwin, 2, 11, "CAPTURE OFF");
 		    wattrset(qtcwin, attributes);
 		    showfield(activefield);
 		    refreshp();
@@ -846,7 +846,7 @@ void qtc_main_panel(int direction) {
 			    qtc_ry_capture = 1;
 			    wattr_get(qtcwin, &attributes, &cpair, NULL);
 			    wattrset(qtcwin, LINE_INVERTED);
-			    mvwprintw(qtcwin, 2, 11, "CAPTURE ON ");
+			    mvwaddstr(qtcwin, 2, 11, "CAPTURE ON ");
 			    wattrset(qtcwin, attributes);
 			    showfield(activefield);
 			    refreshp();
@@ -918,7 +918,7 @@ void qtc_main_panel(int direction) {
 		    qtclist.qtclines[activefield - 3].sent = 0;
 		    qtclist.qtclines[activefield - 3].flag = 0;
 		    wattrset(qtcwin, LINE_CURRNORMAL);
-		    mvwprintw(qtcwin, activefield, 30, " ");
+		    mvwaddstr(qtcwin, activefield, 30, " ");
 		    qtclist.totalsent--;
 		}
 		break;
@@ -1209,8 +1209,8 @@ void showfield(int fidx) {
 	wattrset(qtcwin, LINE_NORMAL);
     }
 
-    mvwprintw(qtcwin, winrow, pos[posidx][0], "%s", filled);
-    mvwprintw(qtcwin, winrow, pos[posidx][0], "%s", fieldval);
+    mvwaddstr(qtcwin, winrow, pos[posidx][0], filled);
+    mvwaddstr(qtcwin, winrow, pos[posidx][0], fieldval);
     if (fidx == activefield) {
 	show_help_msg(posidx);
 	if (pos[posidx][0] == pos[posidx][1]) {
@@ -1477,7 +1477,7 @@ void number_fields() {
 
     wattrset(qtcwin, (chtype)(A_NORMAL | COLOR_PAIR(QTCRECVBG)));
     for (i = 0; i < QTC_LINES; i++) {
-	mvwprintw(qtcwin, i + 3, 1, "  ");
+	mvwaddstr(qtcwin, i + 3, 1, "  ");
     }
     for (i = 0; i < *qtccount; i++) {
 	mvwprintw(qtcwin, i + 3, 1, "%2d", i + 1);
@@ -1489,7 +1489,7 @@ void clear_help_block() {
 
     wattrset(qtcwin, LINE_INVERTED);
     for (i = 1; i < 13; i++) {
-	mvwprintw(qtcwin, i, 36, "                                      ");
+	mvwaddstr(qtcwin, i, 36, "                                      ");
     }
 }
 
@@ -1509,25 +1509,25 @@ void show_help_msg(int msgidx) {
 		    strlen(qtcreclist.qtclines[currqtc].callsign) > 0 &&
 		    strlen(qtcreclist.qtclines[currqtc].serial) > 0
 	       ) {
-		mvwprintw(qtcwin, ++j, 36, "Press ENTER to mark as RCVD");
+		mvwaddstr(qtcwin, ++j, 36, "Press ENTER to mark as RCVD");
 	    }
 	} else {
-	    mvwprintw(qtcwin, ++j, 36, "%s", help_rec_msgs[msgidx]);
+	    mvwaddstr(qtcwin, ++j, 36, help_rec_msgs[msgidx]);
 	}
     }
     if (qtccurrdirection == SEND) {
 	if (msgidx > 2 && msgidx < 6) {
 	    msgidx = 3;
 	}
-	mvwprintw(qtcwin, ++j, 36, "%s", help_send_msgs[msgidx]);
+	mvwaddstr(qtcwin, ++j, 36, help_send_msgs[msgidx]);
     }
     wattrset(qtcwin, LINE_INVERTED);
-    mvwprintw(qtcwin, ++j, 36, "PgUP/PgDW: QRQ/QRS      CTRL-N: NO QTC");
+    mvwaddstr(qtcwin, ++j, 36, "PgUP/PgDW: QRQ/QRS      CTRL-N: NO QTC");
     if (qtccurrdirection == RECV) {
-	mvwprintw(qtcwin, ++j, 36, "ENTER: R & next OR AGN  CTRL-L: LATER ");
+	mvwaddstr(qtcwin, ++j, 36, "ENTER: R & next OR AGN  CTRL-L: LATER ");
     }
     if (qtccurrdirection == SEND) {
-	mvwprintw(qtcwin, ++j, 36, "ENTER: send QTC         CTRL-L: LATER ");
+	mvwaddstr(qtcwin, ++j, 36, "ENTER: send QTC         CTRL-L: LATER ");
     }
     for (i = 0; i < 12 && j < 12; i++) {
 	if (qtccurrdirection == RECV) {
@@ -1536,10 +1536,10 @@ void show_help_msg(int msgidx) {
 		mvwprintw(qtcwin, ++j, 36, "F%-2d: %s", (i + 1), buff);
 	    }
 	    if (i == 1) {
-		mvwprintw(qtcwin, j - 1, 56, "CTRL-F: FILL TIMES");
+		mvwaddstr(qtcwin, j - 1, 56, "CTRL-F: FILL TIMES");
 	    }
 	    if (i == 2) {
-		mvwprintw(qtcwin, j - 1, 56, "CTRL-R: RECORD");
+		mvwaddstr(qtcwin, j - 1, 56, "CTRL-R: RECORD");
 	    }
 	}
 	if (qtccurrdirection == SEND) {
@@ -1550,9 +1550,9 @@ void show_help_msg(int msgidx) {
 	}
     }
     if (trxmode == DIGIMODE && qtccurrdirection == RECV) {
-	mvwprintw(qtcwin, ++j, 36, "CTRL-T: Terminal window");
-	mvwprintw(qtcwin, ++j, 36, "CTRL-S: Start capture");
-	mvwprintw(qtcwin, ++j, 36, "CTRL-E: End capture");
+	mvwaddstr(qtcwin, ++j, 36, "CTRL-T: Terminal window");
+	mvwaddstr(qtcwin, ++j, 36, "CTRL-S: Start capture");
+	mvwaddstr(qtcwin, ++j, 36, "CTRL-E: End capture");
     }
 }
 
@@ -1719,14 +1719,14 @@ void show_rtty_lines() {
     wnicebox(ry_win, 0, 0, 12, 38, boxhead);
     wattrset(ry_win, LINE_NORMAL);
     for (j = 1; j < 13; j++) {
-	mvwprintw(ry_win, j, 1, "                                      ");
+	mvwaddstr(ry_win, j, 1, "                                      ");
     }
     refreshp();
 
     if (qtc_ry_capture == 1) {
-	mvwprintw(qtcwin, 2, 11, "CAPTURE ON ");
+	mvwaddstr(qtcwin, 2, 11, "CAPTURE ON ");
     } else {
-	mvwprintw(qtcwin, 2, 11, "CAPTURE OFF");
+	mvwaddstr(qtcwin, 2, 11, "CAPTURE OFF");
     }
 
     x = -1; j = 1;
@@ -1807,7 +1807,7 @@ void show_rtty_lines() {
 		for (j = 0; j < 12; j++) {
 		    qtc_ry_lines[j].content[0] = '\0';
 		    qtc_ry_lines[j].attr = 0;
-		    mvwprintw(ry_win, (j + 1), 1, "                                      ");
+		    mvwaddstr(ry_win, (j + 1), 1, "                                      ");
 		}
 		prevline = -1;
 		actline = 1;
@@ -1818,13 +1818,13 @@ void show_rtty_lines() {
 	    // Ctrl-S (^S), start capture
 	    case CTRL_S:
 		qtc_ry_capture = 1;
-		mvwprintw(qtcwin, 2, 11, "CAPTURE ON ");
+		mvwaddstr(qtcwin, 2, 11, "CAPTURE ON ");
 		break;
 
 	    // Ctrl-E (^E), end capture
 	    case CTRL_E:
 		qtc_ry_capture = 0;
-		mvwprintw(qtcwin, 2, 11, "CAPTURE OFF");
+		mvwaddstr(qtcwin, 2, 11, "CAPTURE OFF");
 		break;
 
 	    // <Enter>, add to qtc
@@ -1844,7 +1844,7 @@ void show_rtty_lines() {
 	}
 	if (*qtccount > 0 && qtc_ry_copied == qtcreclist.count) {
 	    qtc_ry_capture = 0;
-	    mvwprintw(qtcwin, 2, 11, "CAPTURE OFF");
+	    mvwaddstr(qtcwin, 2, 11, "CAPTURE OFF");
 	}
     }
     hide_panel(ry_panel);
@@ -1863,7 +1863,7 @@ void put_qtc() {
 
     wattrset(qtcwin, LINE_NORMAL);
     if (qtc_temp_obj->capable == -1 && qtc_temp_obj->total == 0) {
-	mvwprintw(qtcwin, 1, 19, "FLAG: NO QTC");
+	mvwaddstr(qtcwin, 1, 19, "FLAG: NO QTC");
     } else {
 	mvwprintw(qtcwin, 1, 19, "%s %2d QTC", qtcdirstring[qtccurrdirection],
 		  qtc_temp_obj->total);
@@ -1904,20 +1904,20 @@ void show_sendto_lines() {
 
     wattrset(qtcwin, LINE_INVERTED);
     for (i = 0; i < QTC_LINES; i++) {
-	mvwprintw(qtcwin, i + 3, 1, "                                 ");
+	mvwaddstr(qtcwin, i + 3, 1, "                                 ");
     }
 
     wattrset(qtcwin, LINE_NORMAL);
     for (i = 0; i < qtclist.count; i++) {
-	mvwprintw(qtcwin, i + 3, 4, "%s", qtclist.qtclines[i].qtc);
+	mvwaddstr(qtcwin, i + 3, 4, qtclist.qtclines[i].qtc);
 	if (qtclist.qtclines[i].sent == 1) {
-	    mvwprintw(qtcwin, i + 3, 30, "*");
+	    mvwaddstr(qtcwin, i + 3, 30, "*");
 	}
     }
 
     wattrset(qtcwin, LINE_NORMAL);
     for (i = qtclist.count; i < QTC_LINES; i++) {
-	mvwprintw(qtcwin, i + 3, 4, "                        ");
+	mvwaddstr(qtcwin, i + 3, 4, "                        ");
     }
     number_fields();
 }

--- a/src/readctydata.c
+++ b/src/readctydata.c
@@ -42,7 +42,7 @@ void readctydata(void) {
 
     if (load_ctydata(filename) == -1) {
 	g_free(filename);
-	mvprintw(4, 0, "Error opening cty.dat file.\n");
+	mvaddstr(4, 0, "Error opening cty.dat file.\n");
 	refreshp();
 	sleep(5);
 	endwin();

--- a/src/recall_exchange.c
+++ b/src/recall_exchange.c
@@ -121,7 +121,7 @@ int recall_exchange(void) {
 
     strcpy(comment, proposed_exchange);
 
-    mvprintw(12, 54, "%s", comment);  //TODO move this to UI code
+    mvaddstr(12, 54, comment);  //TODO move this to UI code
     refreshp();
 
     return 1;

--- a/src/rtty.h
+++ b/src/rtty.h
@@ -28,7 +28,7 @@
 
 int init_controller() ;
 void deinit_controller();
-int rx_rtty() ;
+void  rx_rtty();
 void show_rtty(void);
 
 #endif /* end of include guard: RTTY_H */

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -117,23 +117,23 @@ void drawSearchWin(void) {
 
     wnicebox(search_win, 0, 0, nr_bands, 37, "Worked");
     if (qtcdirection > 0) {
-	mvwprintw(search_win, 0, 35, "Q");
+	mvwaddstr(search_win, 0, 35, "Q");
     }
 
     wattrset(search_win, COLOR_PAIR(C_LOG) | A_STANDOUT);
     for (i = 0; i < nr_bands; i++)
-	mvwprintw(search_win, i + 1, 1, "%s", spaces(37));
+	mvwaddstr(search_win, i + 1, 1, spaces(37));
 
-    mvwprintw(search_win, 1, 1, " 10");
-    mvwprintw(search_win, 2, 1, " 15");
-    mvwprintw(search_win, 3, 1, " 20");
-    mvwprintw(search_win, 4, 1, " 40");
-    mvwprintw(search_win, 5, 1, " 80");
-    mvwprintw(search_win, 6, 1, "160");
+    mvwaddstr(search_win, 1, 1, " 10");
+    mvwaddstr(search_win, 2, 1, " 15");
+    mvwaddstr(search_win, 3, 1, " 20");
+    mvwaddstr(search_win, 4, 1, " 40");
+    mvwaddstr(search_win, 5, 1, " 80");
+    mvwaddstr(search_win, 6, 1, "160");
     if (IsAllBand()) {
-	mvwprintw(search_win, 7, 1, " 12");
-	mvwprintw(search_win, 8, 1, " 17");
-	mvwprintw(search_win, 9, 1, " 30");
+	mvwaddstr(search_win, 7, 1, " 12");
+	mvwaddstr(search_win, 8, 1, " 17");
+	mvwaddstr(search_win, 9, 1, " 30");
     }
 }
 
@@ -142,7 +142,7 @@ void displayCallInfo(dxcc_data *dx, char *pxstr) {
     wattroff(search_win, A_STANDOUT);
     wattron(search_win, COLOR_PAIR(C_BORDER));
 
-    mvwprintw(search_win, nr_bands + 1, 2, "%s", dx->countryname);
+    mvwaddstr(search_win, nr_bands + 1, 2, dx->countryname);
 
     if (CONTEST_IS(CQWW) || wazmult || itumult) {
 	char *zone_info = NULL;
@@ -158,7 +158,7 @@ void displayCallInfo(dxcc_data *dx, char *pxstr) {
 
     if (CONTEST_IS(WPX) || pfxmult == 1) {
 	int i = strlen(dx->countryname);
-	mvwprintw(search_win, nr_bands + 1, 2 + i + 3, "%s", pxstr);
+	mvwaddstr(search_win, nr_bands + 1, 2 + i + 3, pxstr);
     }
 }
 
@@ -469,7 +469,7 @@ void displaySearchResults(void) {
 	j = bandstr2line(buffer);
 
 	if ((j < 7) || IsAllBand()) {
-	    mvwprintw(search_win, j, 1, "%s", buffer);
+	    mvwaddstr(search_win, j, 1, buffer);
 	}
 
 
@@ -521,62 +521,62 @@ void displayWorkedZonesCountries(int z) {
     if (CONTEST_IS(CQWW) || !iscontest || CONTEST_IS(PACC_PA)) {
 
 	if ((countries[countrynr] & BAND10) != 0) {
-	    mvwprintw(search_win, 1, 36, "C");
-	    mvwprintw(search_win, 1, 1, " 10");
+	    mvwaddstr(search_win, 1, 36, "C");
+	    mvwaddstr(search_win, 1, 1, " 10");
 	}
 	if ((countries[countrynr] & BAND15) != 0) {
-	    mvwprintw(search_win, 2, 36, "C");
-	    mvwprintw(search_win, 2, 1, " 15");
+	    mvwaddstr(search_win, 2, 36, "C");
+	    mvwaddstr(search_win, 2, 1, " 15");
 	}
 	if ((countries[countrynr] & BAND20) != 0) {
-	    mvwprintw(search_win, 3, 36, "C");
-	    mvwprintw(search_win, 3, 1, " 20");
+	    mvwaddstr(search_win, 3, 36, "C");
+	    mvwaddstr(search_win, 3, 1, " 20");
 	}
 	if ((countries[countrynr] & BAND40) != 0) {
-	    mvwprintw(search_win, 4, 36, "C");
-	    mvwprintw(search_win, 4, 1, " 40");
+	    mvwaddstr(search_win, 4, 36, "C");
+	    mvwaddstr(search_win, 4, 1, " 40");
 	}
 	if ((countries[countrynr] & BAND80) != 0) {
-	    mvwprintw(search_win, 5, 36, "C");
-	    mvwprintw(search_win, 5, 1, " 80");
+	    mvwaddstr(search_win, 5, 36, "C");
+	    mvwaddstr(search_win, 5, 1, " 80");
 	}
 	if ((countries[countrynr] & BAND160) != 0) {
-	    mvwprintw(search_win, 6, 1, "160");
-	    mvwprintw(search_win, 6, 36, "C");
+	    mvwaddstr(search_win, 6, 1, "160");
+	    mvwaddstr(search_win, 6, 36, "C");
 	}
 	if (IsAllBand()) {
 	    if ((countries[countrynr] & BAND12) != 0) {
-		mvwprintw(search_win, 7, 1, " 12");
-		mvwprintw(search_win, 7, 36, "C");
+		mvwaddstr(search_win, 7, 1, " 12");
+		mvwaddstr(search_win, 7, 36, "C");
 	    }
 	    if ((countries[countrynr] & BAND17) != 0) {
-		mvwprintw(search_win, 8, 1, " 17");
-		mvwprintw(search_win, 8, 36, "C");
+		mvwaddstr(search_win, 8, 1, " 17");
+		mvwaddstr(search_win, 8, 36, "C");
 	    }
 	    if ((countries[countrynr] & BAND30) != 0) {
-		mvwprintw(search_win, 9, 1, " 30");
-		mvwprintw(search_win, 9, 36, "C");
+		mvwaddstr(search_win, 9, 1, " 30");
+		mvwaddstr(search_win, 9, 36, "C");
 	    }
 	}
     }
     if (CONTEST_IS(CQWW) || (wazmult == 1) || (itumult == 1)) {
 	if ((zones[z] & BAND10) != 0) {
-	    mvwprintw(search_win, 1, 37, "Z");
+	    mvwaddstr(search_win, 1, 37, "Z");
 	}
 	if ((zones[z] & BAND15) != 0) {
-	    mvwprintw(search_win, 2, 37, "Z");
+	    mvwaddstr(search_win, 2, 37, "Z");
 	}
 	if ((zones[z] & BAND20) != 0) {
-	    mvwprintw(search_win, 3, 37, "Z");
+	    mvwaddstr(search_win, 3, 37, "Z");
 	}
 	if ((zones[z] & BAND40) != 0) {
-	    mvwprintw(search_win, 4, 37, "Z");
+	    mvwaddstr(search_win, 4, 37, "Z");
 	}
 	if ((zones[z] & BAND80) != 0) {
-	    mvwprintw(search_win, 5, 37, "Z");
+	    mvwaddstr(search_win, 5, 37, "Z");
 	}
 	if ((zones[z] & BAND160) != 0) {
-	    mvwprintw(search_win, 6, 37, "Z");
+	    mvwaddstr(search_win, 6, 37, "Z");
 	}
     }
 
@@ -596,22 +596,22 @@ void displayWorkedZonesCountries(int z) {
 		(countrynr == zs_cty) ||
 		(countrynr == vk_cty)) {
 	    if ((pacc_qsos[0][pxnr] & BAND160) == BAND160)
-		mvwprintw(search_win, 6, 37, "M");
+		mvwaddstr(search_win, 6, 37, "M");
 
 	    if ((pacc_qsos[0][pxnr] & BAND80) == BAND80)
-		mvwprintw(search_win, 5, 37, "M");
+		mvwaddstr(search_win, 5, 37, "M");
 
 	    if ((pacc_qsos[0][pxnr] & BAND40) == BAND40)
-		mvwprintw(search_win, 4, 37, "M");
+		mvwaddstr(search_win, 4, 37, "M");
 
 	    if ((pacc_qsos[0][pxnr] & BAND20) == BAND20)
-		mvwprintw(search_win, 3, 37, "M");
+		mvwaddstr(search_win, 3, 37, "M");
 
 	    if ((pacc_qsos[0][pxnr] & BAND15) == BAND15)
-		mvwprintw(search_win, 2, 37, "M");
+		mvwaddstr(search_win, 2, 37, "M");
 
 	    if ((pacc_qsos[0][pxnr] & BAND10) == BAND10)
-		mvwprintw(search_win, 1, 37, "M");
+		mvwaddstr(search_win, 1, 37, "M");
 
 	}
     }
@@ -641,22 +641,22 @@ void displayWorkedZonesCountries(int z) {
 	}
 
 	if ((tbandidx & BAND160) == BAND160) {
-	    mvwprintw(search_win, 6, 37, "M");
+	    mvwaddstr(search_win, 6, 37, "M");
 	}
 	if ((tbandidx & BAND80) == BAND80) {
-	    mvwprintw(search_win, 5, 37, "M");
+	    mvwaddstr(search_win, 5, 37, "M");
 	}
 	if ((tbandidx & BAND40) == BAND40) {
-	    mvwprintw(search_win, 4, 37, "M");
+	    mvwaddstr(search_win, 4, 37, "M");
 	}
 	if ((tbandidx & BAND20) == BAND20) {
-	    mvwprintw(search_win, 3, 37, "M");
+	    mvwaddstr(search_win, 3, 37, "M");
 	}
 	if ((tbandidx & BAND15) == BAND15) {
-	    mvwprintw(search_win, 2, 37, "M");
+	    mvwaddstr(search_win, 2, 37, "M");
 	}
 	if ((tbandidx & BAND10) == BAND10) {
-	    mvwprintw(search_win, 1, 37, "M");
+	    mvwaddstr(search_win, 1, 37, "M");
 	}
     }
 }
@@ -801,7 +801,7 @@ void show_needed_sections(void) {
 	wattron(search_win, modify_attr(COLOR_PAIR(C_WINDOW) | A_STANDOUT));
 
 	for (j = 1; j < 7; j++)
-	    mvwprintw(search_win, j, 1, "%s", spaces(37));
+	    mvwaddstr(search_win, j, 1, spaces(37));
 
 	for (vert = 1; vert < 7; vert++) {
 	    if (cnt >= get_mult_count())
@@ -848,5 +848,5 @@ void OnLowerSearchPanel(int x, char *str) {
     int y = 1 + (IsAllBand() ? 10 : 6);
 
     wattrset(search_win, modify_attr(COLOR_PAIR(C_BORDER)));
-    mvwprintw(search_win, y, x, "%s", str);
+    mvwaddstr(search_win, y, x, str);
 }

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -228,7 +228,7 @@ int displayPartials(char *suggested_call) {
     }
 
     attrset(COLOR_PAIR(C_DUPE));
-    mvprintw(1, 1, "??");
+    mvaddstr(1, 1, "??");
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
     /* check what we have worked first */
@@ -702,7 +702,7 @@ void searchlog() {
 
 	if (dupe == ISDUPE) {
 	    attrset(COLOR_PAIR(C_DUPE));
-	    mvprintw(12, 29, "%s", hiscall);
+	    mvaddstr(12, 29, hiscall);
 	    refreshp();
 	    usleep(500000);
 	}

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -273,7 +273,7 @@ void sendbuf(void) {
 	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
 	if (get_simulator_state() == IDLE) {
-	    mvprintw(5, 0, "%s", printlinebuffer);
+	    mvaddstr(5, 0, printlinebuffer);
 	}
 	refreshp();
 

--- a/src/set_tone.c
+++ b/src/set_tone.c
@@ -41,7 +41,7 @@ void set_tone(void) {
 
     nicebox(4, 40, 1, 6, "Tone");
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-    mvprintw(5, 41, "      ");
+    mvaddstr(5, 41, "      ");
     move(5, 42);
     echo();
     getnstr(tonestr, 3);

--- a/src/showpxmap.c
+++ b/src/showpxmap.c
@@ -25,6 +25,7 @@
 #include <glib.h>
 #include <string.h>
 
+#include "clear_display.h"
 #include "dxcc.h"
 #include "focm.h"
 #include "changepars.h"
@@ -53,7 +54,7 @@ void show_mults(void) {
 
     if (CONTEST_IS(CQWW)) {
 
-	mvprintw(12, 29, "E,A,F,N,S,O");
+	mvaddstr(12, 29, "E,A,F,N,S,O");
 
 	refreshp();
 
@@ -83,7 +84,7 @@ void show_mults(void) {
 	    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
 	    for (l = 1; l < 6; l++)
-		mvprintw(l, 0, "%s", backgrnd_str);
+		clear_line(l);
 
 	    i = 0;
 
@@ -107,13 +108,13 @@ void show_mults(void) {
 
 			attron(modify_attr(COLOR_PAIR(C_INPUT)));
 
-			mvprintw(k, j * 4, "%s", prefix);
+			mvaddstr(k, j * 4, prefix);
 			refreshp();
 			i++;
 
 		    } else {
 
-			mvprintw(k, j * 4, "    ");
+			mvaddstr(k, j * 4, "    ");
 			refreshp();
 			i++;
 
@@ -134,7 +135,7 @@ void show_mults(void) {
 
 	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 	for (l = 1; l < 6; l++)
-	    mvprintw(l, 0, "%s", backgrnd_str);
+	    clear_line(l);
     } else
 
 	multiplierinfo();

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -65,7 +65,7 @@ void stewperry_show_summary(int points, float fixedmult);
 void stewperry_show_summary(int points, float fixedmult) {
     float mult;
 
-    mvprintw(5, START_COL, "%s", spaces(80 - START_COL));
+    mvaddstr(5, START_COL, spaces(80 - START_COL));
     /* TODO: respect field boundaries for large numbers */
     mult = (fixedmult == 0.0) ? 1.0 : fixedmult;
 
@@ -76,7 +76,7 @@ void stewperry_show_summary(int points, float fixedmult) {
 
 /* show summary line */
 void show_summary(int points, int multi) {
-    mvprintw(5, START_COL, "%s", spaces(80 - START_COL));
+    mvaddstr(5, START_COL, spaces(80 - START_COL));
     /* TODO: respect field boundaries for large numbers */
     mvprintw(5, START_COL, "Pts: %d  Mul: %d Score: %d",
 	     points, multi, points * multi);
@@ -95,7 +95,7 @@ void display_header(int *bi) {
 
     /* prepare header line */
     attron(COLOR_PAIR(C_WINDOW) | A_STANDOUT);
-    mvprintw(1, START_COL, "Band ");
+    mvaddstr(1, START_COL, "Band ");
     for (i = 0; i < 6; i++) {
 	attron(COLOR_PAIR(C_WINDOW) | A_STANDOUT);
 	addstr("  ");
@@ -107,14 +107,14 @@ void display_header(int *bi) {
 
     /* show number of QSO */
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-    mvprintw(2, START_COL, "QSO   ");
+    mvaddstr(2, START_COL, "QSO   ");
     for (i = 0; i < 6; i++) {
 	printfield(2, band_cols[i], qsos_per_band[bi[i]]);
     }
 
-    mvprintw(3, START_COL, "%s", spaces(80 - START_COL));
-    mvprintw(4, START_COL, "%s", spaces(80 - START_COL));
-    mvprintw(5, START_COL, "%s", spaces(80 - START_COL));
+    mvaddstr(3, START_COL, spaces(80 - START_COL));
+    mvaddstr(4, START_COL, spaces(80 - START_COL));
+    mvaddstr(5, START_COL, spaces(80 - START_COL));
 
 }
 
@@ -251,7 +251,7 @@ void showscore(void) {
 	    || (serial_grid4_mult == 1)
 	    || (sectn_mult == 1)) {
 
-	mvprintw(3, START_COL, "Mult ");
+	mvaddstr(3, START_COL, "Mult ");
 	for (i = 0; i < 6; i++) {
 	    printfield(3, band_cols[i], multscore[bi_normal[i]]);
 	}
@@ -259,14 +259,14 @@ void showscore(void) {
 
     if ((itumult == 1) || (wazmult == 1)) {
 
-	mvprintw(3, START_COL, "Mult ");
+	mvaddstr(3, START_COL, "Mult ");
 	for (i = 0; i < 6; i++) {
 	    printfield(3, band_cols[i], zonescore[bi_normal[i]]);
 	}
     }
 
     if (pfxmultab == 1) {
-	mvprintw(3, START_COL, "Mult ");
+	mvaddstr(3, START_COL, "Mult ");
 	for (i = 0; i < 6; i++) {
 	    printfield(3, band_cols[i], GetNrOfPfx_OnBand(bi_normal[i]));
 	}
@@ -274,12 +274,12 @@ void showscore(void) {
 
     if (dx_arrlsections == 1) {
 
-	mvprintw(3, START_COL, "Cty  ");
+	mvaddstr(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
 	    printfield(3, band_cols[i], countryscore[bi_normal[i]]);
 	}
 
-	mvprintw(4, START_COL, "Sect");
+	mvaddstr(4, START_COL, "Sect");
 	for (i = 0; i < 6; i++) {
 	    printfield(4, band_cols[i], multscore[bi_normal[i]]);
 	}
@@ -287,12 +287,12 @@ void showscore(void) {
 
     if (CONTEST_IS(CQWW)) {
 
-	mvprintw(3, START_COL, "Cty  ");
+	mvaddstr(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
 	    printfield(3, band_cols[i], countryscore[bi_normal[i]]);
 	}
 
-	mvprintw(4, START_COL, "Zone ");
+	mvaddstr(4, START_COL, "Zone ");
 	for (i = 0; i < 6; i++) {
 	    printfield(4, band_cols[i], zonescore[bi_normal[i]]);
 	}
@@ -300,7 +300,7 @@ void showscore(void) {
 
     if (CONTEST_IS(ARRLDX_USA)) {
 
-	mvprintw(3, START_COL, "Cty  ");
+	mvaddstr(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
 	    printfield(3, band_cols[i], countryscore[bi_normal[i]]);
 	}
@@ -308,7 +308,7 @@ void showscore(void) {
 
     if (iscontest && country_mult == 1) {
 
-	mvprintw(3, START_COL, "Cty  ");
+	mvaddstr(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
 	    printfield(3, band_cols[i], countryscore[bi_normal[i]]);
 	}
@@ -316,7 +316,7 @@ void showscore(void) {
 
     if (CONTEST_IS(PACC_PA)) {
 
-	mvprintw(3, START_COL, "Cty  ");
+	mvaddstr(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
 	    printfield(3, band_cols[i], countryscore[bi_normal[i]]);
 	}
@@ -338,7 +338,7 @@ void showscore(void) {
 
     /* show statistics */
     attron(COLOR_PAIR(C_HEADER));
-    mvprintw(6, 55, "%s", spaces(19));
+    mvaddstr(6, 55, spaces(19));
 
     if (iscontest) {   /* show statistics in any contest */
 

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -364,7 +364,7 @@ int pagedn(int lines) {
 	}
 	scroll(sclwin);
 	wattrset(sclwin, logattr());
-	mvwprintw(sclwin, LINES - ENTRYROWS - 1, 0, "%s", s);
+	mvwaddstr(sclwin, LINES - ENTRYROWS - 1, 0, s);
     }
     wrefresh(sclwin);
     return (s != NULL);
@@ -422,7 +422,7 @@ void resume_editing(void) {
     viewbottom();
     wattrset(sclwin, curattr);
     werase(entwin);
-    mvwprintw(entwin, 0, 0, "%s", entry_text);
+    mvwaddstr(entwin, 0, 0, entry_text);
     wmove(entwin, currow, curcol);
     viewing = NULL;
     view_state = STATE_EDITING;
@@ -438,7 +438,7 @@ void viewlog(void) {
     }
     gather_input(entry_text);
     werase(entwin);
-    mvwprintw(entwin, 0, 0, "Viewing data... hit ENTER to return\n");
+    mvwaddstr(entwin, 0, 0, "Viewing data... hit ENTER to return\n");
     pageup(SCROLLSIZE);
 }
 

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -637,14 +637,14 @@ void addtext(char *s) {
     if (strncmp(s, my.call, strlen(my.call)) == 0
 	    && strlen(s) < 81 && strchr(s, '>') == NULL) {
 
-	mvprintw(LINES - 1, 0, "%s", backgrnd_str);
+	clear_line(LINES - 1);
 
 	if ((strlen(s) + strlen(my.call) + 3) < 80) {
 	    strcpy(dxtext, s + strlen(my.call) + 3);
 	    if (dxtext[strlen(dxtext) - 1] == '\n')
 		dxtext[strlen(dxtext) - 1] = '\0';	// remove the newline
-	    mvprintw(LINES - 1, 0, "%s", dxtext);
-	    mvprintw(12, 29, "%s", hiscall);
+	    mvaddstr(LINES - 1, 0, dxtext);
+	    mvaddstr(12, 29, hiscall);
 	}
 	refreshp();
 
@@ -1178,8 +1178,8 @@ void send_cluster(void) {
     char line[MAX_CMD_LEN + 2] = "";
 
     cluster = CLUSTER;
-    mvprintw(LINES - 1, 0, "%s", backgrnd_str);
-    mvprintw(LINES - 1, 0, ">");
+    clear_line(LINES - 1);
+    mvaddstr(LINES - 1, 0, ">");
     refreshp();
     echo();
     getnstr(line, MAX_CMD_LEN);
@@ -1199,6 +1199,6 @@ void send_cluster(void) {
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 
-    mvprintw(LINES - 1, 0, "%s", backgrnd_str);
+    clear_line(LINES - 1);
     refreshp();
 }

--- a/src/startmsg.c
+++ b/src/startmsg.c
@@ -38,7 +38,7 @@ void clearmsg_wait(void) {
     if (verbose) {
 	move(LINES - 3, 0);
 	clrtoeol();
-	mvprintw(LINES - 2, 0, "Press any key to continue!");
+	mvaddstr(LINES - 2, 0, "Press any key to continue!");
 	move(LINES - 1, 0);
 	clrtoeol();
 	refreshp();
@@ -60,7 +60,7 @@ static int has_room_for_message() {
 void showmsg(char *message) {
     if (!has_room_for_message())
 	clearmsg_wait();
-    mvprintw(linectr, 0, "%s", message);
+    mvaddstr(linectr, 0, message);
     refreshp();
     linectr++;
 }

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -88,13 +88,13 @@ void show_freq(void) {
 	mvprintw(13, 67, FREQ_DISPLAY_FORMAT, "TRX", freq / 1000.0);
 	memfreq = memory_get_freq();
     } else {
-	mvprintw(13, 67, "%s", spaces(80 - 67));
+	mvaddstr(13, 67, spaces(80 - 67));
     }
 
     if (memfreq > 0) {
 	mvprintw(14, 67, FREQ_DISPLAY_FORMAT, "MEM", memfreq / 1000.0);
     } else {
-	mvprintw(14, 67, "%s", spaces(80 - 67));
+	mvaddstr(14, 67, spaces(80 - 67));
     }
 
 }
@@ -167,14 +167,14 @@ void time_update(void) {
 
 	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
-	mvprintw(7, 0, "%s", logline0);
-	mvprintw(8, 0, "%s", logline1);
-	mvprintw(9, 0, "%s", logline2);
-	mvprintw(10, 0, "%s", logline3);
-	mvprintw(11, 0, "%s", logline4);
-	mvprintw(13, 0, "%s", spaces(67));
+	mvaddstr(7, 0, logline0);
+	mvaddstr(8, 0, logline1);
+	mvaddstr(9, 0, logline2);
+	mvaddstr(10, 0, logline3);
+	mvaddstr(11, 0, logline4);
+	mvaddstr(13, 0, spaces(67));
 	attron(COLOR_PAIR(C_WINDOW));
-	mvprintw(12, 23, "%s", qsonrstr);
+	mvaddstr(12, 23, qsonrstr);
 	printcall();
 
 	showscore();	/* update  score  window every 2 seconds */

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -228,7 +228,7 @@ void free_linedata(struct linedata_t *ptr) {
 /** write out information */
 void info(char *s) {
     attron(modify_attr(COLOR_PAIR(C_INPUT) | A_STANDOUT));
-    mvprintw(13, 29, "%s", s);
+    mvaddstr(13, 29, s);
     refreshp();
 }
 

--- a/test/test_checklogfile.c
+++ b/test/test_checklogfile.c
@@ -15,6 +15,8 @@
 // dummy
 void shownr(char *msg, int x) {
 }
+void clear_line(int row) {
+}
 
 extern char logfile[];
 

--- a/test/test_clusterinfo.c
+++ b/test/test_clusterinfo.c
@@ -18,6 +18,9 @@ int LINES = 25; /* test for 25 lines */
 int getctynr(char *checkcall) {
     return 0;
 }
+void clear_line(int row) {
+    mvaddstr(row, 0, backgrnd_str);
+}
 
 char thisnode = 'A';
 freq_t node_frequencies[MAXNODES];

--- a/test/test_lancode.c
+++ b/test/test_lancode.c
@@ -15,6 +15,8 @@ void handle_logging(enum log_lvl lvl, ...) {
 time_t get_time() {
     return 0;   // TBD
 }
+void clear_line(int row) {
+}
 
 int setup_default(void **state) {
 

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -51,6 +51,8 @@ int stoptx() {
 // clear_display.c
 void clear_display() {
 }
+void clear_line(int row) {
+}
 
 // clusterinfo.c
 void clusterinfo() {


### PR DESCRIPTION
Related to #284: following transformations were done to get away from mvprintw

- `mvprintw(y, x, "%s", "const string")` and `mvprintw(y, x, "const string")` into `mvaddstr(y, x, "const string")`
- `mvprintw(y, x, backgrnd_str)` into `clear_line(y)`

Test had to be fixed as `mvaddstr` is (unlike `mvprintw`) a macro not a function.

On the occasion the code duplication in `rtty.c` was reduced. (it's not an exact duplicate, probably due to a bug).

Will also check `mvwprintw` and `wprintw`.