### PR TITLE
Fix leading zeros and Hamlib debug

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -711,6 +711,8 @@ static int databases_load() {
 
 static void hamlib_init() {
 
+    rig_set_debug(RIG_DEBUG_NONE);
+
     if (no_trx_control) {
 	trx_control = false;
     }

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -197,18 +197,18 @@ void ExpandMacro(void) {
 
     if (NULL != strstr(buffer, "#")) {
 	int leading_zeros = 0;
-	int lead = 1;
+	bool lead = true;
 	for (i = 0; i <= 4; i++) {
 	    if (lead && qsonrstr[i] == '0') {
 		++leading_zeros;
 	    } else {
-		lead = 0;
+		lead = false;
 	    }
 	    qsonroutput[i] = short_number(qsonrstr[i]);
 	}
 	qsonroutput[4] = '\0';
 
-	if (noleadingzeros && leading_zeros > 1) {
+	if (!noleadingzeros && leading_zeros > 1) {
 	    leading_zeros = 1;
 	}
 

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -74,8 +74,6 @@ int init_tlf_rig(void) {
     const struct rig_caps *caps;
     int rig_cwspeed;
 
-    rig_set_debug(RIG_DEBUG_NONE);
-
     /*
      * allocate memory, setup & open port
      */

--- a/test/test_sendbuf.c
+++ b/test/test_sendbuf.c
@@ -184,6 +184,30 @@ void test_expandQsoNrshort(void **state) {
     check_ExpandMacro("nr #", "nr 3TN");
 }
 
+void test_expandQsoNr_leadingzeros(void **state) {
+    noleadingzeros = false;
+    strcpy(qsonrstr, "0007");
+    check_ExpandMacro("nr #", "nr 007");
+    strcpy(qsonrstr, "0073");
+    check_ExpandMacro("nr #", "nr 073");
+    strcpy(qsonrstr, "0123");
+    check_ExpandMacro("nr #", "nr 123");
+    strcpy(qsonrstr, "4711");
+    check_ExpandMacro("nr #", "nr 4711");
+}
+
+void test_expandQsoNr_noleadingzeros(void **state) {
+    noleadingzeros = true;
+    strcpy(qsonrstr, "0007");
+    check_ExpandMacro("nr #", "nr 7");
+    strcpy(qsonrstr, "0073");
+    check_ExpandMacro("nr #", "nr 73");
+    strcpy(qsonrstr, "0123");
+    check_ExpandMacro("nr #", "nr 123");
+    strcpy(qsonrstr, "4711");
+    check_ExpandMacro("nr #", "nr 4711");
+}
+
 void test_expandHisNr(void **state) {
     check_ExpandMacro("was !", "was Alex");
 }


### PR DESCRIPTION
Fixing 2 minor issues:

 *   QSO number is sent without leading zeros due to a glitch in 5fca304
*    Hamlib log level not set to DEBUG when starting without rig control. Setting got lost in 90e9c98
![image](https://user-images.githubusercontent.com/15141948/148648288-d0ca826c-26e0-4aaf-91f1-f6d175f10ed2.png)


First comes a (failing) test for leading zeros...