### PR TITLE
Fix display of call input field length

### DIFF
--- a/src/printcall.c
+++ b/src/printcall.c
@@ -39,7 +39,7 @@ void printcall(void) {
 
     attron(COLOR_PAIR(C_INPUT) | attrib);
 
-    mvaddstr(12, 29, "            ");
+    mvaddstr(12, 29, spaces(MAX_CALL_LENGTH));
     mvaddstr(12, 29, hiscall);
     if ((cqmode == CQ) && (cwstart > 0))
 	mvchgat(12, 29 + cwstart, 12 - cwstart,


### PR DESCRIPTION
Found in #306: call input field length is shown too short. Input actually works correctly, just the background highlight was one character off.

Here the editing field shows the 13 character size:
![image](https://user-images.githubusercontent.com/15141948/151669711-58d42885-00e5-4027-89c1-80fc0478f40d.png)
