### PR TITLE
Don't print a complaint if either Alt-PgUp/Dn or Ctrl-PgUp/Dn work

### DIFF
--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -95,7 +95,8 @@ int lookup_key(char *capability) {
 
 /** lookup all needed special keys not defined by ncurses */
 void lookup_keys() {
-    int not_ok = 0;
+    bool alt_not_ok = 0;
+    bool ctrl_not_ok = 0;
 
     key_kNXT3 = lookup_key("kNXT3");
     key_kPRV3 = lookup_key("kPRV3");
@@ -104,15 +105,15 @@ void lookup_keys() {
 
     if ((key_kNXT3 || key_kPRV3) == 0) {
 	showmsg("Terminal does not support Alt-PgUp/PgDn keys");
-	not_ok = 1;
+	alt_not_ok = 1;
     }
 
     if ((key_kNXT5 || key_kPRV5) == 0) {
 	showmsg("Terminal does not support Ctrl-PgUp/PgDn keys");
-	not_ok = 1;
+	ctrl_not_ok = 1;
     }
 
-    if (not_ok == 1) {
+    if (alt_not_ok == 1 && ctrl_not_ok == 1) {
 	showmsg("See ':CQD' in man page for setting Auto_CQ delay");
 	showmsg("");
 	beep();


### PR DESCRIPTION
There is an annoying delay on startup if the terminal doesn't support
one of Alt-PgUp Alt-PgDn Ctrl-PgUp Ctrl-PgDn, even if the other
combination works. If fact this even happens with rxvt-unicode which the
manpage advertises as "does not eat Ctrl-PgUp".

Change logic such that the delay only happens if none of the keys work.