### PR TITLE
Fix for rescore on log read

### DIFF
--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -154,6 +154,10 @@ int readcalls(const char *logfile, bool interactive) {
 	    strcpy(qso->comment, normalized_comment);
 	}
 	dupe = is_dupe(qso->call, qso->bandindex, qso->mode);
+
+	/* needed scoring in for country_found() */
+	g_strlcpy(hiscall, qso->call, sizeof(hiscall));
+
 	addcall(qso);
 	score_qso();    //FIXME argument?
 


### PR DESCRIPTION
Scoring for contests with country or continent based scoring (MY_CONTINENT_POINTS of DX_POINTS set) results always MY_COUNTRY_POINTS. 

Reason is empty 'hiscall' variable during readcalls(). country_found() will therefore always use operators own country for evaluation.

The fix provides the call sign of evaluated station in 'hicall' variable.

That is only a quick fix. The underlying problem is the code in country_found() which needs to be fixed.