### PR TITLE
Drop newline

### DIFF
--- a/src/listmessages.c
+++ b/src/listmessages.c
@@ -41,11 +41,15 @@ char  printbuffer[160];
 
 char *formatMessage(int i) {
 
-    /* copy the message string WITHOUT trailing newline/space */
+    /* copy the message string */
     if (trxmode == DIGIMODE)
-	g_strlcpy(printbuffer,  digi_message[i],  strlen(digi_message[i]));
+	g_strlcpy(printbuffer,  digi_message[i],  sizeof(printbuffer));
     else
-	g_strlcpy(printbuffer,  message[i],  strlen(message[i]));
+	g_strlcpy(printbuffer,  message[i],  sizeof(printbuffer));
+
+    /* and strip off trailing newline/whitespace */
+    g_strchomp(printbuffer);
+
     /* and fill up with spaces */
     strcat(printbuffer, backgrnd_str);
     printbuffer[LIST_WIDTH - 7] = '\0';

--- a/src/main.c
+++ b/src/main.c
@@ -221,9 +221,9 @@ char message[25][80] = /**< Array of CW messages
 			* message[1]  (F2)  - insert pressed
  			*/
 {
-    "TEST %", "@ DE %", "@ [", "TU 73", " @", "%",
+    "TEST %", "@ DE %", "@ [", "TU 73", "@", "%",
     "@ SRI QSO B4 GL", "AGN",
-    " ?", " QRZ?", " PSE K", "TEST % %", "@ [", "TU %",
+    "?", "QRZ?", "PSE K", "TEST % %", "@ [", "TU %",
     "", "", "", "", "", "", "", "", "", "", ""
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -221,9 +221,9 @@ char message[25][80] = /**< Array of CW messages
 			* message[1]  (F2)  - insert pressed
  			*/
 {
-    "TEST %\n", "@ DE %\n", "@ [\n", "TU 73\n", " @\n", "%\n",
-    "@ SRI QSO B4 GL\n", "AGN\n",
-    " ?\n", " QRZ?\n", " PSE K\n", "TEST % %\n", "@ [\n", "TU %\n",
+    "TEST %", "@ DE %", "@ [", "TU 73", " @", "%",
+    "@ SRI QSO B4 GL", "AGN",
+    " ?", " QRZ?", " PSE K", "TEST % %", "@ [", "TU %",
     "", "", "", "", "", "", "", "", "", "", ""
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -234,7 +234,10 @@ char ph_message[14][80] = /**< Array of file names for voice keyer messages
 			   */
 { "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
 
-char qtc_recv_msgs[12][80] = {"QTC?\n", "QRV\n", "R\n", "", "TIME?\n", "CALL?\n", "NR?\n", "AGN\n", "", "QSL ALL\n", "", ""}; // QTC receive windowS Fx messages
+char qtc_recv_msgs[12][80] = {
+    "QTC?", "QRV", "R", "", "TIME?", "CALL?",
+    "NR?", "AGN", "", "QSL ALL", "", ""}; // QTC receive windows Fx messages
+
 char qtc_send_msgs[12][80] = {"QRV?\n", "QTC sr/nr\n", "", "", "TIME\n", "CALL\n", "NR\n", "", "", "", "", ""}; // QTC send window Fx messages
 char qtc_phrecv_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when receives QTCs
 char qtc_phsend_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when send QTCs

--- a/src/main.c
+++ b/src/main.c
@@ -232,15 +232,24 @@ char *digi_message[sizeof(message) / sizeof(message[0])];
 char ph_message[14][80] = /**< Array of file names for voice keyer messages
 			   * See description of message[]
 			   */
-{ "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
+    { "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
 
 char qtc_recv_msgs[12][80] = {
     "QTC?", "QRV", "R", "", "TIME?", "CALL?",
-    "NR?", "AGN", "", "QSL ALL", "", ""}; // QTC receive windows Fx messages
+    "NR?", "AGN", "", "QSL ALL", "", ""};	// QTC receive windows Fx messages
 
-char qtc_send_msgs[12][80] = {"QRV?\n", "QTC sr/nr\n", "", "", "TIME\n", "CALL\n", "NR\n", "", "", "", "", ""}; // QTC send window Fx messages
-char qtc_phrecv_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when receives QTCs
-char qtc_phsend_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when send QTCs
+char qtc_send_msgs[12][80] = {
+    "QRV?", "QTC sr/nr", "", "", "TIME", "CALL",
+    "NR", "", "", "", "", ""};		    	// QTC send window Fx messages
+
+char qtc_phrecv_message[14][80] = {
+    "", "", "", "", "", "",
+    "", "", "", "", "", "" };			// voice keyer file names when receives QTCs
+
+char qtc_phsend_message[14][80] = {
+    "", "", "", "", "", "",
+    "", "", "", "", "", "" };			// voice keyer file names when send QTCs
+
 bool qtcrec_record = false;
 char qtcrec_record_command[2][50] = {"rec -q 8000", "-q &"};
 char qtcrec_record_command_shutdown[50] = "pkill -SIGINT -n rec";

--- a/src/messagechange.c
+++ b/src/messagechange.c
@@ -43,6 +43,9 @@ static void enter_message(int bufnr) {
 	msg = message[bufnr];
 
     g_strlcpy(printbuf, msg, sizeof(printbuf));
+
+    g_strchomp(printbuf);
+
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
     mvaddstr(15, 4, printbuf);
     refreshp();

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1078,11 +1078,11 @@ static config_t logcfg_configs[] = {
     {"KEYER_BACKSPACE", CFG_BOOL_TRUE(keyer_backspace)},
     {"SECTION_MULT_ONCE",   CFG_BOOL_TRUE(sectn_mult_once)},
 
-    {"F([1-9]|1[0-2])", CFG_MESSAGE(message, -1)},  // index is 1-based
-    {"S&P_TU_MSG",      CFG_MESSAGE(message, SP_TU_MSG)},
-    {"CQ_TU_MSG",       CFG_MESSAGE(message, CQ_TU_MSG)},
-    {"ALT_([0-9])",     CFG_MESSAGE(message, CQ_TU_MSG + 1)},
-    {"S&P_CALL_MSG",    CFG_MESSAGE(message, SP_CALL_MSG)},
+    {"F([1-9]|1[0-2])", CFG_MESSAGE_CHOMP(message, -1)},  // index is 1-based
+    {"S&P_TU_MSG",      CFG_MESSAGE_CHOMP(message, SP_TU_MSG)},
+    {"CQ_TU_MSG",       CFG_MESSAGE_CHOMP(message, CQ_TU_MSG)},
+    {"ALT_([0-9])",     CFG_MESSAGE_CHOMP(message, CQ_TU_MSG + 1)},
+    {"S&P_CALL_MSG",    CFG_MESSAGE_CHOMP(message, SP_CALL_MSG)},
 
     {"VKM([1-9]|1[0-2])",   CFG_MESSAGE_CHOMP(ph_message, -1)},
     {"VKCQM",               CFG_MESSAGE_CHOMP(ph_message, CQ_TU_MSG)},

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1078,15 +1078,15 @@ static config_t logcfg_configs[] = {
     {"KEYER_BACKSPACE", CFG_BOOL_TRUE(keyer_backspace)},
     {"SECTION_MULT_ONCE",   CFG_BOOL_TRUE(sectn_mult_once)},
 
-    {"F([1-9]|1[0-2])", CFG_MESSAGE_CHOMP(message, -1)},  // index is 1-based
-    {"S&P_TU_MSG",      CFG_MESSAGE_CHOMP(message, SP_TU_MSG)},
-    {"CQ_TU_MSG",       CFG_MESSAGE_CHOMP(message, CQ_TU_MSG)},
-    {"ALT_([0-9])",     CFG_MESSAGE_CHOMP(message, CQ_TU_MSG + 1)},
-    {"S&P_CALL_MSG",    CFG_MESSAGE_CHOMP(message, SP_CALL_MSG)},
+    {"F([1-9]|1[0-2])", CFG_MESSAGE(message, -1)},  // index is 1-based
+    {"S&P_TU_MSG",      CFG_MESSAGE(message, SP_TU_MSG)},
+    {"CQ_TU_MSG",       CFG_MESSAGE(message, CQ_TU_MSG)},
+    {"ALT_([0-9])",     CFG_MESSAGE(message, CQ_TU_MSG + 1)},
+    {"S&P_CALL_MSG",    CFG_MESSAGE(message, SP_CALL_MSG)},
 
-    {"VKM([1-9]|1[0-2])",   CFG_MESSAGE_CHOMP(ph_message, -1)},
-    {"VKCQM",               CFG_MESSAGE_CHOMP(ph_message, CQ_TU_MSG)},
-    {"VKSPM",               CFG_MESSAGE_CHOMP(ph_message, SP_TU_MSG)},
+    {"VKM([1-9]|1[0-2])",   CFG_MESSAGE(ph_message, -1)},
+    {"VKCQM",               CFG_MESSAGE(ph_message, CQ_TU_MSG)},
+    {"VKSPM",               CFG_MESSAGE(ph_message, SP_TU_MSG)},
 
     {"DKF([1-9]|1[0-2])",   CFG_MESSAGE_DYNAMIC(digi_message, -1)},
     {"DKCQM",               CFG_MESSAGE_DYNAMIC(digi_message, CQ_TU_MSG)},
@@ -1094,15 +1094,15 @@ static config_t logcfg_configs[] = {
     {"DKSPC",               CFG_MESSAGE_DYNAMIC(digi_message, SP_CALL_MSG)},
     {"ALT_DK([1-9]|10)",    CFG_MESSAGE_DYNAMIC(digi_message, CQ_TU_MSG)},
 
-    {"QR_F([1-9]|1[0-2])",      CFG_MESSAGE_CHOMP(qtc_recv_msgs, -1) },
-    {"QR_VKM([1-9]|1[0-2])",    CFG_MESSAGE_CHOMP(qtc_phrecv_message, -1) },
-    {"QR_VKCQM",                CFG_MESSAGE_CHOMP(qtc_phrecv_message, CQ_TU_MSG) },
-    {"QR_VKSPM",                CFG_MESSAGE_CHOMP(qtc_phrecv_message, SP_TU_MSG) },
+    {"QR_F([1-9]|1[0-2])",      CFG_MESSAGE(qtc_recv_msgs, -1) },
+    {"QR_VKM([1-9]|1[0-2])",    CFG_MESSAGE(qtc_phrecv_message, -1) },
+    {"QR_VKCQM",                CFG_MESSAGE(qtc_phrecv_message, CQ_TU_MSG) },
+    {"QR_VKSPM",                CFG_MESSAGE(qtc_phrecv_message, SP_TU_MSG) },
 
-    {"QS_F([1-9]|1[0-2])",      CFG_MESSAGE_CHOMP(qtc_send_msgs, -1) },
-    {"QS_VKM([1-9]|1[0-2])",    CFG_MESSAGE_CHOMP(qtc_phsend_message, -1) },
-    {"QS_VKCQM",                CFG_MESSAGE_CHOMP(qtc_phsend_message, CQ_TU_MSG) },
-    {"QS_VKSPM",                CFG_MESSAGE_CHOMP(qtc_phsend_message, SP_TU_MSG) },
+    {"QS_F([1-9]|1[0-2])",      CFG_MESSAGE(qtc_send_msgs, -1) },
+    {"QS_VKM([1-9]|1[0-2])",    CFG_MESSAGE(qtc_phsend_message, -1) },
+    {"QS_VKCQM",                CFG_MESSAGE(qtc_phsend_message, CQ_TU_MSG) },
+    {"QS_VKSPM",                CFG_MESSAGE(qtc_phsend_message, SP_TU_MSG) },
 
     {"TLFCOLOR([1-6])",  NEED_PARAM, cfg_tlfcolor},
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1255,6 +1255,10 @@ static int apply_config(const char *keyword, const char *param,
 	    WrongFormat_details(keyword, "value out of range");
 	    break;
 
+	case PARSE_STRING_TOO_LONG:
+	    WrongFormat_details(keyword, "value too long");
+	    break;
+
 	default:
 	    if (error_details != NULL) {
 		WrongFormat_details(keyword, error_details);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1099,7 +1099,7 @@ static config_t logcfg_configs[] = {
     {"QR_VKCQM",                CFG_MESSAGE_CHOMP(qtc_phrecv_message, CQ_TU_MSG) },
     {"QR_VKSPM",                CFG_MESSAGE_CHOMP(qtc_phrecv_message, SP_TU_MSG) },
 
-    {"QS_F([1-9]|1[0-2])",      CFG_MESSAGE(qtc_send_msgs, -1) },
+    {"QS_F([1-9]|1[0-2])",      CFG_MESSAGE_CHOMP(qtc_send_msgs, -1) },
     {"QS_VKM([1-9]|1[0-2])",    CFG_MESSAGE_CHOMP(qtc_phsend_message, -1) },
     {"QS_VKCQM",                CFG_MESSAGE_CHOMP(qtc_phsend_message, CQ_TU_MSG) },
     {"QS_VKSPM",                CFG_MESSAGE_CHOMP(qtc_phsend_message, SP_TU_MSG) },

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1094,7 +1094,7 @@ static config_t logcfg_configs[] = {
     {"DKSPC",               CFG_MESSAGE_DYNAMIC(digi_message, SP_CALL_MSG)},
     {"ALT_DK([1-9]|10)",    CFG_MESSAGE_DYNAMIC(digi_message, CQ_TU_MSG)},
 
-    {"QR_F([1-9]|1[0-2])",      CFG_MESSAGE(qtc_recv_msgs, -1) },
+    {"QR_F([1-9]|1[0-2])",      CFG_MESSAGE_CHOMP(qtc_recv_msgs, -1) },
     {"QR_VKM([1-9]|1[0-2])",    CFG_MESSAGE_CHOMP(qtc_phrecv_message, -1) },
     {"QR_VKCQM",                CFG_MESSAGE_CHOMP(qtc_phrecv_message, CQ_TU_MSG) },
     {"QR_VKSPM",                CFG_MESSAGE_CHOMP(qtc_phrecv_message, SP_TU_MSG) },

--- a/src/parse_logcfg.h
+++ b/src/parse_logcfg.h
@@ -109,10 +109,6 @@ typedef struct {
         (cfg_arg_t){.char_pp=&var, .chomp=true, \
                     .string_type=DYNAMIC}
 
-#define CFG_MESSAGE(var, i)     NEED_PARAM, cfg_string, \
-        (cfg_arg_t){.msg=var, .base=i, .size=80, \
-                    .string_type=MESSAGE}
-
 #define CFG_MESSAGE_CHOMP(var, i)   NEED_PARAM, cfg_string, \
         (cfg_arg_t){.msg=var, .base=i, .size=80, .chomp=true, \
                     .string_type=MESSAGE}

--- a/src/parse_logcfg.h
+++ b/src/parse_logcfg.h
@@ -109,7 +109,7 @@ typedef struct {
         (cfg_arg_t){.char_pp=&var, .chomp=true, \
                     .string_type=DYNAMIC}
 
-#define CFG_MESSAGE_CHOMP(var, i)   NEED_PARAM, cfg_string, \
+#define CFG_MESSAGE(var, i)   NEED_PARAM, cfg_string, \
         (cfg_arg_t){.msg=var, .base=i, .size=80, .chomp=true, \
                     .string_type=MESSAGE}
 

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -729,9 +729,6 @@ void qtc_main_panel(int direction) {
 		if (trxmode == DIGIMODE) {
 		    if (direction == SEND && (activefield == 0 || activefield == 2)
 			    && qtclist.totalsent == 0) {
-			if (qtc_send_msgs[1][strlen(qtc_send_msgs[1]) - 1] == 10) {
-			    qtc_send_msgs[1][strlen(qtc_send_msgs[1]) - 1] = '\0';
-			}
 			tlen = strlen(qtc_send_msgs[1]) - 5; // len("sr/nr") = 5
 			char tmess[300], timec[40];
 			int ql;
@@ -854,10 +851,6 @@ void qtc_main_panel(int direction) {
 		    }
 
 		    if (direction == SEND && strlen(qtc_send_msgs[x - KEY_F(1)]) > 0) {
-			if (qtc_send_msgs[x - KEY_F(1)][strlen(qtc_send_msgs[x - KEY_F(
-				1)]) - 1] == '\n') {
-			    qtc_send_msgs[x - KEY_F(1)][strlen(qtc_send_msgs[x - KEY_F(1)]) - 1] = 0;
-			}
 			tlen = strlen(qtc_send_msgs[x - KEY_F(1)]) - 5; // len("sr/nr") = 5
 			char tmess[60];
 			tmess[0] = '\0';

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -225,8 +225,11 @@ void ExpandMacro(void) {
 
 
     replace_all(buffer, BUFSIZE, "!", comment);
+
     if (trxmode == DIGIMODE)
-	replace_all(buffer, BUFSIZE, "|", "\r");   /* CR */
+	replace_all(buffer, BUFSIZE, "|", "\r");    /* CR */
+    else
+	replace_all(buffer, BUFSIZE, "|", "");	    /* drop it */
 }
 
 

--- a/test/data.c
+++ b/test/data.c
@@ -186,9 +186,9 @@ char message[25][80] = /**< Array of CW/DigiMode messages
 			* message[1]  (F2)  - insert pressed
  			*/
 {
-    "TEST %", "@ DE %", "@ [", "TU 73", " @", "%",
+    "TEST %", "@ DE %", "@ [", "TU 73", "@", "%",
     "@ SRI QSO B4 GL", "AGN",
-    " ?", " QRZ?", " PSE K", "TEST % %", "@ [", "TU %",
+    "?", "QRZ?", "PSE K", "TEST % %", "@ [", "TU %",
     "", "", "", "", "", "", "", "", "", "", ""
 };
 

--- a/test/data.c
+++ b/test/data.c
@@ -200,15 +200,24 @@ char *digi_message[sizeof(message) / sizeof(message[0])];
 char ph_message[14][80] = /**< Array of file names for voice keyer messages
 			   * See description of message[]
 			   */
-{ "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
+    { "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
 
 char qtc_recv_msgs[12][80] = {
     "QTC?", "QRV", "R", "", "TIME?", "CALL?",
     "NR?", "AGN", "", "QSL ALL", "", ""}; // QTC receive windows Fx messages
 
-char qtc_send_msgs[12][80] = {"QRV?\n", "QTC sr/nr\n", "", "", "TIME\n", "CALL\n", "NR\n", "", "", "", "", ""}; // QTC send window Fx messages
-char qtc_phrecv_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when receives QTCs
-char qtc_phsend_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when send QTCs
+char qtc_send_msgs[12][80] = {
+    "QRV?", "QTC sr/nr", "", "", "TIME", "CALL",
+    "NR", "", "", "", "", ""};		    	// QTC send window Fx messages
+
+char qtc_phrecv_message[14][80] = {
+    "", "", "", "", "", "",
+    "", "", "", "", "", "" };			// voice keyer file names when receives QTCs
+
+char qtc_phsend_message[14][80] = {
+    "", "", "", "", "", "",
+    "", "", "", "", "", "" };			// voice keyer file names when send QTCs
+
 bool qtcrec_record = false;
 char qtcrec_record_command[2][50] = {"rec -q 8000", "-q &"};
 char qtcrec_record_command_shutdown[50] = "pkill -SIGINT -n rec";

--- a/test/data.c
+++ b/test/data.c
@@ -202,7 +202,10 @@ char ph_message[14][80] = /**< Array of file names for voice keyer messages
 			   */
 { "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
 
-char qtc_recv_msgs[12][80] = {"QTC?\n", "QRV\n", "R\n", "", "TIME?\n", "CALL?\n", "NR?\n", "AGN\n", "", "QSL ALL\n", "", ""}; // QTC receive windowS Fx messages
+char qtc_recv_msgs[12][80] = {
+    "QTC?", "QRV", "R", "", "TIME?", "CALL?",
+    "NR?", "AGN", "", "QSL ALL", "", ""}; // QTC receive windows Fx messages
+
 char qtc_send_msgs[12][80] = {"QRV?\n", "QTC sr/nr\n", "", "", "TIME\n", "CALL\n", "NR\n", "", "", "", "", ""}; // QTC send window Fx messages
 char qtc_phrecv_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when receives QTCs
 char qtc_phsend_message[14][80] = { "", "", "", "", "", "", "", "", "", "", "", "" };	// voice keyer file names when send QTCs

--- a/test/data.c
+++ b/test/data.c
@@ -186,9 +186,9 @@ char message[25][80] = /**< Array of CW/DigiMode messages
 			* message[1]  (F2)  - insert pressed
  			*/
 {
-    "TEST %\n", "@ DE %\n", "@ [\n", "TU 73\n", " @\n", "%\n",
-    "@ SRI QSO B4 GL\n", "AGN\n",
-    " ?\n", " QRZ?\n", " PSE K\n", "TEST % %\n", "@ [\n", "TU %\n",
+    "TEST %", "@ DE %", "@ [", "TU 73", " @", "%",
+    "@ SRI QSO B4 GL", "AGN",
+    " ?", " QRZ?", " PSE K", "TEST % %", "@ [", "TU %",
     "", "", "", "", "", "", "", "", "", "", ""
 };
 

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -592,7 +592,7 @@ void test_qs_fn(void **state) {
 	sprintf(line, "QS_F%d = %s \n", i, msg);
 	int rc = call_parse_logcfg(line);
 	assert_int_equal(rc, PARSE_OK);
-	sprintf(msg, "QSMSG%d MNO \n", i);    // FIXME NL is kept
+	sprintf(msg, "QSMSG%d MNO", i);
 	assert_string_equal(qtc_send_msgs[j], msg);
     }
 }

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -278,6 +278,13 @@ void test_keyer_device(void **state) {
     assert_string_equal(keyer_device, "/dev/tty0");
 }
 
+void test_keyer_device_too_long(void **state) {
+    int rc = call_parse_logcfg("KEYER_DEVICE=/dev/bus/usb/002/001");
+    assert_int_equal(rc, PARSE_ERROR);
+    assert_string_equal(showmsg_spy,
+			"Wrong parameter for keyword 'KEYER_DEVICE': value too long.\n");
+}
+
 void test_editor(void **state) {
     int rc = call_parse_logcfg("EDITOR= pico \n");   // space around argument
     assert_int_equal(rc, 0);

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -411,7 +411,7 @@ void test_fn(void **state) {
 	sprintf(line, "F%d= %s \n", i, msg);
 	int rc = call_parse_logcfg(line);
 	assert_int_equal(rc, PARSE_OK);
-	sprintf(msg, "MSG%d ABC \n", i);   // trailing space+NL are kept, FIXME
+	sprintf(msg, "MSG%d ABC", i);
 	assert_string_equal(message[j], msg);
     }
 }
@@ -425,7 +425,7 @@ void test_alt_n(void **state) {
 	sprintf(line, "ALT_%d= %s \n", i, msg);
 	int rc = call_parse_logcfg(line);
 	assert_int_equal(rc, PARSE_OK);
-	sprintf(msg, "MSG%d ALT \n", i);   // trailing space+NL are kept, FIXME
+	sprintf(msg, "MSG%d ALT", i);
 	assert_string_equal(message[j], msg);
     }
 }
@@ -433,19 +433,19 @@ void test_alt_n(void **state) {
 void test_sp_tu_msg(void **state) {
     int rc = call_parse_logcfg("S&P_TU_MSG=TU\n");
     assert_int_equal(rc, PARSE_OK);
-    assert_string_equal(message[SP_TU_MSG], "TU\n");
+    assert_string_equal(message[SP_TU_MSG], "TU");
 }
 
 void test_cq_tu_msg(void **state) {
     int rc = call_parse_logcfg("CQ_TU_MSG=TU QRZ?\n");
     assert_int_equal(rc, PARSE_OK);
-    assert_string_equal(message[CQ_TU_MSG], "TU QRZ?\n");
+    assert_string_equal(message[CQ_TU_MSG], "TU QRZ?");
 }
 
 void test_sp_call_msg(void **state) {
     int rc = call_parse_logcfg("S&P_CALL_MSG=DE AB1CD\r\n");
     assert_int_equal(rc, PARSE_OK);
-    assert_string_equal(message[SP_CALL_MSG], "DE AB1CD\r\n");  // FIXME line end...
+    assert_string_equal(message[SP_CALL_MSG], "DE AB1CD");
 }
 
 typedef struct {

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -577,7 +577,7 @@ void test_qr_fn(void **state) {
 	sprintf(line, "QR_F%d = %s \n", i, msg);
 	int rc = call_parse_logcfg(line);
 	assert_int_equal(rc, PARSE_OK);
-	sprintf(msg, "QRMSG%d MNO \n", i);    // FIXME NL is kept
+	sprintf(msg, "QRMSG%d MNO", i);
 	assert_string_equal(qtc_recv_msgs[j], msg);
     }
 }

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -2420,9 +2420,10 @@ pass another value (in seconds) after the \(oq=\(cq sign.
 .IP
 There must be an integral number of time sections per hour!
 .
-.SS CW and Voice Keyer Macros
+.SS CW, Digimode and Voice Keyer Macros
 .
-The following parameters configure the CW and voice mode keyer message macros.
+The following parameters configure the CW, Digimode and voice mode keyer
+message macros.
 .
 .TP
 .B Macro characters in the message strings
@@ -2457,6 +2458,10 @@ The following parameters configure the CW and voice mode keyer message macros.
 .BR DIG imode),
 .B |
 = carriage return (only in digi mode messages).
+.
+.P
+Be aware that unspecified digimode messages gets the value of their CW
+counterpart prepended with '|'.
 .
 .TP
 \fBF1\fR=\fI"cw message 1"\fR

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -2450,11 +2450,13 @@ The following parameters configure the CW and voice mode keyer message macros.
 = SN,
 .B &
 = AS,
-.B > =
-BK,
+.B > 
+= BK,
 .B !
 = his serial (e.g. confirm exchange of station in
-.BR DIG imode).
+.BR DIG imode),
+.B |
+= carriage return (only in digi mode messages).
 .
 .TP
 \fBF1\fR=\fI"cw message 1"\fR


### PR DESCRIPTION
Cleanup trailing newlines on all CW messages.

Furthermore fix a bug in message listing if no \n is present.