### PR TITLE
Use struct qso for scoring

### DIFF
--- a/src/addcall.c
+++ b/src/addcall.c
@@ -241,7 +241,7 @@ int addcall2(void) {
     int station = lookup_or_add_worked(qso->call);
     update_worked(station, qso);
 
-    cty = worked[station].country;
+    cty = worked[station].ctyinfo->dxcc_ctynr;
 
     bandinx = qso->bandindex;
 

--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -241,7 +241,7 @@ void prefix_add(char *pfxstr) {
 	new_prefix -> cq = last_dx -> cq;
 
     new_prefix -> pfx = g_strdup(pfxstr);
-    new_prefix -> dxcc_index = last_index;
+    new_prefix -> dxcc_ctynr = last_index;
 
     g_ptr_array_add(prefix, new_prefix);
     int index = prefix_count() - 1;

--- a/src/dxcc.h
+++ b/src/dxcc.h
@@ -28,7 +28,7 @@ typedef struct {
     char *pfx;
     unsigned short cq;
     unsigned short itu;
-    short dxcc_index;
+    short dxcc_ctynr;	    /* cty number is index in dxcc table */
     float lat;
     float lon;
     char *continent;

--- a/src/focm.c
+++ b/src/focm.c
@@ -160,7 +160,7 @@ static int get_nr_cont() {
     cont = g_hash_table_new(g_str_hash, g_str_equal);
 
     for (i = 0; i < nr_worked; i++) {
-	data = dxcc_by_index(worked[i].country);
+	data = dxcc_by_index(worked[i].ctyinfo->dxcc_ctynr);
 
 	g_hash_table_replace(cont, data->continent, data->continent);
     }

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -63,7 +63,7 @@ void change_area(char *call, char area) {
 /* prepare and check callsign and look it up in dxcc data base
  *
  * returns index in data base or -1 if not found
- * if normalized_call ptr is not NULL retruns a copy of the normalized call
+ * if normalized_call ptr is not NULL returns a copy of the normalized call
  * e.g. DL1XYZ/PA gives PA/DL1XYZ
  * caller has to free the copy after use
  */

--- a/src/getctydata.c
+++ b/src/getctydata.c
@@ -157,14 +157,20 @@ int getpfxindex(char *checkcallptr, char **normalized_call) {
     return w;
 }
 
+/* lookup dxcc country and prefix information from callsign */
+prefix_data *getctyinfo(char *call) {
+    int w = getpfxindex(call, NULL);
+    return prefix_by_index(w);
+}
+
 /* lookup dxcc cty number from callsign */
-int getctynr(char *checkcall) {
+int getctynr(char *call) {
     int w;
 
-    w = getpfxindex(checkcall, NULL);
+    w = getpfxindex(call, NULL);
 
     if (w >= 0)
-	return prefix_by_index(w)->dxcc_index;
+	return prefix_by_index(w)->dxcc_ctynr;
     else
 	return 0;	/* no country found */
 }
@@ -174,10 +180,10 @@ int getctynr(char *checkcall) {
  *
  * side effect: set up various global variables
  */
-static int getctydata_internal(char *checkcallptr, bool get_country) {
+static int getctydata_internal(char *call, bool get_country) {
     char *normalized_call = NULL;
 
-    int w = getpfxindex(checkcallptr, &normalized_call);
+    int w = getpfxindex(call, &normalized_call);
 
     if (CONTEST_IS(WPX) || pfxmult)
 	/* needed for wpx and other pfx contests */
@@ -187,7 +193,7 @@ static int getctydata_internal(char *checkcallptr, bool get_country) {
 
     // fill global variables
     prefix_data *pfx = prefix_by_index(w);
-    countrynr = pfx->dxcc_index;
+    countrynr = pfx->dxcc_ctynr;
     sprintf(cqzone, "%02d", pfx->cq);
     sprintf(ituzone, "%02d", pfx->itu);
     DEST_Lat = pfx->lat;
@@ -198,10 +204,10 @@ static int getctydata_internal(char *checkcallptr, bool get_country) {
     return get_country ? countrynr : w;
 }
 
-int getctydata(char *checkcallptr) {
-    return getctydata_internal(checkcallptr, true);
+int getctydata(char *call) {
+    return getctydata_internal(call, true);
 }
 
-int getctydata_pfx(char *checkcallptr) {
-    return getctydata_internal(checkcallptr, false);
+int getctydata_pfx(char *call) {
+    return getctydata_internal(call, false);
 }

--- a/src/getctydata.h
+++ b/src/getctydata.h
@@ -21,9 +21,12 @@
 #ifndef GETCTYDATA_H
 #define GETCTYDATA_H
 
-int getctynr(char *checkcall);
-int getctydata(char *checkcall);
-int getctydata_pfx(char *checkcallptr);
+#include "dxcc.h"
+
+prefix_data *getctyinfo(char *call);
+int getctynr(char *call);
+int getctydata(char *call);
+int getctydata_pfx(char *call);
 
 
 #endif /* end of include guard: GETCTYDATA_H */

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -87,7 +87,7 @@ void log_to_disk(int from_lan) {
 	current_qso = collect_qso_data();
 	addcall(current_qso);		/* add call to dupe list */
 
-	score_qso();
+	score_qso(current_qso);
 	char *logline = makelogline(current_qso);
 	strcpy(logline4, logline);
 	g_free(logline);

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -85,7 +85,7 @@ void write_log_fm_cabr(struct qso_t *qso) {
     checkexchange(qso->comment, false);
     dupe = is_dupe(qso->call, qso->bandindex, qso->mode);
     addcall(qso);           /* add call to worked list and check it for dupe */
-    score_qso();
+    score_qso(qso);
     char *logline = makelogline(qso);	    /* format logline */
     store_qso(logline);
     g_free(logline);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -155,9 +155,6 @@ int readcalls(const char *logfile, bool interactive) {
 	}
 	dupe = is_dupe(qso->call, qso->bandindex, qso->mode);
 
-	/* needed scoring in for country_found() */
-	g_strlcpy(hiscall, qso->call, sizeof(hiscall));
-
 	addcall(qso);
 	score_qso(qso);
 

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -159,7 +159,7 @@ int readcalls(const char *logfile, bool interactive) {
 	g_strlcpy(hiscall, qso->call, sizeof(hiscall));
 
 	addcall(qso);
-	score_qso();    //FIXME argument?
+	score_qso(qso);
 
 	char *logline = makelogline(qso);
 

--- a/src/score.c
+++ b/src/score.c
@@ -154,7 +154,7 @@ int scoreByMode() {
 			    points = x; \
 			} while(0);
 
-int scoreByContinentOrCountry() {
+int scoreByContinentOrCountry(struct qso_t *qso) {
 
     int points = 0;
     bool inCountryList = exist_in_country_list();
@@ -203,14 +203,14 @@ int scoreByContinentOrCountry() {
  * are active
  * \return points for QSO
  */
-int scoreDefault() {
+int scoreDefault(struct qso_t *qso) {
 
     int points;
 
     if (ssbpoints != 0 && cwpoints != 0)	//  e.g. arrl 10m contest
 	points = scoreByMode();
     else
-	points = scoreByContinentOrCountry();
+	points = scoreByContinentOrCountry(qso);
 
     points = apply_bandweight(points);
     points = portable_doubles(points);
@@ -218,7 +218,7 @@ int scoreDefault() {
     return points;
 }
 
-int score_wpx() {
+int score_wpx(struct qso_t *qso) {
     int points;
     if (countrynr == my.countrynr) {
 	points = 1;
@@ -262,7 +262,7 @@ int score_wpx() {
 }
 
 
-int score_cqww() {
+int score_cqww(struct qso_t *qso) {
     int points;
     int zone;
 
@@ -293,7 +293,7 @@ int score_cqww() {
 }
 
 
-int score_arrlfd() {
+int score_arrlfd(struct qso_t *qso) {
     int points;
 
     if (trxmode == SSBMODE) {
@@ -305,7 +305,7 @@ int score_arrlfd() {
 }
 
 
-int score_arrldx_usa() {
+int score_arrldx_usa(struct qso_t *qso) {
     int points;
 
     if ((countrynr == w_cty) || (countrynr == ve_cty)) {
@@ -318,7 +318,7 @@ int score_arrldx_usa() {
 }
 
 
-int score_stewperry() {
+int score_stewperry(struct qso_t *qso) {
     int points;
     double s1long, s1lat, s2long, s2lat, distance, azimuth;
 
@@ -337,7 +337,7 @@ int score_stewperry() {
 }
 
 
-int score() {
+int score(struct qso_t *qso) {
 
     int points;
 
@@ -348,7 +348,7 @@ int score() {
     }
 
     if (contest->points.type == FUNCTION) {
-	return contest->points.fn();
+	return contest->points.fn(qso);
     }
 
     if (contest->points.type == FIXED) {
@@ -356,12 +356,12 @@ int score() {
     }
 
     /* start of the universal scoring code */
-    return scoreDefault();
+    return scoreDefault(qso);
 }
 
 /* score QSO and add to total points */
-void score_qso(void) {
-    qso_points = score();		/* update qso's per band and score */
+void score_qso(struct qso_t *qso) {
+    qso_points = score(qso);		/* update qso's per band and score */
     total = total + qso_points;
 }
 

--- a/src/score.c
+++ b/src/score.c
@@ -127,8 +127,8 @@ int apply_bandweight(int points) {
 
 /* portable stations may count double
  * see PORTABLE_X2 */
-int portable_doubles(int points) {
-    if (portable_x2 && g_str_has_suffix(hiscall, "/P")) {
+int portable_doubles(int points, char *call) {
+    if (portable_x2 && g_str_has_suffix(call, "/P")) {
 	points *= 2;
     }
     return points;
@@ -213,7 +213,7 @@ int scoreDefault(struct qso_t *qso) {
 	points = scoreByContinentOrCountry(qso);
 
     points = apply_bandweight(points);
-    points = portable_doubles(points);
+    points = portable_doubles(points, qso->call);
 
     return points;
 }

--- a/src/score.c
+++ b/src/score.c
@@ -327,8 +327,8 @@ int score_stewperry(struct qso_t *qso) {
 
     points = 0;
 
-    if (strlen(comment) > 3) {
-	locator2longlat(&s1long, &s1lat, comment);
+    if (strlen(qso->comment) > 3) {
+	locator2longlat(&s1long, &s1lat, qso->comment);
 	locator2longlat(&s2long, &s2lat, my.qra);
 
 	qrb(s1long, s1lat, s2long, s2lat, &distance, &azimuth);

--- a/src/score.c
+++ b/src/score.c
@@ -221,13 +221,17 @@ int scoreDefault(struct qso_t *qso) {
 
 int score_wpx(struct qso_t *qso) {
     int points;
+
+    prefix_data *ctyinfo = getctyinfo(qso->call);
+    int countrynr = ctyinfo->dxcc_ctynr;
+
     if (countrynr == my.countrynr) {
 	points = 1;
 
 	return points;
     }
 
-    if ((strcmp(continent, my.continent) == 0)
+    if ((strcmp(ctyinfo->continent, my.continent) == 0)
 	    && (bandinx > BANDINDEX_30)) {
 	if (strstr(my.continent, "NA") != NULL) {
 	    points = 2;
@@ -238,7 +242,7 @@ int score_wpx(struct qso_t *qso) {
 	return points;
     }
 
-    if ((strcmp(continent, my.continent) == 0)
+    if ((strcmp(ctyinfo->continent, my.continent) == 0)
 	    && (bandinx < BANDINDEX_30)) {
 	if (strstr(my.continent, "NA") != NULL) {
 	    points = 4;
@@ -247,13 +251,13 @@ int score_wpx(struct qso_t *qso) {
 	}
 	return points;
     }
-    if ((strcmp(continent, my.continent) != 0)
+    if ((strcmp(ctyinfo->continent, my.continent) != 0)
 	    && (bandinx > BANDINDEX_30)) {
 	points = 3;
 
 	return points;
     }
-    if ((strcmp(continent, my.continent) != 0)
+    if ((strcmp(ctyinfo->continent, my.continent) != 0)
 	    && (bandinx < BANDINDEX_30)) {
 	points = 6;
 

--- a/src/score.c
+++ b/src/score.c
@@ -309,6 +309,8 @@ int score_arrlfd(struct qso_t *qso) {
 int score_arrldx_usa(struct qso_t *qso) {
     int points;
 
+    prefix_data *ctyinfo = getctyinfo(qso->call);
+    int countrynr = ctyinfo->dxcc_ctynr;
     if ((countrynr == w_cty) || (countrynr == ve_cty)) {
 	points = 0;
     } else {

--- a/src/score.c
+++ b/src/score.c
@@ -42,7 +42,7 @@
 #include "setcontest.h"
 #include "tlf.h"
 
-void calc_continent(int zone);
+char *calc_continent(int zone);
 
 /* check if countrynr is in countrylist */
 bool is_in_countrylist(int countrynr) {
@@ -271,9 +271,13 @@ int score_cqww(struct qso_t *qso) {
     int points;
     int zone;
 
+    prefix_data *ctyinfo = getctyinfo(qso->call);
+    int countrynr = ctyinfo->dxcc_ctynr;
+    char *continent = ctyinfo->continent;
+
     if (countrynr == 0) {
-	zone = atoi(comment);
-	calc_continent(zone);	// sets continent
+	zone = atoi(qso->comment);
+	continent = calc_continent(zone);	// sets continent
     }
 
     if (countrynr == my.countrynr) {
@@ -289,12 +293,11 @@ int score_cqww(struct qso_t *qso) {
 	    points = 1;
 	}
 
-	return points;
     } else {
 	points = 3;
-
-	return points;
     }
+
+    return points;
 }
 
 
@@ -315,6 +318,7 @@ int score_arrldx_usa(struct qso_t *qso) {
 
     prefix_data *ctyinfo = getctyinfo(qso->call);
     int countrynr = ctyinfo->dxcc_ctynr;
+
     if ((countrynr == w_cty) || (countrynr == ve_cty)) {
 	points = 0;
     } else {
@@ -380,31 +384,30 @@ int score2(char *line) {
 
 /* ----------------------------------------------------------------- */
 /* calculates continent from zone and sets 'continent' variable      */
-void calc_continent(int zone) {
+char *calc_continent(int zone) {
+    char *continent;
 
     switch (zone) {
 	case 1 ... 8:
-	    strcpy(continent, "NA");
+	    continent = "NA";
 	    break;
 	case 9 ... 13:
-	    strcpy(continent, "SA");
+	    continent = "SA";
 	    break;
 	case 14 ... 16:
-	    strcpy(continent, "EU");
+	    continent = "EU";
 	    break;
-	case 17 ... 26:
-	    strcpy(continent, "AS");
-	    break;
-	case 27 ... 32:
-	    strcpy(continent, "AS");
+	case 17 ... 32:
+	    continent = "AS";
 	    break;
 	case 33 ... 39:
-	    strcpy(continent, "AF");
+	    continent = "AF";
 	    break;
 	case 40:
-	    strcpy(continent, "EU");
+	    continent = "EU";
 	    break;
 	default:
-	    strcpy(continent, "??");
+	    continent = "??";
     }
+    return continent;
 }

--- a/src/score.c
+++ b/src/score.c
@@ -157,7 +157,8 @@ int scoreByMode() {
 int scoreByContinentOrCountry(struct qso_t *qso) {
 
     int points = 0;
-    bool inCountryList = exist_in_country_list();
+    prefix_data *ctyinfo = getctyinfo(qso->call);
+    bool inCountryList = is_in_countrylist(ctyinfo->dxcc_ctynr);
 
     if (countrylist_only) {
 	points = 0;
@@ -171,10 +172,10 @@ int scoreByContinentOrCountry(struct qso_t *qso) {
     if (continentlist_only) {
 	points = 0;
 	// only continent list allowed
-	if (is_in_continentlist(continent)) {
+	if (is_in_continentlist(ctyinfo->continent)) {
 	    USE_IF_SET(continentlist_points);
 	    // overwrite if own continent and my_cont_points set
-	    if (strcmp(continent, my.continent) == 0) {
+	    if (strcmp(ctyinfo->continent, my.continent) == 0) {
 		USE_IF_SET(my_cont_points);
 	    }
 	}
@@ -182,13 +183,13 @@ int scoreByContinentOrCountry(struct qso_t *qso) {
     }
 
     // default
-    if (countrynr == my.countrynr) {
+    if (ctyinfo->dxcc_ctynr == my.countrynr) {
 	points = 0;
 	USE_IF_SET(my_cont_points);
 	USE_IF_SET(my_country_points);
     } else if (inCountryList) {
 	USE_IF_SET(countrylist_points);
-    } else if (strcmp(continent, my.continent) == 0) {
+    } else if (strcmp(ctyinfo->continent, my.continent) == 0) {
 	USE_IF_SET(my_cont_points);
     } else
 	USE_IF_SET(dx_cont_points);

--- a/src/score.h
+++ b/src/score.h
@@ -22,14 +22,15 @@
 #ifndef _SCORE_H
 #define _SCORE_H
 #include <stdbool.h>
+#include "tlf.h"
 
 int score_wpx();
 int score_cqww();
 int score_arrlfd();
 int score_arrldx_usa();
 int score_stewperry();
-int score(void);
-void score_qso(void);
+int score(struct qso_t *qso);
+void score_qso(struct qso_t *qso);
 int score2(char *line);
 bool country_found(char prefix[]);
 bool is_in_countrylist(int countrynr);

--- a/src/searchcallarray.c
+++ b/src/searchcallarray.c
@@ -35,9 +35,6 @@
  */
 void init_worked(void) {
     memset(worked, 0, sizeof(worked));
-    for (int i = 0; i < sizeof(worked)/sizeof(worked[0]); i++) {
-	worked[i].country = -1;
-    }
     nr_worked = 0;
 }
 
@@ -66,10 +63,11 @@ int lookup_worked(char *call) {
 /* add a new entry for call to the collection */
 static int add_new(char *call) {
     int i = nr_worked;
+    prefix_data *prefix;
 
     memset(&worked[i], 0, sizeof(worked_t));
     g_strlcpy(worked[i].call, call, sizeof(worked[0].call));
-    worked[i].country = getctynr(call);
+    worked[i].ctyinfo = getctyinfo(call);
     nr_worked++;
 
     return nr_worked - 1;

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -51,14 +51,14 @@ static void showinfo_internal(int pfx_index) {
     char timebuff[80];
 
     prefix_data *pfx = prefix_by_index(pfx_index);
-    dxcc_data *dx = dxcc_by_index(pfx -> dxcc_index);
+    dxcc_data *dx = dxcc_by_index(pfx -> dxcc_ctynr);
 
     getyx(stdscr, cury, curx);
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
 
     mvaddstr(LINES - 1, 0, backgrnd_str);
 
-    if (pfx->dxcc_index > 0) {
+    if (pfx->dxcc_ctynr > 0) {
 	mvprintw(LINES - 1, 0, " %s  %s", dx->pfx, dx->countryname);
 
 	mvprintw(LINES - 1, 26, " %s %02d", pfx->continent, pfx->cq);

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -25,6 +25,7 @@
 #include <time.h>
 
 #include "hamlib/rig.h"
+#include "dxcc.h"
 
 enum {
     NO_KEYER,
@@ -164,7 +165,7 @@ typedef struct {
     char call[20]; 		/**< call of the station */
     char exchange[24]; 		/**< the last exchange */
     int band; 			/**< bitmap for worked bands */
-    int country; 		/**< its country number */
+    prefix_data *ctyinfo;	/**< pointer to country info from cty.dat */
     long qsotime[3][NBANDS];	/**< last timestamp of qso in gmtime
 				  for all modes and bands */
 } worked_t;

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -250,7 +250,7 @@ typedef struct {
 	points_type_t type;
 	union {
 	    int point;
-	    int (*fn)();
+	    int (*fn)(struct qso_t *);
 	};
     }			points;
     bool (*is_multi)();

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -155,7 +155,7 @@ void test_add_to_worked(void **state) {
     assert_string_equal(worked[0].exchange, "Hi");
     assert_int_equal(worked[0].band & inxes[BANDINDEX_10], inxes[BANDINDEX_10]);
     assert_in_range(worked[0].qsotime[trxmode][BANDINDEX_10], now, now + 1);
-    assert_int_equal(worked[0].country, getctynr("LZ1AB"));
+    assert_int_equal(worked[0].ctyinfo->dxcc_ctynr, getctynr("LZ1AB"));
 }
 
 void test_add_to_worked_continentlistonly(void **state) {

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -35,6 +35,9 @@ int getctydata(char *checkcall) {
     return 0;
 }
 
+prefix_data *getctyinfo(char *call) {
+    return NULL;
+}
 
 contest_config_t config_focm;
 struct qso_t *this_qso;

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -33,7 +33,7 @@ int get_total_score() {
     return 123;
 }
 
-void score_qso() {
+void score_qso(struct qso_t *qso) {
 }
 
 void ask(char *buffer, char *what) {

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -1,6 +1,7 @@
 #include "test.h"
 
 #include "../src/cabrillo_utils.h"
+#include "../src/dxcc.h"
 #include "../src/readcabrillo.h"
 #include "../src/cqww_simulator.h"
 
@@ -64,6 +65,10 @@ int modify_attr(int attr) { // FIXME: remove once info() moved to UI code
 
 int getctynr(char *call) {
     return 42;
+}
+
+prefix_data *getctyinfo(char *call) {
+    return NULL;
 }
 
 /* some spies */

--- a/test/test_contest.c
+++ b/test/test_contest.c
@@ -21,6 +21,10 @@ int getctydata(char *checkcall) {
     return 0;
 }
 
+prefix_data *getctyinfo(char * call) {
+    return NULL;
+}
+
 contest_config_t config_focm;
 
 int setup_default(void **state) {

--- a/test/test_dxcc.c
+++ b/test/test_dxcc.c
@@ -71,7 +71,7 @@ void test_add_prefix_check_defaults(void **state) {
     prefix_add("HW");
     pfx = prefix_by_index(0);
     assert_string_equal(pfx->pfx, "HW");
-    assert_int_equal(pfx->dxcc_index, dxcc_count() - 1);
+    assert_int_equal(pfx->dxcc_ctynr, dxcc_count() - 1);
     dxcc_data *mydx = dxcc_by_index(dxcc_count() - 1);
     assert_int_equal(pfx->cq, mydx->cq);
     assert_int_equal(pfx->itu, mydx->itu);
@@ -89,7 +89,7 @@ void test_add_prefix_check_overrides(void **state) {
     g_free(input);
     pfx = prefix_by_index(0);
     assert_string_equal(pfx->pfx, "HW");
-    assert_int_equal(pfx->dxcc_index, dxcc_count() - 1);
+    assert_int_equal(pfx->dxcc_ctynr, dxcc_count() - 1);
     assert_int_equal(pfx->cq, 11);
     assert_int_equal(pfx->itu, 22);
     assert_string_equal(pfx->continent, "OC");

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -110,7 +110,7 @@ void test_xspeed(void **state) {
 #if 0
 	printf("%d -> %s: %d\n", j, call[j], w);
 	prefix_data *pfx = prefix_by_index(w);
-	dxcc_data *dx = dxcc_by_index(pfx->dxcc_index);
+	dxcc_data *dx = dxcc_by_index(pfx->dxcc_ctynr);
 	printf("--> %s\n", dx->countryname);
 #endif
     }

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -109,6 +109,10 @@ int foc_score(char *a) {
     return 0;
 }
 
+prefix_data *getctyinfo(char * call) {
+    return NULL;
+}
+
 
 /* setup/teardown */
 int setup_default(void **state) {

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -22,7 +22,7 @@
 // OBJECT ../src/setcontest.o
 // OBJECT ../src/utils.o
 
-void calc_continent(int zone);
+char *calc_continent(int zone);
 char section[8] = "";       // defined in getexchange.c
 
 struct qso_t qso = { };
@@ -103,9 +103,9 @@ int teardown_default(void **state) {
 }
 
 void check_score_to_continent(int i, char * cont) {
-    strcpy(continent, "");
-    calc_continent(i);
-    assert_string_equal(continent, cont);
+    strcpy(continent, "abc");
+    assert_string_equal(calc_continent(i), cont);
+    assert_string_equal(continent, "abc"); /* do not touch 'continent' */
 }
 
 void test_calc_continent(void **state) {
@@ -165,21 +165,19 @@ void test_wpx(void **state) {
 void test_cqww(void **state) {
     setcontest("cqww");
 
-    countrynr = my.countrynr;
-    check_points(0);
+    check_call_points("DL3ABC", 0);
 
-    countrynr = 2;
-    strcpy(continent, "EU");
     strcpy(my.continent, "EU");
-    check_points(1);
+    check_call_points("HB9ABC", 1);
 
-    strcpy(continent, "NA");
     strcpy(my.continent, "NA");
-    check_points(2);
+    check_call_points("XE1ABC", 2);
 
-    strcpy(continent, "EU");
     strcpy(my.continent, "NA");
-    check_points(3);
+    check_call_points("PY2ABC", 3);
+
+    qso.comment = "19";		    /* CQ Zone 19 => AS */
+    check_call_points("HB9ABC/mm", 3);
 }
 
 void test_arrl_fd(void **state) {

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -30,8 +30,7 @@ struct qso_t qso = { };
     do{ assert_int_equal(score(&qso), point); }while(0)
 
 #define check_call_points(thecall,point) \
-    do{ strcpy(hiscall, thecall); \
-	qso.call = g_strdup(thecall); \
+    do{ qso.call = g_strdup(thecall); \
 	assert_int_equal(score(&qso), point); \
 	g_free(qso.call); \
 	qso.call = NULL; }while(0)

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -47,23 +47,17 @@ int __wrap_foc_score() {
 }
 #endif
 
-int setup(void **state) {
-
-    strcpy(my.qra, "jo60lx");
-
-    strcpy(my.continent, "EU");
-
-    my.countrynr = 95;   /* DL */
-
-    trxmode = CWMODE;
-
-    return 0;
-}
 
 int setup_default(void **state) {
 
     static char filename[] =  TOP_SRCDIR "/share/cty.dat";
     assert_int_equal(load_ctydata(filename), 0);
+
+    strcpy(my.qra, "jo60lx");
+    strcpy(my.continent, "EU");
+    my.countrynr = getctynr("DL");
+
+    trxmode = CWMODE;
 
     setcontest("qso");
 
@@ -81,8 +75,6 @@ int setup_default(void **state) {
     continentlist_only = false;
     continentlist_points = -1;
     strcpy(continent_multiplier_list[0], "");
-
-    strcpy(my.continent, "EU");
 
     lowband_point_mult = false;
     portable_x2 = false;

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -53,8 +53,6 @@ int setup(void **state) {
     strcpy(my.continent, "EU");
 
     my.countrynr = 95;   /* DL */
-    w_cty = 184;        /* W */
-    ve_cty = 283;       /* VE */
 
     trxmode = CWMODE;
 
@@ -190,14 +188,11 @@ void test_simple_points(void **state) {
 void test_arrldx_usa(void **state) {
     setcontest("arrldx_usa");
 
-    countrynr = w_cty;
-    check_points(0);
+    check_call_points("W3ABC",0);
 
-    countrynr = ve_cty;
-    check_points(0);
+    check_call_points("VE2ABC",0);
 
-    countrynr = my.countrynr;
-    check_points(3);
+    check_call_points("DL3ABC",3);
 }
 
 void test_ssbcw(void **state) {

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -24,12 +24,14 @@
 
 char section[8] = "";       // defined in getexchange.c
 
+struct qso_t qso = { };
+
 #define check_points(point) \
-    do{ assert_int_equal(score(), point); }while(0)
+    do{ assert_int_equal(score(&qso), point); }while(0)
 
 #define check_call_points(call,point) \
     do{ strcpy(hiscall, call); \
-	assert_int_equal(score(), point); }while(0)
+	assert_int_equal(score(&qso), point); }while(0)
 
 void clear_display() {}
 

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -29,9 +29,12 @@ struct qso_t qso = { };
 #define check_points(point) \
     do{ assert_int_equal(score(&qso), point); }while(0)
 
-#define check_call_points(call,point) \
-    do{ strcpy(hiscall, call); \
-	assert_int_equal(score(&qso), point); }while(0)
+#define check_call_points(thecall,point) \
+    do{ strcpy(hiscall, thecall); \
+	qso.call = g_strdup(thecall); \
+	assert_int_equal(score(&qso), point); \
+	g_free(qso.call); \
+	qso.call = NULL; }while(0)
 
 void clear_display() {}
 
@@ -86,19 +89,11 @@ int setup_default(void **state) {
     lowband_point_mult = false;
     portable_x2 = false;
 
-    return 0;
-}
-
-int setup_ssbcw(void **state) {
-
-    setup_default(state);
-
-    static char filename[] =  TOP_SRCDIR "/share/cty.dat";
-    assert_int_equal(load_ctydata(filename), 0);
+    ssbpoints = 0;
+    cwpoints = 0;
 
     return 0;
 }
-
 
 void test_dupe(void **state) {
     dupe = 1;
@@ -227,6 +222,7 @@ void test_ssbcw(void **state) {
     portable_x2 = true;
     check_call_points("DL3XYZ", 6);
     check_call_points("DL3XYZ/P", 12);
+    portable_x2 = false;
 
     trxmode = DIGIMODE;
     check_points(0);

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -22,6 +22,7 @@
 // OBJECT ../src/setcontest.o
 // OBJECT ../src/utils.o
 
+void calc_continent(int zone);
 char section[8] = "";       // defined in getexchange.c
 
 struct qso_t qso = { };
@@ -99,6 +100,33 @@ void test_dupe(void **state) {
 
 int teardown_default(void **state) {
     return 0;
+}
+
+void check_score_to_continent(int i, char * cont) {
+    strcpy(continent, "");
+    calc_continent(i);
+    assert_string_equal(continent, cont);
+}
+
+void test_calc_continent(void **state) {
+    check_score_to_continent(0, "??");
+    for (int i = 1; i < 9; i++) {
+	check_score_to_continent(i, "NA");
+    }
+    for (int i = 9; i < 14; i++) {
+	check_score_to_continent(i, "SA");
+    }
+    for (int i = 14; i < 17; i++) {
+	check_score_to_continent(i, "EU");
+    }
+    for (int i = 17; i < 33; i++) {
+	check_score_to_continent(i, "AS");
+    }
+    for (int i = 33; i < 40; i++) {
+	check_score_to_continent(i, "AF");
+    }
+    check_score_to_continent(40, "EU");
+    check_score_to_continent(41, "??");
 }
 
 

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -107,34 +107,29 @@ void test_wpx(void **state) {
     pfxmult = false;
 
     /* same country */
-    countrynr = my.countrynr;
-    check_points(1);
+    check_call_points("DL3ABC",1);
 
     /* different continents */
-    countrynr = 2;
-    strcpy(continent, "AF");
     bandinx = BANDINDEX_20;
-    check_points(3);
+    check_call_points("ZS6ABC",3);
 
     bandinx = BANDINDEX_40;
-    check_points(6);
+    check_call_points("ZS6ABC",6);
 
     /* same continent, not NA */
-    strcpy(continent, my.continent);
     bandinx = BANDINDEX_20;
-    check_points(1);
+    check_call_points("HB9ABC",1);
 
     bandinx = BANDINDEX_40;
-    check_points(2);
+    check_call_points("HB9ABC",2);
 
     /* same continent, NA */
     strcpy(my.continent, "NA");
-    strcpy(continent, my.continent);
     bandinx = BANDINDEX_20;
-    check_points(2);
+    check_call_points("VE3ABC",2);
 
     bandinx = BANDINDEX_40;
-    check_points(4);
+    check_call_points("VE3ABC",4);
 
 }
 

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -88,6 +88,9 @@ int getctydata(char *checkcallptr) {
     return 0;
 }
 
+prefix_data *getctyinfo(char *call) {
+    return NULL;
+}
 
 contest_config_t config_focm;
 

--- a/test/test_workedstations.c
+++ b/test/test_workedstations.c
@@ -2,16 +2,19 @@
 
 #include <time.h>
 
+#include "../src/dxcc.h"
 #include "../src/searchcallarray.h"
 #include "../src/bands.h"
 #include "../src/globalvars.h"
 
+// OBJECT ../src/dxcc.o
 // OBJECT ../src/searchcallarray.o
 // OBJECT ../src/bands.o
 
+prefix_data pfx_dummy = { };
 
-int getctynr(char *call) {
-    return 42;
+prefix_data *getctyinfo(char * call) {
+    return &pfx_dummy;
 }
 
 time_t get_time() {
@@ -52,7 +55,7 @@ int setup_default(void **state) {
 void test_init(void **state) {
     init_worked();
     assert_int_equal(nr_worked, 0);
-    assert_int_equal(worked[0].country, -1);
+    assert_ptr_equal(worked[0].ctyinfo, NULL);
 }
 
 /* test index lookup entry*/


### PR DESCRIPTION
Do no longer use global variables to provide qso information to scoring functions. Rely only on information from actual parameter 'struct qso_t *qso'.

