### PR TITLE
Fix display of keyer messages containing embedded NL/CR characters

### DIFF
--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -159,22 +159,21 @@ void clear_display(void) {
 }
 
 /*
- *  scroll the loglines of the keyer terminal and show them
+ * add 'buffer' to the keyer terminal while scrolling one line up
+ * and refreshing the display
  */
-void displayit(void) {
-    extern char termbuf[];
+void add_to_keyer_terminal(char *buffer) {
 
-    char term2buf[81] = "";
+    char term2buf[81];
 
-    g_strlcpy(term2buf, termbuf, sizeof(term2buf));
+    g_strlcpy(term2buf, buffer, sizeof(term2buf));
     g_strchomp(term2buf);
-    g_strlcat(term2buf, backgrnd_str, sizeof(term2buf));	/* fill with blanks */
+    g_strlcat(term2buf, backgrnd_str, sizeof(term2buf));  /* fill with blanks */
 
     strcpy(terminal1, terminal2);
     strcpy(terminal2, terminal3);
     strcpy(terminal3, terminal4);
     strcpy(terminal4, term2buf);
-    termbuf[0] = '\0';
     move(5, 0);
 
     clear_display();

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -48,17 +48,54 @@
 #include "tlf_curses.h"
 #include "ui_utils.h"
 
-static char terminal1[88] = "";
-static char terminal2[88] = "";
-static char terminal3[88] = "";
-static char terminal4[88] = "";
+void clear_display(void);
 
 
-void init_terminal_strings(void) {
-    strcat(terminal1, backgrnd_str);
-    strcat(terminal2, backgrnd_str);
-    strcat(terminal3, backgrnd_str);
-    strcat(terminal4, backgrnd_str);
+void clear_line(int row) {
+    mvaddstr(row, 0, backgrnd_str);
+}
+
+static char terminal1[88];
+static char terminal2[88];
+static char terminal3[88];
+static char terminal4[88];
+
+void init_keyer_terminal(void) {
+    strcpy(terminal1, "");
+    strcpy(terminal2, "");
+    strcpy(terminal3, "");
+    strcpy(terminal4, "");
+}
+
+static void show_keyer_terminal() {
+    attron(modify_attr(COLOR_PAIR(C_LOG) | A_STANDOUT));
+    for (int i = 1; i < 6; i++)
+	clear_line(i);
+
+    mvaddstr(1, 0, terminal1);
+    mvaddstr(2, 0, terminal2);
+    mvaddstr(3, 0, terminal3);
+    mvaddstr(4, 0, terminal4);
+}
+
+/*
+ * add 'buffer' to the keyer terminal while scrolling one line up
+ * and refreshing the display
+ */
+void add_to_keyer_terminal(char *buffer) {
+
+    char term2buf[81];
+
+    strcpy(terminal1, terminal2);
+    strcpy(terminal2, terminal3);
+    strcpy(terminal3, terminal4);
+
+    g_strlcpy(terminal4, buffer, sizeof(term2buf));
+    g_strchomp(term2buf);
+
+    move(5, 0);
+
+    clear_display();
 }
 
 
@@ -87,7 +124,6 @@ void show_header_line() {
     mvaddstr(0, 21, fkey_header);
 }
 
-
 void clear_display(void) {
     int cury, curx;
 
@@ -95,12 +131,7 @@ void clear_display(void) {
 
     show_header_line();
 
-    attron(modify_attr(COLOR_PAIR(C_LOG) | A_STANDOUT));
-    mvaddstr(1, 0, terminal1);
-    mvaddstr(2, 0, terminal2);
-    mvaddstr(3, 0, terminal3);
-    mvaddstr(4, 0, terminal4);
-    mvaddstr(5, 0, backgrnd_str);
+    show_keyer_terminal();
 
     attron(COLOR_PAIR(C_HEADER));
     mvaddstr(6, 0, backgrnd_str);
@@ -156,29 +187,4 @@ void clear_display(void) {
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
     move(cury, curx);
     refreshp();
-}
-
-/*
- * add 'buffer' to the keyer terminal while scrolling one line up
- * and refreshing the display
- */
-void add_to_keyer_terminal(char *buffer) {
-
-    char term2buf[81];
-
-    g_strlcpy(term2buf, buffer, sizeof(term2buf));
-    g_strchomp(term2buf);
-    g_strlcat(term2buf, backgrnd_str, sizeof(term2buf));  /* fill with blanks */
-
-    strcpy(terminal1, terminal2);
-    strcpy(terminal2, terminal3);
-    strcpy(terminal3, terminal4);
-    strcpy(terminal4, term2buf);
-    move(5, 0);
-
-    clear_display();
-}
-
-void clear_line(int row) {
-    mvaddstr(row, 0, backgrnd_str);
 }

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -84,14 +84,12 @@ static void show_keyer_terminal() {
  */
 void add_to_keyer_terminal(char *buffer) {
 
-    char term2buf[81];
-
     strcpy(terminal1, terminal2);
     strcpy(terminal2, terminal3);
     strcpy(terminal3, terminal4);
 
-    g_strlcpy(terminal4, buffer, sizeof(term2buf));
-    g_strchomp(term2buf);
+    g_strlcpy(terminal4, buffer, sizeof(terminal4));
+    g_strchomp(terminal4);
 
     move(5, 0);
 

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -55,16 +55,16 @@ void clear_line(int row) {
     mvaddstr(row, 0, backgrnd_str);
 }
 
-static char terminal1[88];
-static char terminal2[88];
-static char terminal3[88];
-static char terminal4[88];
+static char *terminal1;
+static char *terminal2;
+static char *terminal3;
+static char *terminal4;
 
 void init_keyer_terminal(void) {
-    strcpy(terminal1, "");
-    strcpy(terminal2, "");
-    strcpy(terminal3, "");
-    strcpy(terminal4, "");
+    terminal1 = g_strdup("");
+    terminal2 = g_strdup("");
+    terminal3 = g_strdup("");
+    terminal4 = g_strdup("");
 }
 
 static void show_keyer_terminal() {
@@ -84,11 +84,13 @@ static void show_keyer_terminal() {
  */
 void add_to_keyer_terminal(char *buffer) {
 
-    strcpy(terminal1, terminal2);
-    strcpy(terminal2, terminal3);
-    strcpy(terminal3, terminal4);
+    if (terminal1)
+	g_free(terminal1);
+    terminal1 = terminal2;
+    terminal2 = terminal3;
+    terminal3 = terminal4;
 
-    g_strlcpy(terminal4, buffer, sizeof(terminal4));
+    terminal4 = g_strdup(buffer);
     g_strchomp(terminal4);
 
     move(5, 0);

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -84,8 +84,7 @@ static void show_keyer_terminal() {
  */
 static void add_line_to_keyer_terminal(char *buffer) {
 
-    if (terminal1)
-	g_free(terminal1);
+    g_free(terminal1);
     terminal1 = terminal2;
     terminal2 = terminal3;
     terminal3 = terminal4;

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -102,8 +102,10 @@ static void add_line_to_keyer_terminal(char *buffer) {
  */
 void add_to_keyer_terminal(char *buffer) {
     gchar **lines = g_strsplit_set(buffer, "\n\r", 0);
-    for (int i = 0; lines[i] != NULL; i++)
-        add_line_to_keyer_terminal(lines[i]);
+    for (int i = 0; lines[i] != NULL; i++) {
+	if (strlen(lines[i]) > 0)
+	    add_line_to_keyer_terminal(lines[i]);
+    }
     g_strfreev(lines);
 }
 

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -1,7 +1,7 @@
 /*
  * Tlf - contest logging program for amateur radio operators
  * Copyright (C) 2001-2002-2003 Rein Couperus <pa0rct@amsat.org>
- * 		 2013           Thomas Beierlein <tb@forth-ev.de
+ * 		 2013-2021      Thomas Beierlein <tb@forth-ev.de
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,7 +82,7 @@ static void show_keyer_terminal() {
  * add 'buffer' to the keyer terminal while scrolling one line up
  * and refreshing the display
  */
-void add_to_keyer_terminal(char *buffer) {
+static void add_line_to_keyer_terminal(char *buffer) {
 
     if (terminal1)
 	g_free(terminal1);
@@ -97,6 +97,17 @@ void add_to_keyer_terminal(char *buffer) {
 
     clear_display();
 }
+
+/*
+ * add 'buffer' to keyer terminal, splitting it into separate lines if needed
+ */
+void add_to_keyer_terminal(char *buffer) {
+    gchar **lines = g_strsplit_set(buffer, "\n\r", 0);
+    for (int i = 0; lines[i] != NULL; i++)
+        add_line_to_keyer_terminal(lines[i]);
+    g_strfreev(lines);
+}
+
 
 
 void show_header_line() {

--- a/src/clear_display.h
+++ b/src/clear_display.h
@@ -21,7 +21,7 @@
 #ifndef CLEAR_DISPLAY_H
 #define CLEAR_DISPLAY_H
 
-void init_terminal_strings(void);
+void init_keyer_terminal(void);
 void show_header_line(void);
 void clear_display(void);
 void add_to_keyer_terminal(char *buffer);

--- a/src/clear_display.h
+++ b/src/clear_display.h
@@ -24,7 +24,7 @@
 void init_terminal_strings(void);
 void show_header_line(void);
 void clear_display(void);
-void displayit(void);
+void add_to_keyer_terminal(char *buffer);
 void clear_line(int);
 
 #endif /* CLEAR_DISPLAY_H */

--- a/src/focm.c
+++ b/src/focm.c
@@ -297,7 +297,7 @@ void foc_show_cty() {
     refreshp();
 
     key_get();
-    displayit();
+    clear_display();
 
     g_tree_destroy(tree);
 }

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -245,6 +245,7 @@ extern bool mult_side;
 extern bool countrylist_only;
 extern bool mixedmode;
 extern bool qso_once;
+extern bool noleadingzeros;
 extern bool ignoredupe;
 extern bool continentlist_only;
 extern bool debugflag;

--- a/src/main.c
+++ b/src/main.c
@@ -138,7 +138,7 @@ bool serial_section_mult = false;
 bool serial_or_section = false;	/* exchange is serial OR section, like HA-DX */
 bool serial_grid4_mult = false;
 bool qso_once = false;
-int noleadingzeros;
+bool noleadingzeros;
 bool ctcomp = false;
 bool nob4 = false;		// allow auto b4
 bool ignoredupe = false;

--- a/src/main.c
+++ b/src/main.c
@@ -401,9 +401,6 @@ const char *backgrnd_str;
 
 char logline_edit[5][LOGLINELEN + 1];
 
-char termbuf[88] = "";
-int termbufcount = 0;
-
 double DEST_Lat = 51.;
 double DEST_Long = 1.;
 
@@ -942,7 +939,6 @@ int main(int argc, char *argv[]) {
 
     init_terminal_strings();
 
-    termbuf[0] = '\0';
     hiscall[0] = '\0';
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -937,7 +937,7 @@ int main(int argc, char *argv[]) {
     strcat(logline3, backgrnd_str);
     strcat(logline4, backgrnd_str);
 
-    init_terminal_strings();
+    init_keyer_terminal();
 
     hiscall[0] = '\0';
 

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -166,8 +166,6 @@ void replace_all(char *buf, int size, const char *what, const char *rep) {
 
 void ExpandMacro(void) {
 
-    extern int noleadingzeros;
-
     int i;
     static char qsonroutput[5] = "";
     static char rst_out[4] = "";
@@ -210,7 +208,7 @@ void ExpandMacro(void) {
 	}
 	qsonroutput[4] = '\0';
 
-	if (noleadingzeros != 1 && leading_zeros > 1) {
+	if (noleadingzeros && leading_zeros > 1) {
 	    leading_zeros = 1;
 	}
 

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -232,20 +232,15 @@ void ExpandMacro(void) {
 
 
 void sendbuf(void) {
-    extern char termbuf[];
 
     if ((trxmode == CWMODE && cwkeyer != NO_KEYER) ||
 	    (trxmode == DIGIMODE && digikeyer != NO_KEYER)) {
 
 	ExpandMacro();
 
-	if ((strlen(buffer) + strlen(termbuf)) < 80) {
-	    if (!simulator)
-		strcat(termbuf, buffer);
-//              if (sending_call == 1) {
-//                      strcat (termbuf, " ");
-//                      sending_call = 0;
-//              }
+	if (!simulator) {
+	    if (sending_call == 0)
+		add_to_keyer_terminal(buffer);
 	}
 
 	if (trxmode == DIGIMODE) {
@@ -275,11 +270,7 @@ void sendbuf(void) {
 	    keyer_append(buffer);
 	}
 
-	if (!simulator) {
-	    if (sending_call == 0)
-		displayit();
-	    refreshp();
-	} else {
+	if (simulator) {
 	    set_simulator_state(REPEAT);
 	}
 

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -236,10 +236,6 @@ void ExpandMacro(void) {
 void sendbuf(void) {
     extern char termbuf[];
 
-    static char printlinebuffer[82] = "";
-
-    printlinebuffer[0] = '\0';
-
     if ((trxmode == CWMODE && cwkeyer != NO_KEYER) ||
 	    (trxmode == DIGIMODE && digikeyer != NO_KEYER)) {
 
@@ -253,32 +249,6 @@ void sendbuf(void) {
 //                      sending_call = 0;
 //              }
 	}
-
-	g_strlcpy(printlinebuffer, termbuf, sizeof(printlinebuffer));
-
-	if (!searchflg && !simulator)
-	    strncat(printlinebuffer, backgrnd_str,
-		    80 - strlen(printlinebuffer));
-	else {
-	    int len = 40 - (int)strlen(printlinebuffer);
-	    if (len > 0) {
-		strncat(printlinebuffer, backgrnd_str, len);
-	    }
-	    if (strlen(printlinebuffer) > 45) {
-		printlinebuffer[42] = '.';
-		printlinebuffer[43] = '.';
-		printlinebuffer[44] = '.';
-		printlinebuffer[45] = '\0';
-	    }
-
-	}
-
-	attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
-
-	if (get_simulator_state() == IDLE) {
-	    mvaddstr(5, 0, printlinebuffer);
-	}
-	refreshp();
 
 	if (trxmode == DIGIMODE) {
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -304,7 +304,6 @@ void setcontest(char *name) {
     extern int vk_cty;
     extern int zs_cty;
     extern int ua9_cty;
-    extern int noleadingzeros;
 
     char wcall[] = "W1AW";
     char vecall[] = "VE1AA";
@@ -322,7 +321,7 @@ void setcontest(char *name) {
     showscore_flag = true;
     searchflg = true;
     sectn_mult = false;
-    noleadingzeros = 0;
+    noleadingzeros = false;
 
     w_cty = getctynr(wcall);
     ve_cty = getctynr(vecall);
@@ -342,7 +341,7 @@ void setcontest(char *name) {
 	qso_once = true;
 	multlist = 1;
 //      sectn_mult = true;
-	noleadingzeros = 1;
+	noleadingzeros = true;
     }
 
     if (CONTEST_IS(PACC_PA)) {

--- a/test/data.c
+++ b/test/data.c
@@ -103,7 +103,7 @@ bool serial_section_mult = false;
 bool serial_or_section = false;	/* exchange is serial OR section, like HA-DX */
 bool serial_grid4_mult = false;
 bool qso_once = false;
-int noleadingzeros;
+bool noleadingzeros;
 bool ctcomp = false;
 int isdupe = 0;			// 0 if nodupe -- for auto qso b4 (LZ3NY)
 bool nob4 = false;			// allow auto b4

--- a/test/data.c
+++ b/test/data.c
@@ -385,9 +385,6 @@ const char *backgrnd_str =
 
 char logline_edit[5][LOGLINELEN + 1];
 
-char termbuf[88] = "";
-int termbufcount = 0;
-
 double DEST_Lat = 51.;
 double DEST_Long = 1.;
 

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -29,6 +29,7 @@
 
 void addmult(struct qso_t qso) {}
 void addmult_lan() {}
+void clear_display() {}
 int pacc_pa(void) {
     return 0;
 }

--- a/test/test_adif.c
+++ b/test/test_adif.c
@@ -23,6 +23,7 @@ void add_adif_field(char *adif_line, char *field, char *value);
 bool simulator = false;
 
 void nicebox();
+void add_to_keyer_terminal(char *buffer) {}
 
 int stoptx() {
     return 0;

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -31,6 +31,7 @@ void cleanup_qso() { }
 void make_qtc_logline(struct read_qtc_t qtc_line, char *fname) { }
 char *getgrid(char *comment) { return comment; }
 void checkexchange(int x) { }
+void add_to_keyer_terminal(char *buffer) {}
 
 int get_total_score() {
     return 123;

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -31,6 +31,8 @@ char section[8] = "";       // defined in getexchange.c
     do{ strcpy(hiscall, call); \
 	assert_int_equal(score(), point); }while(0)
 
+void clear_display() {}
+
 #if 0
 void __wrap_qrb(char *x, char *y, char *u, char *v, double *a, double *b) {
 }

--- a/test/test_sendbuf.c
+++ b/test/test_sendbuf.c
@@ -42,6 +42,7 @@ int play_file(char *file) { return 0; }
 bool simulator;
 void set_simulator_state(simstate_t s) { }
 simstate_t get_simulator_state() { return IDLE; }
+void add_to_keyer_terminal(char *buffer) {}
 
 
 /* test helpers */


### PR DESCRIPTION
Furthermore clean up 'sendbuf()' and keyer terminal display