### PR TITLE
Add a HAMLIBKEYER option to send CW via hamlib

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -820,6 +820,16 @@ static void keyer_init() {
 	init_controller();
     }
 
+    if (cwkeyer == HAMLIB_KEYER) {
+	if (!trx_control) {
+	    showmsg("CW-Keyer is set to HAMLIB");
+	    showmsg("BUT hamlib is not working !!");
+	    sleep(1);
+	    endwin();
+	    exit(EXIT_FAILURE);
+	}
+	showmsg("CW-Keyer is hamlib");
+    }
 }
 
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1126,6 +1126,7 @@ static config_t logcfg_configs[] = {
     {"CONTINENT_LIST_POINTS",   CFG_INT(continentlist_points, 0, INT32_MAX)},
 
     {"NETKEYER",        CFG_INT_CONST(cwkeyer, NET_KEYER)},
+    {"HAMLIBKEYER",     CFG_INT_CONST(cwkeyer, HAMLIB_KEYER)},
     {"FIFO_INTERFACE",  CFG_INT_CONST(packetinterface, FIFO_INTERFACE)},
     {"LONG_SERIAL",     CFG_INT_CONST(shortqsonr, 0)},
     {"CLUSTER",         CFG_INT_CONST(cluster, CLUSTER)},

--- a/src/stoptx.c
+++ b/src/stoptx.c
@@ -22,6 +22,7 @@
 *--------------------------------------------------------------*/
 
 
+#include <hamlib/rig.h>
 #include "clear_display.h"
 #include "err_utils.h"
 #include "globalvars.h"
@@ -45,6 +46,12 @@ int stoptx(void) {
 		clear_display();
 
 	    }
+	} else if (cwkeyer == HAMLIB_KEYER) {
+	    int error = rig_stop_morse(my_rig, RIG_VFO_CURR);
+	    if (error != RIG_OK) {
+		TLF_LOG_WARN("Stop error: %s", rigerror(error));
+	    }
+
 	}
     } else {
 	return (1);

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -32,6 +32,7 @@ enum {
     MFJ1278_KEYER,
     GMFSK,
     FLDIGI,
+    HAMLIB_KEYER,
 };
 
 #define SINGLE 0        /* single op */

--- a/src/write_keyer.c
+++ b/src/write_keyer.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <glib.h>
+#include <hamlib/rig.h>
 
 #include "clear_display.h"
 #include "err_utils.h"
@@ -94,6 +95,20 @@ void write_keyer(void) {
     } else if (cwkeyer == NET_KEYER) {
 	netkeyer(K_MESSAGE, tosend);
 
+    } else if (cwkeyer == HAMLIB_KEYER) {
+	// Ignore +/- speed up/slow down instructions
+	char *q = tosend;
+	for (char *p = q; *p; p++) {
+	    if (*p != '+' && *p != '-') {
+		*q++ = *p;
+	    }
+	}
+	*q = 0;
+
+	int error = rig_send_morse(my_rig, RIG_VFO_CURR, tosend);
+	if (error != RIG_OK) {
+	    TLF_LOG_WARN("Send error: %s", rigerror(error));
+	}
     } else if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {
 	if ((bfp = fopen(controllerport, "a")) == NULL) {
 	    TLF_LOG_WARN("1278 not active. Switching to SSB mode.");


### PR DESCRIPTION
Most modern rigs can send CW using an internal keyer. Hamrig exposes this functionality in the `send_morse` and `stop_morse` functions.

This introduces a new keyer type `HAMLIB_KEYER` and when this is set in the config file with the `HAMLIBKEYER` options sends CW via hamlib.

Hamlib doesn't (yet) expose setting the speed of the CW so this will be sent at whatever the rig's keyer is set to. This also ignores speed change commands in the CW.

This simplifies the setup enormously meaning no external keyer is needed.

-----

I've tested this on my Icom 7300 and it seems to work OK!

This doesn't patch any docs and there is probably other stuff I've missed, but I thought I'd let you have a look at it first and see if you like the idea before I finish it off.