### PR TITLE
Fix leading zeros and Hamlib debug

### DIFF
--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -208,7 +208,7 @@ void ExpandMacro(void) {
 	}
 	qsonroutput[4] = '\0';
 
-	if (noleadingzeros && leading_zeros > 1) {
+	if (!noleadingzeros && leading_zeros > 1) {
 	    leading_zeros = 1;
 	}
 


### PR DESCRIPTION
Fixing 2 minor issues:
* QSO number is sent without leading zeros due to a glitch in 5fca304
* Hamlib log level not set to DEBUG when starting without rig control. Setting got lost in 90e9c98
![image](https://user-images.githubusercontent.com/15141948/148647934-737296bd-2414-4545-9133-b77bffa7fb21.png)

First comes a (failing) test for leading zeros...