### PR TITLE
Rescore edit of last qsos

### DIFF
--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -40,6 +40,10 @@
 #define NR_LINES 5
 #define NR_COLS 80
 
+#define SOTIME 17	    /* start of time field */
+#define SOCALL 29	    /* start of call field */
+#define SOEXCH 54	    /* start of exchange field */
+#define EOEXCH (54 + contest->exchange_width) /* end of last field */
 
 /* highlight the edit line and set the cursor */
 static void highlight_line(int row, char *line, int column) {
@@ -104,7 +108,7 @@ void edit_last(void) {
 
     stop_background_process();
 
-    b = 29;
+    b = SOCALL;
 
     /* start with last QSO */
     get_qso(nr_qsos - (NR_LINES - editline), editbuffer);
@@ -120,20 +124,16 @@ void edit_last(void) {
 
 	    // Ctrl-E (^E) or <End>, end of line.
 	} else if (j == CTRL_E || j == KEY_END) {
-	    b = 77;
+	    b = EOEXCH - 1;
 
 	    // <Tab>, next field.
 	} else if (j == TAB) {
-	    if (b < 17)
-		b = 17;
-	    else if (b < 29)
-		b = 29;
-	    else if (b < 54)
-		b = 54;
-	    else if (b < 68)
-		b = 68;
-	    else if (b < 77)
-		b = 77;
+	    if (b < SOTIME)
+		b = SOTIME;
+	    else if (b < SOCALL)
+		b = SOCALL;
+	    else if (b < SOEXCH)
+		b = SOEXCH;
 	    else
 		b = 1;
 
@@ -167,30 +167,24 @@ void edit_last(void) {
 
 	    // Right arrow, move cursor one position right.
 	} else if (j == KEY_RIGHT) {
-	    if (b < 79)
+	    if (b < EOEXCH - 1)
 		b++;
 
-	    // <Insert>, positions 0 to 27.
-	} else if ((j == KEY_IC) && (b >= 0) && (b < 28)) {
-	    for (k = 28; k > b; k--)
+	    // <Insert>, positions 0 to 26.
+	} else if ((j == KEY_IC) && (b >= 0) && (b < 27)) {
+	    for (k = 26; k > b; k--)
 		editbuffer[k] = editbuffer[k - 1];
 	    editbuffer[b] = ' ';
 
-	    // <Insert>, positions 29 to 38.
-	} else if ((j == KEY_IC) && (b >= 29) && (b < 39)) {
-	    for (k = 39; k > b; k--)
+	    // <Insert>, positions 29 to 40.
+	} else if ((j == KEY_IC) && (b >= 29) && (b < 40)) {
+	    for (k = 40; k > b; k--)
 		editbuffer[k] = editbuffer[k - 1];
 	    editbuffer[b] = ' ';
 
-	    // <Insert>, positions 54 to 63.
-	} else if ((j == KEY_IC) && (b >= 54) && (b < 64)) {
-	    for (k = 64; k > b; k--)
-		editbuffer[k] = editbuffer[k - 1];
-	    editbuffer[b] = ' ';
-
-	    // <Insert>, positions 68 to 75.
-	} else if ((j == KEY_IC) && (b >= 68) && (b < 76)) {
-	    for (k = 76; k > b; k--)
+	    // <Insert>, positions 54 to end of field.
+	} else if ((j == KEY_IC) && (b >= SOEXCH) && (b < EOEXCH - 1)) {
+	    for (k = EOEXCH - 1; k > b; k--)
 		editbuffer[k] = editbuffer[k - 1];
 	    editbuffer[b] = ' ';
 
@@ -199,20 +193,17 @@ void edit_last(void) {
 	    for (k = b; k < 28; k++)
 		editbuffer[k] = editbuffer[k + 1];
 
-	    // <Delete>, positions 29 to 38.
-	} else if ((j == KEY_DC) && (b >= 29) && (b < 39)) {
-	    for (k = b; k < 39; k++)
+	    // <Delete>, positions 29 to 40.
+	} else if ((j == KEY_DC) && (b >= 29) && (b < 41)) {
+	    for (k = b; k < 40; k++)
 		editbuffer[k] = editbuffer[k + 1];
-
-	    // <Delete>, positions 68 to 75.
-	} else if ((j == KEY_DC) && (b >= 68) && (b < 76)) {
-	    for (k = b; k < 76; k++)
-		editbuffer[k] = editbuffer[k + 1];
+	    editbuffer[40] = ' ';
 
 	    // <Delete>, positions 54 to 63.
-	} else if ((j == KEY_DC) && (b >= 54) && (b < 64)) {
-	    for (k = b; k < 64; k++)
+	} else if ((j == KEY_DC) && (b >= SOEXCH) && (b < EOEXCH)) {
+	    for (k = b; k < EOEXCH - 1; k++)
 		editbuffer[k] = editbuffer[k + 1];
+	    editbuffer[EOEXCH - 1] = ' ';
 
 	} else if (j != ESCAPE) {
 
@@ -223,7 +214,8 @@ void edit_last(void) {
 	    // Accept most all printable characters.
 	    if ((j >= 32) && (j < 97)) {
 		editbuffer[b] = j;
-		if ((b < strlen(editbuffer) - 2) && (b < 80))
+		if ((b < strlen(editbuffer) - 2) &&
+			(b < EOEXCH - 1))
 		    b++;
 	    }
 	}

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -173,7 +173,7 @@ int readcalls(const char *logfile, bool interactive) {
     }
 
     fclose(fp);
-
+#if 0
     if (log_changed && interactive) {
 	showmsg("Log changed due to rescoring. Do you want to save it? Y/(N)");
 	if (toupper(key_get()) == 'Y') {
@@ -192,6 +192,36 @@ int readcalls(const char *logfile, bool interactive) {
 	    sleep(1);
 	}
     }
+#else
+    if (log_changed) {
+	bool ok = false;
+	if(interactive) {
+	    showmsg("Log changed due to rescoring. Do you want to save it? Y/(N)");
+	    ok = toupper(key_get()) == 'Y';
+	} else {
+	    ok = true;
+	}
+
+	if (ok) {
+	    // save a backup
+	    char prefix[40];
+	    format_time(prefix, sizeof(prefix), "%Y%m%d_%H%M%S");
+	    char *backup = g_strdup_printf("%s_%s", prefix, logfile);
+	    rename(logfile, backup);
+	    // rewrite log
+	    nr_qsos = 0;    // FIXME store_qso increments nr_qsos
+			    // FIXME store_qso write also back to qsos[]
+	    for (int i = 0 ; i < linenr; i++) {
+		store_qso(qsos[i]);
+	    }
+	    if (interactive) {
+		showstring("Log has been backed up as", backup);
+		sleep(1);
+	    }
+	    g_free(backup);
+	}
+    }
+#endif
 
     g_ptr_array_free(qso_array, TRUE);  // FIXME keep the array
 


### PR DESCRIPTION
Tlf supports editing the last 5 qsos. As we now generate the score of each qso programmatically that should also happen after any edit. 

The patch drops the possibility to edit multiplier and point score as they get generated automatically. It furthermore respects now the contest specific exchange_width - first commit.

After any edit (insert, delete or overwrite of any character) a reload and rescore is executed - second commit.

The third commit forces an automatic rewrite of the log file without user intervention in such an case. That works also in the case of a change while :EDITing the log directly.