### PR TITLE
Keep parsed qsos

### DIFF
--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -104,7 +104,7 @@ static void unhighlight_line(int row, char *line) {
 static void get_qso(int nr, char *buffer) {
 
     assert(nr < nr_qsos);
-    strcpy(buffer, qsos[nr]);
+    strcpy(buffer, QSOS(nr));
     assert(strlen(buffer) == (LOGLINELEN - 1));
 }
 

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -124,7 +124,6 @@ static void putback_qso(int nr, char *buffer) {
 
 	fclose(fp);
 
-	strcpy(qsos[nr], buffer);
 	struct qso_t *qso = parse_qso(buffer);
 	struct qso_t *old_qso = g_ptr_array_index(qso_array, nr);
 	g_ptr_array_index(qso_array, nr) = qso;

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -34,6 +34,7 @@
 #include "keystroke_names.h"
 #include "logview.h"
 #include "readcalls.h"
+#include "log_utils.h"
 #include "scroll_log.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
@@ -94,6 +95,10 @@ void putback_qso(int nr, char *buffer) {
 	fclose(fp);
 
 	strcpy(qsos[nr], buffer);
+	struct qso_t *qso = parse_qso(buffer);
+	struct qso_t *old_qso = g_ptr_array_index(qso_array, nr);
+	g_ptr_array_index(qso_array, nr) = qso;
+	free_qso(old_qso);
     }
 }
 

--- a/src/genqtclist.c
+++ b/src/genqtclist.c
@@ -65,13 +65,13 @@ int genqtclist(char *callsign, int nrofqtc) {
 
     while (qtclist.count < qtclistlen && s < nr_qsos) {
 	if (strlen(callsign) == 0 ||
-		strncmp(qsos[s] + 29, callsign, strlen(callsign)) != 0) {
+		strncmp(QSOS(s) + 29, callsign, strlen(callsign)) != 0) {
 	    /* exclude current callsign */
 
 	    if (qsoflags_for_qtc[s] == 0) {
 		/* qso line not yet used for QTC */
 
-		genqtcline(qtclist.qtclines[i].qtc, qsos[s]);
+		genqtcline(qtclist.qtclines[i].qtc, QSOS(s));
 
 		if (trxmode == DIGIMODE) {
 		    qtclist.qtclines[i].flag = 1;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -21,6 +21,8 @@ extern char qsos[MAX_QSOS][LOGLINELEN + 1];
 					// comment, starting with a semicolon
 extern int nr_qsos;			// number of lines in qsos[]
 
+extern GPtrArray *qso_array;		// array of parsed QSOs
+
 extern mults_t multis[MAX_MULTS]; 	// array of multipliers worked so far
 extern int nr_multis;			// number of entries in mults[]
 extern int multscore[NBANDS];		// number of multipliers worked per

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -14,14 +14,14 @@ extern mystation_t my;			// all about my station
 extern char whichcontest[];
 extern contest_config_t *contest;	// contest configuration
 
-extern char qsos[MAX_QSOS][LOGLINELEN + 1];
-					// array of log lines of QSOs so far;
-					// note that not every log line needs
-					// to be a QSO, it could also be a
-					// comment, starting with a semicolon
 extern int nr_qsos;			// number of lines in qsos[]
 
 extern GPtrArray *qso_array;		// array of parsed QSOs
+					// note that not every log line needs
+					// to be a QSO, it could also be a
+					// comment, starting with a semicolon.
+					// Than is_comment field in qso_t
+					// struct gets set
 
 extern mults_t multis[MAX_MULTS]; 	// array of multipliers worked so far
 extern int nr_multis;			// number of entries in mults[]

--- a/src/last10.c
+++ b/src/last10.c
@@ -28,17 +28,15 @@
 #include "get_time.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
 
-
 int last10(void) {
-
-    char input[LOGLINELEN + 1];
 
     int minsbefore;
     int minsnow;
     int span;
-    int counter;
+    int index;
     int qsocount = 0;
     int thisband;
+    struct qso_t *qso;
 
     if (nr_qsos < 10)
 	return (-1);
@@ -46,31 +44,28 @@ int last10(void) {
     thisband = atoi(band[bandinx]);
 
     /* look backwards in actual band for QSOs */
-    for (counter = nr_qsos - 1; counter >= 0; counter--) {
+    for (index = nr_qsos - 1; index >= 0; index--) {
 
-	if (thisband == (atoi(qsos[counter]))) {
+	qso = g_ptr_array_index(qso_array, index);
+	if (thisband == qso->band) {
 	    qsocount++;
 	    if (qsocount >= 10)		/* stop after 10 QSOs found */
 		break;
 	}
     }
 
-    /* counter points to the first QSO */
-    if (counter < 0)
+    /* index points to the first QSO */
+    if (index < 0)
 	return (-1);			/* not 10 QSOs found */
 
-    strncpy(input, qsos[counter], LOGLINELEN + 1);
-
-    input[17 + 5] = '\0';
-    minsbefore = atoi(input + 17 + 3);
-    input[17 + 2] = '\0';
-    minsbefore += (atoi(input + 17) * 60);
+    minsbefore = qso->hour *60 + qso->min;
 
     minsnow = get_minutes();
 
     if ((minsnow - minsbefore) <= 0)
 	minsnow += 1440;
+
     span = minsnow - minsbefore;
 
-    return (span);
+    return span;
 }

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -1,7 +1,7 @@
 /*
  * Tlf - contest logging program for amateur radio operators
  * Copyright (C) 2001-2002-2003 Rein Couperus <pa0rct@amsat.org>
- *               2013           Thomas Beierlein <tb@forth-ev.de>
+ *               2013-2022      Thomas Beierlein <tb@forth-ev.de>
  *               2013           Ervin Hegedüs - HA2OS <airween@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -92,6 +92,7 @@ void log_to_disk(int from_lan) {
 	current_qso->logline = logline; /* remember formatted line in qso entry */
 
 	store_qso(logline);
+	g_ptr_array_add(qso_array, current_qso);
 
 	// send qso to other nodes......
 	send_lan_message(LOGENTRY, logline);
@@ -102,7 +103,6 @@ void log_to_disk(int from_lan) {
 
 	cleanup_qso();		/* reset qso related parameters */
 
-	g_ptr_array_add(qso_array, current_qso);
     } else {			/* qso from lan */
 
 	/* LOGENTRY contains 82 characters (node,command and logline */
@@ -117,9 +117,12 @@ void log_to_disk(int from_lan) {
 
 	total = total + score2(lan_logline);
 
+	struct qso_t *qso = parse_qso(lan_logline);
+
 	addcall2();
 
 	store_qso(lan_logline);
+	g_ptr_array_add(qso_array, qso);
     }
 
 

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -89,20 +89,20 @@ void log_to_disk(int from_lan) {
 
 	score_qso();
 	char *logline = makelogline(current_qso);
-	strcpy(logline4, logline);
-	g_free(logline);
+	current_qso->logline = logline; /* remember formatted line in qso entry */
 
-	store_qso(logline4);
+	store_qso(logline);
 
 	// send qso to other nodes......
-	send_lan_message(LOGENTRY, logline4);
+	send_lan_message(LOGENTRY, logline);
 
 	if (trx_control && (cqmode == S_P))
 	    addspot();		/* add call to bandmap if in S&P and
 				   no need to ask for frequency */
 
 	cleanup_qso();		/* reset qso related parameters */
-	free_qso(current_qso);
+
+	g_ptr_array_add(qso_array, current_qso);
     } else {			/* qso from lan */
 
 	/* LOGENTRY contains 82 characters (node,command and logline */

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -100,6 +100,9 @@ struct qso_t *parse_qso(char *buffer) {
     ptr->logline = g_strdup(buffer);
     ptr->qsots = 0;
 
+    if (log_is_comment(buffer))
+	return ptr;
+
     /* split buffer into parts for linedata_t record and parse
      * them accordingly */
     tmp = strtok_r(buffer, " \t", &sp);

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -100,8 +100,12 @@ struct qso_t *parse_qso(char *buffer) {
     ptr->logline = g_strdup(buffer);
     ptr->qsots = 0;
 
-    if (log_is_comment(buffer))
+    if (log_is_comment(buffer)) {
+	ptr->is_comment = true;
 	return ptr;
+    }
+
+    ptr->is_comment = false;
 
     /* split buffer into parts for linedata_t record and parse
      * them accordingly */

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -171,3 +171,22 @@ void free_qso(struct qso_t *ptr) {
 	g_free(ptr);
     }
 }
+
+
+static void qso_free(gpointer data) {
+    free_qso((struct qso_t *) data);
+}
+
+
+void free_qso_array() {
+   if (qso_array != NULL) {
+	g_ptr_array_free(qso_array, TRUE);
+	qso_array = NULL;
+   }
+}
+
+void init_qso_array() {
+    free_qso_array();
+    qso_array = g_ptr_array_new_with_free_func(qso_free);
+}
+

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -1,6 +1,6 @@
 /*
  * Tlf - contest logging program for amateur radio operators
- * Copyright (C) 2019 Thomas Beierlein <dl1jbe@darc.de>
+ * Copyright (C) 2019-22 Thomas Beierlein <dl1jbe@darc.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/log_utils.h
+++ b/src/log_utils.h
@@ -31,5 +31,7 @@ int log_get_mode(const char *logline);
 int log_get_points(const char *logline);
 struct qso_t *parse_qso(char * buffer);
 void free_qso(struct qso_t *ptr);
+void free_qso_array();
+void init_qso_array();
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -354,6 +354,10 @@ char fldigi_url[50] = "http://localhost:7362/RPC2";
 char qsos[MAX_QSOS][LOGLINELEN + 1];
 int nr_qsos = 0;
 
+// array of qso's
+// FIXME use this instead of qsos[]
+GPtrArray *qso_array;
+
 /*------------------------------dupe array---------------------------------*/
 int nr_worked = 0;		/**< number of calls in worked[] */
 worked_t worked[MAX_CALLS]; 	/**< worked stations */

--- a/src/main.c
+++ b/src/main.c
@@ -350,13 +350,10 @@ int rig_comm_success = 0;
 /*----------------------------------fldigi---------------------------------*/
 char fldigi_url[50] = "http://localhost:7362/RPC2";
 
-/*-------------------------------the log lines-----------------------------*/
-char qsos[MAX_QSOS][LOGLINELEN + 1];
-int nr_qsos = 0;
-
+/*----------------------------the parsed log lines-------------------------*/
 // array of qso's
-// FIXME use this instead of qsos[]
 GPtrArray *qso_array;
+int nr_qsos = 0;
 
 /*------------------------------dupe array---------------------------------*/
 int nr_worked = 0;		/**< number of calls in worked[] */

--- a/src/note.c
+++ b/src/note.c
@@ -1,6 +1,7 @@
 /*
  * Tlf - contest logging program for amateur radio operators
  * Copyright (C) 2001-2002-2003 Rein Couperus <pa0rct@amsat.org>
+ *               2022	        Thomas Beierlein <dl1jbe@darc.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,11 +28,12 @@
 
 #include "clear_display.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "log_utils.h"
 #include "nicebox.h"		// Includes curses.h
 #include "scroll_log.h"
 
 
-int include_note(void) {
+void include_note(void) {
 
     extern char thisnode;
 
@@ -74,12 +76,12 @@ int include_note(void) {
 	fclose(fp);
 
 	g_strlcpy(qsos[nr_qsos], buffer2, LOGLINELEN);
+	struct qso_t *qso = parse_qso(buffer2);
+	g_ptr_array_add(qso_array, qso);
 	nr_qsos++;
 
 	scroll_log();
-	g_strlcpy(logline4, buffer2, 81);  /* max. 80 columns */
 	clear_display();
-
     }
 
     attron(COLOR_PAIR(C_LOG | A_STANDOUT));
@@ -87,5 +89,5 @@ int include_note(void) {
     for (i = 14; i <= 16; i++)
 	clear_line(i);
 
-    return (0);
+    return;
 }

--- a/src/note.c
+++ b/src/note.c
@@ -75,7 +75,6 @@ void include_note(void) {
 
 	fclose(fp);
 
-	g_strlcpy(qsos[nr_qsos], buffer2, LOGLINELEN);
 	struct qso_t *qso = parse_qso(buffer2);
 	g_ptr_array_add(qso_array, qso);
 	nr_qsos++;

--- a/src/note.h
+++ b/src/note.h
@@ -21,6 +21,6 @@
 #ifndef NOTE_H
 #define NOTE_H
 
-int include_note(void);
+void include_note(void);
 
 #endif /* NOTE_H */

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -195,26 +195,7 @@ int readcalls(const char *logfile, bool interactive) {
     }
 
     fclose(fp);
-#if 0
-    if (log_changed && interactive) {
-	showmsg("Log changed due to rescoring. Do you want to save it? Y/(N)");
-	if (toupper(key_get()) == 'Y') {
-	    // save a backup
-	    char prefix[40];
-	    format_time(prefix, sizeof(prefix), "%Y%m%d_%H%M%S");
-	    char *backup = g_strdup_printf("%s_%s", prefix, logfile);
-	    rename(logfile, backup);
-	    // rewrite log
-	    nr_qsos = 0;    // FIXME store_qso increments nr_qsos
-	    for (int i = 0 ; i < linenr; i++) {
-		store_qso(qsos[i]);
-	    }
-	    showstring("Log has been backed up as", backup);
-	    g_free(backup);
-	    sleep(1);
-	}
-    }
-#else
+
     if (log_changed) {
 	bool ok = false;
 	if(interactive) {
@@ -243,7 +224,6 @@ int readcalls(const char *logfile, bool interactive) {
 	    g_free(backup);
 	}
     }
-#endif
 
     return linenr;			// nr of lines in log
 }

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -51,6 +51,12 @@
 #include "store_qso.h"
 #include "ui_utils.h"
 
+static void qso_free(gpointer data);
+
+// array of qso's
+// FIXME use this instead of qsos[]
+// FIXME also include comments/notes into qso_t
+GPtrArray *qso_array;
 
 void init_scoring(void) {
     /* reset counter and score anew */
@@ -102,6 +108,19 @@ static void qso_free(gpointer data) {
     free_qso((struct qso_t *) data);
 }
 
+
+void free_qso_array() {
+   if (qso_array != NULL) {
+	g_ptr_array_free(qso_array, TRUE);
+	qso_array = NULL;
+   }
+}
+
+void init_qso_array() {
+    free_qso_array();
+    qso_array = g_ptr_array_new_with_free_func(qso_free);
+}
+
 int readcalls(const char *logfile, bool interactive) {
 
     char inputbuffer[LOGLINELEN + 1];
@@ -123,10 +142,8 @@ int readcalls(const char *logfile, bool interactive) {
     }
 
     bool log_changed = false;
-    // array of qso's
-    // FIXME use this instead of qsos[] (make it global and don't free it here)
-    // FIXME also include comments/notes into qso_t
-    GPtrArray *qso_array = g_ptr_array_new_with_free_func(qso_free);
+
+    init_qso_array();
 
     while (fgets(inputbuffer, sizeof(inputbuffer), fp) != NULL) {
 
@@ -192,8 +209,6 @@ int readcalls(const char *logfile, bool interactive) {
 	    sleep(1);
 	}
     }
-
-    g_ptr_array_free(qso_array, TRUE);  // FIXME keep the array
 
     return linenr;			// nr of lines in log
 }

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -51,7 +51,6 @@
 #include "store_qso.h"
 #include "ui_utils.h"
 
-static void qso_free(gpointer data);
 
 void init_scoring(void) {
     /* reset counter and score anew */

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -55,7 +55,6 @@ static void qso_free(gpointer data);
 
 // array of qso's
 // FIXME use this instead of qsos[]
-// FIXME also include comments/notes into qso_t
 GPtrArray *qso_array;
 
 void init_scoring(void) {
@@ -159,10 +158,12 @@ int readcalls(const char *logfile, bool interactive) {
 	    show_progress(linenr);
 	}
 
-	if (log_is_comment(inputbuffer))
-	    continue;		/* skip note in log */
-
 	qso = parse_qso(inputbuffer);
+
+	if (log_is_comment(inputbuffer)) {
+	    g_ptr_array_add(qso_array, qso);
+	    continue;		/* skip further processing for note entry */
+	}
 
 	/* get the country number, not known at this point */
 	countrynr = getctydata(qso->call);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -53,10 +53,6 @@
 
 static void qso_free(gpointer data);
 
-// array of qso's
-// FIXME use this instead of qsos[]
-GPtrArray *qso_array;
-
 void init_scoring(void) {
     /* reset counter and score anew */
     total = 0;
@@ -101,23 +97,6 @@ static void show_progress(int linenr) {
 	printw("*");
 	refreshp();
     }
-}
-
-static void qso_free(gpointer data) {
-    free_qso((struct qso_t *) data);
-}
-
-
-void free_qso_array() {
-   if (qso_array != NULL) {
-	g_ptr_array_free(qso_array, TRUE);
-	qso_array = NULL;
-   }
-}
-
-void init_qso_array() {
-    free_qso_array();
-    qso_array = g_ptr_array_new_with_free_func(qso_free);
 }
 
 int readcalls(const char *logfile, bool interactive) {

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -56,9 +56,7 @@ void init_scoring(void) {
     /* reset counter and score anew */
     total = 0;
 
-    for (int i = 0; i < MAX_QSOS; i++)
-	qsos[i][0] = '\0';
-
+    init_qso_array();
     init_worked();
 
     for (int i = 1; i <= MAX_DATALINES - 1; i++)
@@ -120,17 +118,12 @@ int readcalls(const char *logfile, bool interactive) {
 
     bool log_changed = false;
 
-    init_qso_array();
-
     while (fgets(inputbuffer, sizeof(inputbuffer), fp) != NULL) {
 
 	// drop trailing newline
 	inputbuffer[LOGLINELEN - 1] = '\0';
 
-	// remember logline in qsos[] field
-	g_strlcpy(qsos[linenr], inputbuffer, sizeof(qsos[0]));
 	linenr++;
-	// FIXME check for overflow....
 
 	if (interactive) {
 	    show_progress(linenr);
@@ -156,9 +149,8 @@ int readcalls(const char *logfile, bool interactive) {
 
 	char *logline = makelogline(qso);
 
-	if (strcmp(logline, qsos[linenr - 1]) != 0) {
+	if (strcmp(logline, qso->logline) != 0) {
 	    // different: update log line and mark change
-	    g_strlcpy(qsos[linenr - 1], logline, sizeof(qsos[0]));
 	    g_free(qso->logline);
 	    qso->logline = g_strdup(logline);
 	    log_changed = true;
@@ -188,9 +180,8 @@ int readcalls(const char *logfile, bool interactive) {
 	    rename(logfile, backup);
 	    // rewrite log
 	    nr_qsos = 0;    // FIXME store_qso increments nr_qsos
-			    // FIXME store_qso write also back to qsos[]
 	    for (int i = 0 ; i < linenr; i++) {
-		store_qso(qsos[i]);
+		store_qso(QSOS(i));
 	    }
 	    if (interactive) {
 		showstring("Log has been backed up as", backup);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -2,7 +2,7 @@
  * Tlf - contest logging program for amateur radio operators
  * Copyright (C) 2001-2002-2003 Rein Couperus <pa0rct@amsat.org>
  *               2013           Ervin Hegedüs - HA2OS <airween@gmail.com>
- *               2012-2021      Thomas Beierlein <dl1jbe@darc.de>
+ *               2012-2022      Thomas Beierlein <dl1jbe@darc.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/readcalls.h
+++ b/src/readcalls.h
@@ -26,8 +26,6 @@
 #include <stdbool.h>
 
 int lookup_country_in_pfxnummult_array(int n);
-void free_qso_array();
-void init_qso_array();
 int readcalls(const char *logfile, bool interactive);
 int log_read_n_score();
 int synclog(char *synclogfile);

--- a/src/readcalls.h
+++ b/src/readcalls.h
@@ -2,6 +2,7 @@
  * Tlf - contest logging program for amateur radio operators
  * Copyright (C) 2001-2002-2003 Rein Couperus <pa0rct@amsat.org>
  *               2013           Ervin Hegedüs - HA2OS <airween@gmail.com>
+ *               2012-2022      Thomas Beierlein <dl1jbe@darc.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/readcalls.h
+++ b/src/readcalls.h
@@ -25,6 +25,8 @@
 #include <stdbool.h>
 
 int lookup_country_in_pfxnummult_array(int n);
+void free_qso_array();
+void init_qso_array();
 int readcalls(const char *logfile, bool interactive);
 int log_read_n_score();
 int synclog(char *synclogfile);

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -100,14 +100,14 @@ void get_next_serial(void) {
 
 #define LINELEN 80
 
-/** read the last 5 log lines from qsos[] array and set the next qso number */
+/** read the last 5 log lines from qso_array and set the next qso number */
 void scroll_log(void) {
 
     for (int i = 5; i > 0; i--) {
 	if (nr_qsos < i) {
 	    g_strlcpy(logline_edit[5 - i], spaces(80), LINELEN + 1);
 	} else {
-	    g_strlcpy(logline_edit[5- i], qsos[nr_qsos - i], LINELEN + 1);
+	    g_strlcpy(logline_edit[5- i], QSOS(nr_qsos - i), LINELEN + 1);
 	}
     }
 

--- a/src/searchcallarray.c
+++ b/src/searchcallarray.c
@@ -63,7 +63,6 @@ int lookup_worked(char *call) {
 /* add a new entry for call to the collection */
 static int add_new(char *call) {
     int i = nr_worked;
-    prefix_data *prefix;
 
     memset(&worked[i], 0, sizeof(worked_t));
     g_strlcpy(worked[i].call, call, sizeof(worked[0].call));

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -390,8 +390,6 @@ static bool qso_has_current_mode(const struct qso_t *qso) {
  */
 void filterLog(const char *call) {
 
-    char s_inputbuffer[LOGLINELEN + 1] = "";
-
     srch_index = 0;
 
     for (int qso_index = 0; qso_index < nr_qsos; qso_index++) {

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -395,6 +395,10 @@ void filterLog(const char *call) {
     for (int qso_index = 0; qso_index < nr_qsos; qso_index++) {
 
 	struct qso_t *qso = g_ptr_array_index(qso_array, qso_index);
+	if (qso->is_comment) {
+	    continue;
+	}
+
 	if (!qso_has_current_mode(qso)) {
 	    continue;	// different mode
 	}

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -383,23 +383,23 @@ static bool is_current_mode(const char *qso) {
 }
 
 
-/* search complete Log for 'hiscall' as substring in callsign field and
+/* search complete Log for 'call' as substring in callsign field and
  * copy found QSO to 'searchresults'. Extract relevant data to 'result'.
  * */
-void filterLog() {
+void filterLog(const char *call) {
 
     char s_inputbuffer[LOGLINELEN + 1] = "";
 
     srch_index = 0;
 
-    for (int qso_index = 0; strlen(qsos[qso_index]) > 4; qso_index++) {
+    for (int qso_index = 0; qso_index < nr_qsos; qso_index++) {
 
 	if (!is_current_mode(qsos[qso_index])) {
 	    continue;   // different mode
 	}
 
 	g_strlcpy(s_inputbuffer, qsos[qso_index] + 29, 13); /* call */
-	if (strstr(s_inputbuffer, hiscall) == 0) {
+	if (strstr(s_inputbuffer, call) == 0) {
 	    continue;   // no match
 	}
 
@@ -678,7 +678,7 @@ void searchlog() {
 	ShowSearchPanel();
 	drawSearchWin();
 
-	filterLog();
+	filterLog(hiscall);
 	displaySearchResults();
 
 

--- a/src/store_qso.c
+++ b/src/store_qso.c
@@ -38,7 +38,6 @@ void store_qso(char *loglineptr) {
 	endwin();
 	exit(1);
     }
-    strcpy(qsos[nr_qsos], loglineptr);
     nr_qsos++;
 
     fputs(loglineptr, fp);

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -190,6 +190,7 @@ typedef struct {
 /* represents different parts of a qso line */
 struct qso_t {
     char *logline;
+    bool is_comment;
     int band;
     int bandindex;
     int mode;

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -285,5 +285,7 @@ enum {
 
 #define LEN(array) (sizeof(array) / sizeof(array[0]))
 
+#define QSOS(n)    (((struct qso_t*)g_ptr_array_index(qso_array, n))->logline)
+
 #endif /* TLF_H */
 

--- a/test/data.c
+++ b/test/data.c
@@ -329,13 +329,10 @@ int rig_comm_error = 0;
 int rig_comm_success = 0;
 int rigptt = 0;
 
-/*-------------------------------the log lines-----------------------------*/
-char qsos[MAX_QSOS][LOGLINELEN + 1];
-int nr_qsos = 0;
-
+/*----------------------------the parsed log lines-------------------------*/
 // array of qso's
-// FIXME use this instead of qsos[]
 GPtrArray *qso_array;
+int nr_qsos = 0;
 
 /*------------------------------dupe array---------------------------------*/
 int nr_worked = 0;		/*< number of calls in worked[] */

--- a/test/data.c
+++ b/test/data.c
@@ -333,6 +333,10 @@ int rigptt = 0;
 char qsos[MAX_QSOS][LOGLINELEN + 1];
 int nr_qsos = 0;
 
+// array of qso's
+// FIXME use this instead of qsos[]
+GPtrArray *qso_array;
+
 /*------------------------------dupe array---------------------------------*/
 int nr_worked = 0;		/*< number of calls in worked[] */
 worked_t worked[MAX_CALLS]; 	/*< worked stations */

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -4,6 +4,7 @@
 #include "../src/dxcc.h"
 #include "../src/readcabrillo.h"
 #include "../src/cqww_simulator.h"
+#include "../src/log_utils.h"
 
 // OBJECT ../src/cabrillo_utils.o
 // OBJECT ../src/readcabrillo.o
@@ -88,13 +89,19 @@ char *error_details;
 
 char formatfile[] = TOP_SRCDIR "/share/cabrillo.fmt" ;
 
-int setup(void **state) {
+int setup_default(void **state) {
     strcpy(my.call, "A1BCD");
     strcpy(exchange, "#");
+
+    init_qso_array();
+    nr_qsos = 0;
+
     return 0;
 }
 
 int teardown_default(void **state) {
+    free_qso_array();
+
     g_free(qso_spy);
     qso_spy = NULL;
     return 0;

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -8,6 +8,7 @@
 #include "../src/globalvars.h"
 #include "../src/getctydata.h"
 #include "../src/get_time.h"
+#include "../src/log_utils.h"
 #include "../src/readcalls.h"
 #include "../src/setcontest.h"
 #include "../src/showscore.h"
@@ -187,7 +188,11 @@ void test_readcalls_note(void **state) {
     write_log(LOGFILE);
     append_log_line(LOGFILE, NOTE);
     assert_int_equal(readcalls(LOGFILE, true), 2);;
-    assert_string_equal(((struct qso_t *)g_ptr_array_index(qso_array, 1))->logline, note);
+
+    struct qso_t *qso = g_ptr_array_index(qso_array, 1);
+    assert_string_equal(qso->logline, note);
+    assert_int_equal(qso->is_comment, true);
+
     g_free(note);
 }
 

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -36,7 +36,7 @@ extern char searchresult[MAX_CALLS][82];
 extern char result[MAX_CALLS][82];
 
 void handlePartials(void);
-void filterLog();
+void filterLog(const char * call);
 int bandstr2line(char *buffer);
 int getZone(void);
 
@@ -114,6 +114,7 @@ static void write_qsos() {
     strcpy(qsos[3], QSO4);
     strcpy(qsos[4], QSO5);
     strcpy(qsos[5], QSO6);
+    nr_qsos = 6;
 }
 
 int setup_default(void **state) {
@@ -241,8 +242,7 @@ void test_init_search_panel_dxped(void **state) {
 
 /* testing searchlog for refactoring */
 void test_searchlog_pickup_call(void **state) {
-    strcpy(hiscall, "UA");
-    filterLog("");
+    filterLog("UA");
     assert_int_equal(strncmp(searchresult[0], QSO3, 80), 0);
     assert_int_equal(strncmp(searchresult[1], QSO4, 80), 0);
     assert_int_equal(strncmp(searchresult[2], QSO5, 80), 0);
@@ -250,23 +250,20 @@ void test_searchlog_pickup_call(void **state) {
 
 void test_searchlog_pickup_call_mixedmode(void **state) {
     mixedmode = 1;
-    strcpy(hiscall, "UA");
-    filterLog("");
+    filterLog("UA");
     assert_int_equal(strncmp(searchresult[0], QSO3, 80), 0);
     assert_int_equal(strncmp(searchresult[1], QSO5, 80), 0);
 }
 
 void test_searchlog_extract_data(void **state) {
-    strcpy(hiscall, "UA");
-    filterLog("");
+    filterLog("UA");
     assert_string_equal(result[0], " 40CW  0007 OE3UAI       15            ");
     assert_string_equal(result[1], " 80SSB 0008 UA3JK        16            ");
 }
 
 void test_searchlog_extract_data_mixedmode(void **state) {
     mixedmode = 1;
-    strcpy(hiscall, "UA");
-    filterLog("");
+    filterLog("UA");
     assert_string_equal(result[0], " 40CW  0007 OE3UAI       15            ");
     assert_string_equal(result[1], " 80CW  0009 UA9LM        17            ");
 }
@@ -287,7 +284,7 @@ void test_bandstr2line(void **state) {
 void test_UsePartialFromLog(void **state) {
     use_part = true;
     strcpy(hiscall, "K4DE");
-    filterLog();
+    filterLog(hiscall);
     handlePartials();
     assert_string_equal(hiscall, "K4DEF");
 }
@@ -295,7 +292,7 @@ void test_UsePartialFromLog(void **state) {
 void test_UsePartialFromLogNotUnique(void **state) {
     use_part = true;
     strcpy(hiscall, "UA");
-    filterLog();
+    filterLog(hiscall);
     handlePartials();
     assert_string_equal(hiscall, "UA");
 }
@@ -305,7 +302,7 @@ void test_UsePartialFromCallmaster(void **state) {
     load_callmaster();
     use_part = true;
     strcpy(hiscall, "A1");
-    filterLog();
+    filterLog(hiscall);
     handlePartials();
     assert_string_equal(hiscall, "A1AA");
 }
@@ -315,7 +312,7 @@ void test_UsePartialNotUnique(void **state) {
     load_callmaster();
     use_part = true;
     strcpy(hiscall, "A3");
-    filterLog();
+    filterLog(hiscall);
     handlePartials();
     assert_string_equal(hiscall, "A3");
 }
@@ -326,7 +323,7 @@ void test_UsePartialNotUnique_only_callmaster(void **state) {
     load_callmaster();
     use_part = true;
     strcpy(hiscall, "HG");  // not in log yet
-    filterLog();
+    filterLog(hiscall);
     handlePartials();
     assert_string_equal(hiscall, "HG");
 }
@@ -339,7 +336,7 @@ void test_displayPartials_exact_callmaster(void **state) {
     load_callmaster();
     strcpy(hiscall, "UA3JK");   // already in log
 
-    filterLog();
+    filterLog(hiscall);
     handlePartials();
 
     check_mvprintw_output(2, 1, 1, "UA3JK");    // first - from log
@@ -354,6 +351,7 @@ void test_displayPartials(void **state) {
 	sprintf(qsos[6 + i],
 		" 80CW  12-Jan-18 16:34 0009  UA9%cAA         599  599  17            UA9 17   3         ",
 		'A' + i);
+	nr_qsos++;
     }
 
     // callmaster has also some UAs
@@ -361,7 +359,7 @@ void test_displayPartials(void **state) {
     load_callmaster();
     strcpy(hiscall, "UA");
 
-    filterLog();
+    filterLog(hiscall);
     handlePartials();
 
     // check selected displayed values only (F2UAA must not be shown)

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -111,7 +111,6 @@ void add_log(int n, char *string) {
     struct qso_t *qso;
     char *line;
 
-    strcpy(qsos[n], string);
     line = g_strdup(string);
     qso = parse_qso(line);
     g_free(line);
@@ -119,13 +118,7 @@ void add_log(int n, char *string) {
 }
 
 static void write_qsos() {
-    int i;
-
     init_qso_array();
-
-    for (i = 0; i < MAX_QSOS; i++) {
-	strcpy(qsos[i], "");
-    }
 
     add_log(0, QSO1);
     add_log(1, QSO2);

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -2,6 +2,7 @@
 
 #include "../src/globalvars.h"
 
+#include "../src/log_utils.h"
 #include "../src/tlf_curses.h"
 #include "../src/tlf_panel.h"
 #include "../src/searchlog.h"
@@ -103,17 +104,36 @@ contest_config_t config_focm;
 #define QSO5 " 80CW  12-Jan-18 16:34 0009  UA9LM          599  599  17            UA9 17   3         "
 #define QSO6 " 80CW  12-Jan-18 16:36 0010  AA3BP          599  599  05            K   05   3         "
 
+/* helper to add string to pos n in qsos array, parse the string as qso
+ * and add it to qso_array
+ */
+void add_log(int n, char *string) {
+    struct qso_t *qso;
+    char *line;
+
+    strcpy(qsos[n], string);
+    line = g_strdup(string);
+    qso = parse_qso(line);
+    g_free(line);
+    g_ptr_array_add(qso_array, qso);
+}
+
 static void write_qsos() {
     int i;
+
+    init_qso_array();
+
     for (i = 0; i < MAX_QSOS; i++) {
 	strcpy(qsos[i], "");
     }
-    strcpy(qsos[0], QSO1);
-    strcpy(qsos[1], QSO2);
-    strcpy(qsos[2], QSO3);
-    strcpy(qsos[3], QSO4);
-    strcpy(qsos[4], QSO5);
-    strcpy(qsos[5], QSO6);
+
+    add_log(0, QSO1);
+    add_log(1, QSO2);
+    add_log(2, QSO3);
+    add_log(3, QSO4);
+    add_log(4, QSO5);
+    add_log(5, QSO6);
+
     nr_qsos = 6;
 }
 
@@ -348,9 +368,12 @@ void test_displayPartials_exact_callmaster(void **state) {
 void test_displayPartials(void **state) {
     // add a bunch of UA QSOs so that they fill up available space
     for (int i = 0; i <= 'Z' - 'A'; ++i) {
-	sprintf(qsos[6 + i],
-		" 80CW  12-Jan-18 16:34 0009  UA9%cAA         599  599  17            UA9 17   3         ",
+
+	char *line = g_strdup_printf(" 80CW  12-Jan-18 16:34 0009  UA9%cAA         599  599  17            UA9 17   3         ",
 		'A' + i);
+	add_log(6 + i, line);
+	g_free(line);
+
 	nr_qsos++;
     }
 


### PR DESCRIPTION
Keep 'qso_array' as parsed representation of the log in memory. 

Keep array up to date while adding or editing new contacts.
Each entry keeps also a copy of the original log line. so we can move away from using the fixed size 'qsos[]' array.

