### PR TITLE
Fix spelling errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -49,7 +49,7 @@
   startup  * Do no longer slow down display of infos. Instead ask for
   continuation before clearing the screen. That gives time to read the
   messages.  * Message display checks for enough room to display. If screen
-  gets full clear and start enew from above (after a small delay or
+  gets full clear and start anew from above (after a small delay or
   confirmation).
 
   * src/getmessages.c, src/getmessages.h, src/main.c: Refactor check for first
@@ -70,7 +70,7 @@
   src/logit.c: Fix Simulator mode for CQWW contest.  - Fix sidetone management
   (Do not change own frequency during QSO and make random change of sidetone
   for other station  working  - Add a little timing space before getting called
-  by other station  - Refactor managment of simulation stages  - Improve logic
+  by other station  - Refactor management of simulation stages  - Improve logic
   to turn on/off of simulator mode
 
 2019-07-19  Thomas Beierlein <tomjbe@gentoo.org>
@@ -152,7 +152,7 @@
   * src/err_utils.c, src/getwwv.c, src/lancode.c, src/lancode.h,
   src/showinfo.c, src/splitscreen.c: Display of infos and errors always on
   bottom line of window.  Fix the display position for the following items:  -
-  error messages - infoline with country informations - new WWV/WCY
+  error messages - infoline with country information - new WWV/WCY
   announcements - talk command input - send cluster command
 
 2019-05-05  Thomas Beierlein <tomjbe@gentoo.org>
@@ -242,7 +242,7 @@
   * src/lancode.c, src/parse_logcfg.c, tlf.1.in: Add lan port config directive 
   - Allows to specify on which port number TLF is listening for incoming
   broadcasts from other instances.  - Allows even to run multiple instances of
-  TLF  on teh same server.
+  TLF  on the same server.
 
 2019-01-05  Thomas Beierlein <tomjbe@gentoo.org>
 
@@ -327,7 +327,7 @@
   places.  - Adapt checklogfile() for use with logedit() Do not exit program if
   file not found. Use ncurses for all text output.  - Use existing
   checklogfile() to check the log after editing Original code was a copy of
-  that funtion with small adaption wrt text output and error handling.  Be
+  that function with small adaption wrt text output and error handling.  Be
   aware that the functionality is still broken as before.
 
 2018-12-05  zcsahok <ha5cqz@freemail.hu>
@@ -487,7 +487,7 @@
   offset. showinfo() now needs a prefix, so create add a getctydata_pfx()
   function which returns the prefix rather than the country.  If a callsign in
   cty.dat starts with an '=', it will only use exact matching, not prefix
-  matching.  To allow backward compatability, Tlf remembers if it saw any '='
+  matching.  To allow backward compatibility, Tlf remembers if it saw any '='
   prefixes and if so, find_full_match() will only match those.  If there were
   no '=' prefixes, the behaviour is as before, and it will match any prefix.
 
@@ -683,7 +683,7 @@
 2017-12-26  Ervin Hegedus <airween@gmail.com>
 
   * src/logit.c: Removed the cleanup() from the end of the change_mode()  In
-  case of SPRINTMODE the TU_MESSAGES was cutted by the cleanup(). That is
+  case of SPRINTMODE the TU_MESSAGES was cut by the cleanup(). That is
   wrong.
 
 2017-12-26  zcsahok <ha5cqz@freemail.hu>
@@ -847,7 +847,7 @@
 2017-02-09  Thomas Beierlein <tomjbe@gentoo.org>
 
   * src/dxcc.c, src/dxcc.h: make usage of function more secure  Only non
-  negativ indices allowed. Check for out of bounds index. Return empty dummy
+  negative indices allowed. Check for out of bounds index. Return empty dummy
   data if no element found.
 
 2017-02-19  Thomas Beierlein <tomjbe@gentoo.org>
@@ -1127,7 +1127,7 @@
 
 2016-05-04  Thomas Beierlein <tb@forth-ev.de>
 
-  * src/checklogfile.c: fix possible ressource leaks
+  * src/checklogfile.c: fix possible resource leaks
 
 2016-05-03  Thomas Beierlein <tomjbe@gentoo.org>
 
@@ -1169,7 +1169,7 @@
 2016-03-03  Thomas Beierlein <tomjbe@gentoo.org>
 
   * src/bandmap.c, src/bandmap.h, src/callinput.c: Implement BMAUTOGRAB  If set
-  callinput field will automatically grab an active spot from teh bandmap if
+  callinput field will automatically grab an active spot from the bandmap if
   TRX frequency is near spot frequency.  Works only in S&P mode.
 
 2016-02-10  Thomas Beierlein <tomjbe@gentoo.org>
@@ -1337,7 +1337,7 @@
 
   * src/addmult.c, src/addmult.h, src/main.c: cleanup logic 
   init_and_load_multipliers is now responsible for (freeing and new) allocation
-  of the mults_possible array. It now handles empty multplier filenames
+  of the mults_possible array. It now handles empty multiplier filenames
   gracefully by giving back an empty mults_possible array. The former check for
   naming the file is now the responsibility of the calling function (if
   needed).
@@ -1387,7 +1387,7 @@
 
   * configure.ac, src/Makefile.am: Update Fldigi XML RPC stanza in configure.ac
    The Autoconf documentation states that LIBS and CFLAGS are reserved for the
-  user.  Refactor the Fldigi XML RPC stanza to avoid assigment to those
+  user.  Refactor the Fldigi XML RPC stanza to avoid assignment to those
   precious variables.  Instead assign new LIBXMLRPC_LIB, LIBXMLRPC_CLIENT_LIB,
   and LIBXMLRPC_UTIL_LIB to tlf_LDDADD in src/Makefile.am.  Define the
   HAVE_LIBXMLRPC, HAVE_LIBXMLRPC_CLIENT, and HAVE_LIBXMLRPC_UTIL macros for
@@ -1396,7 +1396,7 @@
 
   * configure.ac, src/Makefile.am: Update Hamlib stanza in configure.ac  The
   Autoconf documentation states that LIBS and CFLAGS are reserved for the user.
-   Refactor the Hamlib stanza to avoid assigment to those precious variables. 
+   Refactor the Hamlib stanza to avoid assignment to those precious variables. 
   Instead assign the HAMLIB_CFLAGS and HAMLIB_LIBS generated by the pkg-config
   macro to AM_CFLAGS and tlf_LDDADD in src/Makefile.am respectively.  Also use
   standard Autoconf macros instead of raw shell if conditional and complete
@@ -1544,7 +1544,7 @@
   src/sendqrg.h:25:# include <config.h>
   src/sendqrg.h:29:# include <hamlib/rig.h>  
   
-  This minimizes, but doesn't entirely eliminate depedency chains when
+  This minimizes, but doesn't entirely eliminate dependency chains when
   including certain header files.  All local header files should have include
   guards so multiple include directives should not cause an error.
 
@@ -1564,7 +1564,7 @@
   * src/bandmap.c: fix calculation of remaining time during bandmap read 
   Lastly spot->timeout got changed to unsigned. We must take care that we do
   not get a wrap around if the diff between writing und reading the bandmap
-  data ist to big.
+  data is too big.
 
   * src/bandmap.c, src/bandmap.h, src/time_update.c: Fix saving of bandmap data
    Bandmap data are saved every 10s. It works now even if the bandmap is not
@@ -2078,7 +2078,7 @@
   * src/getmessages.c, src/main.c, src/muf.c, src/qrb.c, src/qrb.h,
   src/showinfo.c, src/showinfo.h: cleanup qrb calculation  - change internal
   representation of station coordinates from string to double numbers - drop
-  usage of global variables and make them local funtion parameters - cleaunp
+  usage of global variables and make them local function parameters - cleaunp
   include files - add include guard
 
 2014-06-17  Thomas Beierlein <tb@forth-ev.de>
@@ -2400,7 +2400,7 @@
 
   * src/gettxinfo.c, src/sendqrg.c: call 'rig_get_vfo' before using
   RIG_VFO_CURR  
-  - allows to switch VFO on the rig without loosing control by tlf. 
+  - allows to switch VFO on the rig without losing control by tlf. 
     Tnx HA2OS for help.
 
 2013-12-28  airween <airween@gmail.com>
@@ -2786,7 +2786,7 @@
 
 2013-01-06  Thomas Beierlein <tomjbe@gentoo.org>
 
-  * src/parse_logcfg.c, tlf.1.in: Reduce minimal livetime for bandmap entries
+  * src/parse_logcfg.c, tlf.1.in: Reduce minimal lifetime for bandmap entries
   to 30s (requested by DH5YM)
 
 2012-12-12  Thomas Beierlein <tomjbe@gentoo.org>
@@ -3205,7 +3205,7 @@
 
 2012-06-06  Thomas Beierlein <tb@forth-ev.de>
 
-  * configure.in: Abort configure if ncurses libs not vailable. Tnx Jens DK2AB
+  * configure.in: Abort configure if ncurses libs not available. Tnx Jens DK2AB
   for pointing it out.
 
 2012-05-19  Thomas Beierlein <tomjbe@gentoo.org>
@@ -3390,7 +3390,7 @@
 
 2011-12-13  Thomas Beierlein <tomjbe@gentoo.org>
 
-  * src/parse_logcfg.c: divide livetime by 2 as aging is done every two seconds
+  * src/parse_logcfg.c: divide lifetime by 2 as aging is done every two seconds
 
   * src/parse_logcfg.c: allow configuration of bandmap filtering in logcfg.dat 
 
@@ -3421,7 +3421,7 @@
   Fix use of 'miniterm' variable  - clean old code - add comments - save and
   restore variable if temporary disabled
 
-  * New_Bandmap.txt: Add some additional informations describing the new
+  * New_Bandmap.txt: Add some additional information describing the new
   bandmap functions.
 
   * src/callinput.c, src/grabspot.c: Fix calculation of zone and prefix for
@@ -3453,7 +3453,7 @@
   results for ARRL SS  - displayed on lower line of Search panel again
 
   * src/searchlog.c: fix display of needed sections  - readcalls cuts always 3
-  char to worked mults[] fro some contests - ignore possible trailing spaces in
+  char to worked mults[] for some contests - ignore possible trailing spaces in
   compare
 
   * src/clear_display.c: display contest name on info line
@@ -4115,7 +4115,7 @@
 	* added command to logcfg.dat:
 		FIFO_INTERFACE
 	  this starts a FIFO called clfile in the working directory for
-		added flexibility and backward compatability with previous
+		added flexibility and backward compatibility with previous
 		versions
 
 2002-08-08  rein couperus   <rein@couperus.com>
@@ -4162,7 +4162,7 @@
 
 	* main.c:		added load partials from disk
 
-	* time_update.c		removed disk acces to logfile every 5 secs
+	* time_update.c		removed disk access to logfile every 5 secs
 
 	* score.c		changed cqww scoring (2 pts within NA)
 

--- a/NEWS
+++ b/NEWS
@@ -22,7 +22,7 @@ New features:
     - Drop hard coded editor programs. You can name any editor program 
       to use in the EDITOR= keyword. If none set TLF uses the $EDITOR 
       from environment.
-      The Logfile gets automaticlly reloaded after editing.
+      The Logfile gets automatically reloaded after editing.
     - HA5CQZ provided a good solution to extend the memory TX functionality.
       Besides frequency the memory now also remembers the working mode.
       That allows to just grab a announced station, work it in S&P mode and
@@ -42,7 +42,7 @@ New features:
 
 Bug fixes:
     - There are two major fixes for bugs in the scoring logic:
-      - For US/VE stations runnin ARRLDX contest intra W/VE qso were counted
+      - For US/VE stations running ARRLDX contest intra W/VE qso were counted
 	which was wrong. New code correctly scores these contacts with 0
 	points and does not count it as multi.
       - If you running TLF in CQWW 2 TX mode QSO from other stations on LAN
@@ -113,7 +113,7 @@ Minor corrections:
 Bug fixes:
     - Fix segmentation violation if RIGPORT is undefined in logcfg.dat
     - Fixes some test programs
-    - fix warnigns from clang about taking an abs() from an unsigned number
+    - fix warnings from clang about taking an abs() from an unsigned number
 
 
 tlf-1.3.1
@@ -346,7 +346,7 @@ New features:
       as soon as you get at least one QTC from the station.
       The flags will be stored in a separated file, called
       QTC_meta.log. If you exit from Tlf, and you start it again
-      later, the marked informations will be available.
+      later, the marked information will be available.
     - stations which can give still more QTC's will not be marked as 
       dupe on the bandmap
     - Set QTC_AUTO_FILLTIME keyword in logcfg.dat to automatically fill in the 
@@ -478,7 +478,7 @@ New features:
         + backspace  delete char left from cursor 
         + any non control char   insert if string not to long
     - Reworked autosend feature
-      * starts sending call automatically after entereing 2..5 characters
+      * starts sending call automatically after entering 2..5 characters
         of the call in RUN mode
       * Enable it via ':char' command (accepts 0 (off) or 2..5 as 
         number of characters before autosend start).
@@ -517,7 +517,7 @@ tlf-1.1.6
 Minor maintenance and bugfix release.
 
 New features:
-    - Reduce minimal livetime for bandmap entries to 30s (requested by DH5YM)
+    - Reduce minimal lifetime for bandmap entries to 30s (requested by DH5YM)
     - Update ARRL Field Day rules and arrlsections file. Tnx Nate N0NB.
     - New NO_RST keyword (backported from from tlf-1.2.0 branch). Use it for
       contests which do not exchange and record RS/RST (e.g. ARRL Field Day 
@@ -561,7 +561,7 @@ New features:
     - Report line number for badly formatted lines in initial exchange file.
       That makes it easier to find the problem for files with a lot of entries.
       Thanks Mario DH5YM for reporting the problem.
-    - Allow to set SIDETONE_VOLUME to 0 independent from choosen sidetone
+    - Allow to set SIDETONE_VOLUME to 0 independent from chosen sidetone
       device. Due to a bug in cwdaemon-0.9.4 setting SIDETONE to 0 switches
       off the sidetone but also the keying. So please...
       !!! Set SIDETONE_VOLUME = 0 to switch off sidetone output !!!
@@ -673,7 +673,7 @@ Minor maintenance release.
 New features:
     - Add ARRL 10m Contest rules for DX stations.
     - Provide more actual multiplier files for arrldx and arrl10m contests.
-    - Add a better recognition of unkown keywords in config file.
+    - Add a better recognition of unknown keywords in config file.
 
 Bug fixes:
     - Fix recongnition of COUNTRY_LIST keyword.
@@ -1273,7 +1273,7 @@ tlf-0.9.4
 	tlf seg faults when switching from the NEEDED band map to the 
 	spot list with very large band maps (the 10m bandmap had 150 entries 
 	during cqwwssb sunday afternoon)
-	ce0y/sp9spt shows up as Poland instad of Easter Island...
+	ce0y/sp9spt shows up as Poland instead of Easter Island...
 
 tlf-0.9.3
 =========
@@ -1455,7 +1455,7 @@ tlf-0.8.21
 tlf-0.8.20
 ==========
 
-- Made tlf compatible wit hamlib-1.1.4 (new rig.h).
+- Made tlf compatible with hamlib-1.1.4 (new rig.h).
 
 - Added fast startup (now default).
 
@@ -1604,7 +1604,7 @@ Bug/unwanted feature fixes:
   QSO's in SCORE window is wrong (QSO's count decremented while it
   shouldn't)
 
-- when call field is empty, is TAB suposed to give a zone?
+- when call field is empty, is TAB supposed to give a zone?
 
 - when editing last QSO '@', if I go right (with -> key) till end of line,
   I'm stuck on next line. Actually, If you enter "ggggggggggggggggggggggggg"
@@ -1790,7 +1790,7 @@ tlf-0.7.0 beta test version with hamlib-1.1.3 integration
 
 - add spot (ctrl-A) adds call in call field to bandmap
 
-- frequency conrol (ctrl-F): up/down arrow for 100 Hz, left/right arrow 20 Hz steps.
+- frequency control (ctrl-F): up/down arrow for 100 Hz, left/right arrow 20 Hz steps.
 	escape goes back to normal mode
 
  - mode switch :SSB now gives right side band (USB, LSB)
@@ -1917,7 +1917,7 @@ Major changes with respect to version  tlf-0.5.0 are:
 It is now possible to create your own contest. E.g. for the r1fieldday you can
 enter the following in logcfg.dat:
 
-#dissable all standard contests
+#disable all standard contests
 CONTEST=fieldday
 COUNTRY_MULT 		(dxcc countries = multiplier)
 2EU3DX_POINTS 		(2 points for qso's in own continent, 3 for DX)

--- a/doc/FAQ
+++ b/doc/FAQ
@@ -19,7 +19,7 @@ A: Try https://www.country-files.com/ Make sure to save it as 'cty.dat' in
    * For version before TLF-1.3.1 you have to use the old style CTY.DAT file
      with no embedded '=' character.
    * For newer versions you can also use the newer file format also used by
-     >=CT9.91. It allows to give informations not only for call areas but
+     >=CT9.91. It allows to give information not only for call areas but
      for single stations with a call sign preceded by a '=' character. (See
      http://www.country-files.com/cty-dat-format/ for details).
      

--- a/doc/New_Bandmap.txt
+++ b/doc/New_Bandmap.txt
@@ -4,7 +4,7 @@ New Bandmap in TLF-1.1
 One main poblem in old TLF versions is the very narrow space for cluster
 messages (only 8 entries plus some room in scrolling). Furthermore the code
 for looking up the messages was very inefficient and does not allow good
-filtering of the informations we need.
+filtering of the information we need.
 
 The new bandmap tries to fix some of the problems. The following principles
 were applied:
@@ -56,7 +56,7 @@ or both conditions are not met). Wait some moments until some spots shows up.
   If you reach the last station (highest frequency) the scan switches
   direction and following key presses goes downward (on lower boundary it
   switches to upwards again...).
-  !!! At the moment Ctrl-G requires a connected tranceiver to work correctly as 
+  !!! At the moment Ctrl-G requires a connected transceiver to work correctly as 
   it reads the actual starting frequency from the rig !!!
 - If you type some letters of a call in the map you are interested in and 
   then 'Alt-G' afterwards the first call with that letters gets grabbed. 
@@ -66,9 +66,9 @@ or both conditions are not met). Wait some moments until some spots shows up.
   You can switch back to your old running frequency by '+' (back to Run mode) 
   and '#' (back to old frequency)
 
-You can also configure bandmap filtering and spot livetime from logcfg.dat 
+You can also configure bandmap filtering and spot lifetime from logcfg.dat 
 
-- BANDMAP -> use default values (no filtering, livetime = 900 s)
+- BANDMAP -> use default values (no filtering, lifetime = 900 s)
 - BANDMAP=<xyz>,<number>
   <xyz> string parsed for
   'B' - only own band
@@ -76,6 +76,6 @@ You can also configure bandmap filtering and spot livetime from logcfg.dat
   'D' - do not show dupes
   'S' - skip dupes during grab_next (ctrl-g)
   'O' - only shows the multipliers (CQWW only)
-  <number> livetime for new spots in second (number >=300)
+  <number> lifetime for new spots in second (number >=300)
 
 

--- a/doc/README.Cabrillo
+++ b/doc/README.Cabrillo
@@ -78,7 +78,7 @@ then this line has to be added to the format:
 
 EXCHANGE-SEPARATOR=/
 
-In the provided cabrillo.fmt file the formats for AGCW use this contruct.
+In the provided cabrillo.fmt file the formats for AGCW use this construct.
 
 
 Example

--- a/doc/README.RTTY
+++ b/doc/README.RTTY
@@ -18,11 +18,11 @@ Let's see, how works the TX direction with Fldigi.
 
 Important: if you set up your Fldigi instance, don't set up your
 RIG! Tlf needs to handle the RIG, because it needs to tune the VFO,
-to use the bandmap. After the version 1.3, Tlf can controlls Fldigi,
+to use the bandmap. After the version 1.3, Tlf can controls Fldigi,
 then it can be show the QRG (frequency of RIG - see later), and
 mode of RIG (eg: LSB, USB, FSK).
 
-Starting with TLF-1.3 there are two ways to comunicate with Fldigi -
+Starting with TLF-1.3 there are two ways to communicate with Fldigi -
 the old GMFSK interface and the actual XMLRPC one. Note, that after
 version 1.3 the GMFSK works as standalone interface, but can't work
 with Fldigi.
@@ -52,17 +52,17 @@ You can still read of Fldigi RX window (top) in Tlf own terminal,
 just use ":miniterm" command in callsign field.
 
 There is a new command: ":fldigi", which helps to you to turn on and
-off Fldigi communication. Then you don't need to modifiy the logcfg.dat
+off Fldigi communication. Then you don't need to modify the logcfg.dat
 to change your mode.
 
-Note: in old versions of Tlf, you could't use NETKEYER and FLDIGI in
+Note: in old versions of Tlf, you couldn't use NETKEYER and FLDIGI in
 same time. Now this restriction is gone, you can use them in same time.
 
 The RX mode is a slightly difficult. I don't want to expose that
 here, I suppose that anybody knows that, if works in RTTY. I had
 a "big" problem with Tlf: when I've worked in AFSK, and I moved the
-Fldigi carrier, I could't know exactly, what is the correct QRG of
-my RIG. And it was the problem, because I could't use the cluster
+Fldigi carrier, I couldn't know exactly, what is the correct QRG of
+my RIG. And it was the problem, because I couldn't use the cluster
 info, moreover the grabbed spots! So, when I grabbed a station, TLF
 stored it to the currently QRG, but it didn't stored the Fldigi
 carrier shift! So, now the Tlf follows this philosophy below.
@@ -75,7 +75,7 @@ space is 2125Hz, the mark is 2295Hz. 2295-2125 = 170, 170/2 = 85,
 and 2125+85 = 2210. This value is indicated at bottom-middle of
 Fldigi window.
 
-Note, that you have to swith the Fldigi to reverse mode, so you need
+Note, that you have to switch the Fldigi to reverse mode, so you need
 to push the [Rv] button.
 
 From now on if you find a station on the bandmap, and press the
@@ -98,14 +98,14 @@ Fldigi carrier's frequency, and tune the RIG. That's it.
 
 Error handling: if you forgot to start the Fldigi, or you close that
 till Tlf runs and wants to communicate with it, Tlf tries to connect.
-After ten (10) continuous unsuccessful attemtp Tlf will show you the
+After ten (10) continuous unsuccessful attempt Tlf will show you the
 error message (at bottom left corner): "Fldigi: lost connection", and
 turns it off. If you want to turn on again, just type ":fldigi"
 command in CALLSIGN field. If Fldigi comes back after less, than ten
 attempt, the error counter cleared.
 
 More new feature in Fldigi interface:
-- when Tlf sends a message throug Fldigi, it switches Fldigi to TX mode.
+- when Tlf sends a message through Fldigi, it switches Fldigi to TX mode.
 - similar to CW mode, if you press ESC while Fldigi sends the message,
   Tlf will stop it.
 - if the connection between Tlf and Fldigi breaks (eg. you close

--- a/doc/README.ssb
+++ b/doc/README.ssb
@@ -48,12 +48,12 @@ If you have adopted the method that loops back the mic audio and you want to
 automatically mute the mic when voice keyer messages are played, copy the
 'play_vk' shell script found in the 'scripts' directory of your TLF release to
 the same directory. This will then be used in preference to the default.
-Uncomment the lines begining with 'amixer'.
+Uncomment the lines beginning with 'amixer'.
 
 Since tlf-1.1.0, (un)muting and playing voice messages has been devolved to this
 external script file, because not all soundcards offer the same interface. 'Mic'
 could be called something else. One way of finding this out is to run 'amixer'
-from a terminal whch returns its capabilities. An alternative method is to
+from a terminal which returns its capabilities. An alternative method is to
 install your distro's version of the 'alsamixergui' package and simply see
 what's available on the faders. This is probably a good idea anyway because it's
 likely sound won't work without some manual intervention.

--- a/doc/README_QTC.txt
+++ b/doc/README_QTC.txt
@@ -81,7 +81,7 @@ isn't a mandatory order, but the navigation keys doesn't works in
 all cases. Normally, with TAB you can move to the next field,
 and Shift+TAB goes back. 
 There is an exception: TAB will notleave the current QSO line, 
-untill you confirm the line. Instead it takes you to the time field, 
+until you confirm the line. Instead it takes you to the time field, 
 if you are in the exchange field, and Shift+TAB does it in reverse order.
 With UP and DOWN cursor keys you can go to up or down.
 
@@ -96,7 +96,7 @@ Navigation in a field
 If you press an allowed character in a field, that will be
 displayed, and the cursor will go right to the next place. If you
 press a not allowed character, then nothing happens. The
-BACKSPACE key deletes the next charaters to left, and move the
+BACKSPACE key deletes the next characters to left, and move the
 right part to left. DELETE key deletes the current character as
 you're staying, and shifts the characters to left at the next to
 right. As I described above, the SPACE move the cursor to the next
@@ -174,7 +174,7 @@ When you received a QTC, the cursor goes to the start of the
 next line, and you can continue to receive QTC.
 
 If you received the last line, and all lines are complete,
-after teh last ENTER Tlf will close the QTC window, and send 
+after the last ENTER Tlf will close the QTC window, and send 
 "QSL ALL" message to the station.
 
 At this time the QTC data will be written to the logfile on 

--- a/doc/README_QTC_RTTY.txt
+++ b/doc/README_QTC_RTTY.txt
@@ -33,7 +33,7 @@ in logcfg.dat/rule file, which is "BOTH".
 Receiving QTC
 =============
 Even if you choose the two-way QTC handling, or you just want to
-receive QTCs, the CTRL-Q combinaton remaining to receive the
+receive QTCs, the CTRL-Q combination remaining to receive the
 QTC block. If you open the QTC receive window with CTRL-Q,
 apparently nothing has changed. The point is same than in another
 modes: fill the lines. Yes, the speed of RTTY is a little bit
@@ -91,7 +91,7 @@ sign. That mean, you couldn't capture that anymore.
 
 STILL IMPORTANT!
 If you fill the serial and number fields in main QTC window, the first
-pattern WILL NOT recogized (SERIAL/NR).
+pattern WILL NOT be recognized (SERIAL/NR).
 If you didn't fill the serial AND number fields (with or without the
 capture process), you CAN'T capture the QTC lines! That mean, you press
 ENTER on a QTC line at right side vainly, the line will not copied to

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -251,12 +251,12 @@ gint	cmp_size(char **a, char **b) {
 }
 
 
-/* parse a mult line and add data to databse
+/* parse a mult line and add data to database
  *
  * multline consists of either
  *   multiplier
  * or
- *   multplier:followed,by,comma,separated,list,of,aliases
+ *   multiplier:followed,by,comma,separated,list,of,aliases
  *
  * There may be more than one alias line for a multi, so add all aliases to
  * that multi */
@@ -400,7 +400,7 @@ void init_mults() {
  *			(-1 if multiplier is an empty string or not new)
  */
 int remember_multi(char *multiplier, int band, int show_new_band) {
-    /* search multbuffer in mults arry */
+    /* search multbuffer in mults array */
     int found = 0, i, index = -1;
 
     if (*multiplier == '\0')

--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -74,7 +74,7 @@ bm_config_t bm_config = {
     1,  /* show all mode */
     1,  /* show dupes */
     1,	/* skip dupes during grab */
-    900,/* default livetime */
+    900,/* default lifetime */
     0  /* DO NOT show ONLY multipliers */
 };
 
@@ -188,7 +188,7 @@ void bmdata_read_file() {
 
 /** \brief initialize bandmap
  *
- * initalize colors and data structures for bandmap operation
+ * initialize colors and data structures for bandmap operation
  */
 void bm_init() {
 
@@ -543,7 +543,7 @@ void bm_show_info() {
 
 /* helper function for bandmap display
  * mark entries according to age, source and worked state. Mark new multis
- * - new 	brigth blue
+ * - new 	bright blue
  * - normal	blue
  * - aged	brown
  * - worked	small caps */
@@ -735,13 +735,13 @@ void bandmap_show() {
      * current frequency
      *
      * mark entries according to age, source and worked state. Mark new multis
-     * - new 	brigth blue
+     * - new 	bright blue
      * - normal	blue
      * - aged	brown
      * - worked	small caps
      * - new multi	mark with blue M between QRG and call
      * - self announced stations
-     *   		small preceeding letter for reporting station
+     *   		small preceding letter for reporting station
      *
      * show own frequency as dashline in green color
      * - highligth actual spot if near own frequency
@@ -767,7 +767,7 @@ void bandmap_show() {
     bm_init();
     filter_spots();
 
-    /* afterwards display filtered list around own QRG +/- some offest
+    /* afterwards display filtered list around own QRG +/- some offset
      * (offset gets reset if we change frequency */
 
     getyx(stdscr, cury, curx);		/* remember cursor */
@@ -949,7 +949,7 @@ spot *copy_spot(spot *data) {
 /** Search partialcall in filtered bandmap
  *
  * Lookup given partial call in the list of filtered bandmap spots.
- * Return a copy of the first entry found (means with teh lowest frequency).
+ * Return a copy of the first entry found (means with the lowest frequency).
  *
  * \param 	partialcall - part of call to look up
  * \return 	spot * structure with a copy of the found spot

--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -38,7 +38,7 @@ typedef struct {
     char 	*pfx; /* prefix */
 } spot;
 
-#define SPOT_NEW	(bm_config.livetime)
+#define SPOT_NEW	(bm_config.lifetime)
 #define SPOT_NORMAL	(SPOT_NEW * 95) / 100
 #define SPOT_OLD	(SPOT_NEW * 2)  / 3
 
@@ -47,7 +47,7 @@ typedef struct {
     short allmode;
     short showdupes;
     short skipdupes;
-    short livetime;
+    short lifetime;
     short onlymults;
 } bm_config_t;
 
@@ -111,16 +111,16 @@ void bandmap_show();
  * If more entries to show than place in window, show around current frequency
  *
  * mark entries according to age, source and worked state. Mark new multis
- * - new 	brigth blue
+ * - new 	bright blue
  * - normal	blue
  * - aged	black
  * - worked	small caps
  * - new multi	underlined
  * - self announced stations
- *   		small preceeding letter for repoting station
+ *   		small preceding letter for reporting station
  *
  * maybe show own frequency as dashline in other color
- * (maybee green highlighted)
+ * (maybe green highlighted)
  * - highligth actual spot if near its frequency
  *
  * Allow selection of one of the spots (switches to S&P)

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -326,7 +326,7 @@ int callinput(void) {
 
 	    // Ctrl-S (^S), open QTC window for sending QTCs.
 	    case CTRL_S: {
-		if (qtcdirection == 2 || qtcdirection == 3) {	// in case of QTC=SEND ot QTC=BOTH
+		if (qtcdirection == 2 || qtcdirection == 3) {	// in case of QTC=SEND or QTC=BOTH
 		    qtc_main_panel(SEND);
 		}
 		x = KEY_LEFT;
@@ -622,7 +622,7 @@ int callinput(void) {
 		break;
 	    }
 
-	    // <Backspace>, remove chracter left of cursor, move cursor left one position.
+	    // <Backspace>, remove character left of cursor, move cursor left one position.
 	    case KEY_BACKSPACE: {
 		if (*hiscall != '\0') {
 		    getyx(stdscr, cury, curx);
@@ -891,7 +891,7 @@ int callinput(void) {
 		break;
 	    }
 
-	    // Ctrl-R (^R), toogle trx1, trx2 via lp0 pin 14.
+	    // Ctrl-R (^R), toggle trx1, trx2 via lp0 pin 14.
 	    case CTRL_R: {
 		if (k_pin14 == 0) {
 		    k_pin14 = 1;

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -199,12 +199,12 @@ int fldigi_xmlrpc_query(xmlrpc_res *local_result, xmlrpc_env *local_env,
     }
     /*
     if connerr had been set up to 1, that means an error
-    occured at last xmlrpc_call() method
+    occurred at last xmlrpc_call() method
     if that true, then we count the number of calling this
     function (xmlrpc()), if counter reaches 10, then clear
     it, and try again
     this handles the xmlrpc_call() errors, eg. Fldigi is
-    unreacheable, but it will check again and again, not
+    unreachable, but it will check again and again, not
     need to restart Tlf, or type ":FLDIGI" to turn on again
     */
     if (connerr && use_fldigi) {
@@ -634,7 +634,7 @@ int fldigi_get_log_call() {
 		    return -1;
 		}
 	    }
-	    // otherways, fill the callsign field in Tlf
+	    // otherwise, fill the callsign field in Tlf
 	    else {
 		if (strlen(tempstr) >= 3) {
 		    if (hiscall[0] == '\0') {
@@ -693,7 +693,7 @@ int fldigi_get_log_serial_number() {
 		    return -1;
 		}
 	    }
-	    // otherways we need to fill the Tlf exchange field
+	    // otherwise we need to fill the Tlf exchange field
 	    else {
 		if (strlen(tempstr) > 0 && comment[0] == '\0') {
 		    strcpy(comment, tempstr);

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -151,7 +151,7 @@ int getexchange(void) {
 		continue;
 	    }
 	    case 19: {	// Ctl+s (^S)--Open QTC panel for sending QTCs
-		if (qtcdirection == 2 || qtcdirection == 3) {	// in case of QTC=SEND ot QTC=BOTH
+		if (qtcdirection == 2 || qtcdirection == 3) {	// in case of QTC=SEND or QTC=BOTH
 		    qtc_main_panel(SEND);
 		}
 		x = KEY_LEFT;

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -54,7 +54,7 @@ char bc_hostservice[MAXNODES][16] = {
 };
 int nodes = 0;
 //--------------------------------------
-/* default port to listen for incomming packets and to send packet to */
+/* default port to listen for incoming packets and to send packet to */
 char default_lan_service[16] = "6788";
 /* lan port parsed from config */
 int lan_port = 6788;

--- a/src/main.c
+++ b/src/main.c
@@ -318,7 +318,7 @@ int k_ptt = 0;
 
 int miniterm = 0;		/* is miniterm for digimode active? */
 char modem_mode[8];
-int commentfield = 0;		/* 1 if we are in comment/excahnge input */
+int commentfield = 0;		/* 1 if we are in comment/exchange input */
 
 /*-------------------------------------packet-------------------------------*/
 char spot_ptr[MAX_SPOTS][82];		/* Array of cluster spot lines */

--- a/src/muf.c
+++ b/src/muf.c
@@ -158,7 +158,7 @@ http://www.classiccmp.org/cpmarchives/cpm/Software/WalnutCD/cpm/hamradio/micromu
   FO-E calculations.
 
 
-  For the L.U.F. a minimum useable fieldstrength of 30 DBUV at the
+  For the L.U.F. a minimum usable fieldstrength of 30 DBUV at the
   receiver and 250 KW of transmitter power (aerial gain: 18 DBI) are
   assumed.  The L.U.F. is derived from absorption calculations based
   on the work of Piggot, George, Samuel, and Bradley.  In spite of the
@@ -381,7 +381,7 @@ void muf(void) {
 	mvwprintw(win, 5, 40, "F-hops:    %2.0f", n);
 
 	sunup(xr, &sunrise, &sundown);	/* calculate local sunup and down
-                                               at destination lattitude */
+                                               at destination latitude */
 	/* transform to UTC based on longitude from country description */
 	td = (yr * 4) / 60 ; 	/* 4 degree/min */
 	sunrise += td;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -365,14 +365,14 @@ static int cfg_bandmap(const cfg_arg_t arg) {
     bm_config.allmode = 1;
     bm_config.showdupes = 1;
     bm_config.skipdupes = 0;
-    bm_config.livetime = 900;
+    bm_config.lifetime = 900;
     bm_config.onlymults = 0;
 
     /* Allow configuration of bandmap display if keyword
      * is followed by a '='
      * Parameter format is BANDMAP=<xxx>,<number>
      * <xxx> - string parsed for the letters B, M, D and S
-     * <number> - spot livetime in seconds (>=30)
+     * <number> - spot lifetime in seconds (>=30)
      */
     if (parameter != NULL) {
 	char **bm_fields = g_strsplit(parameter, ",", 2);
@@ -397,12 +397,12 @@ static int cfg_bandmap(const cfg_arg_t arg) {
 	}
 
 	if (bm_fields[1] != NULL) {
-	    int livetime;
+	    int lifetime;
 	    g_strstrip(bm_fields[1]);
-	    livetime = atoi(bm_fields[1]);
-	    if (livetime >= 30)
+	    lifetime = atoi(bm_fields[1]);
+	    if (lifetime >= 30)
 		/* aging called each second */
-		bm_config.livetime = livetime;
+		bm_config.lifetime = lifetime;
 	}
 
 
@@ -552,7 +552,7 @@ static int cfg_countrylist(const cfg_arg_t arg) {
 	case insensitive contest name, we copy the countries from
 	that line into country_list_raw.
 	If the input was not a file name we directly copy it into
-	country_list_raw (must not have a preceeding contest name). */
+	country_list_raw (must not have a preceding contest name). */
 
 	g_strlcpy(temp_buffer, parameter, sizeof(temp_buffer));
 	g_strchomp(temp_buffer);	/* drop trailing whitespace */
@@ -611,7 +611,7 @@ static int cfg_continentlist(const cfg_arg_t arg) {
        parsing the file. If we got our case insensitive contest name,
        we copy the multipliers from it into multipliers_list.
        If the input was not a file name we directly copy it into
-       cont_multiplier_list (must not have a preceeding contest name).
+       cont_multiplier_list (must not have a preceding contest name).
        The last step is to parse the multipliers_list into an array
        (continent_multiplier_list) for future use.
      */

--- a/src/qtcvars.h
+++ b/src/qtcvars.h
@@ -101,12 +101,12 @@ extern int qtc_ry_copied;		// stores the number of copied lines i
 
 extern bool qtcrec_record;		// do we record the received QTCs
 extern char qtcrec_record_command[2][50]; 	// command to start recording
-extern char qtcrec_record_command_shutdown[50]; // coomand to stop recording
+extern char qtcrec_record_command_shutdown[50]; // command to stop recording
 
 /* arras of CW/Digimode messages for QTC receive and send */
 extern char qtc_recv_msgs[12][80];
 extern char qtc_send_msgs[12][80];
-/* arras of SSB fiel names for QTC receive and send */
+/* arras of SSB file names for QTC receive and send */
 extern char qtc_phrecv_message[14][80];
 extern char qtc_phsend_message[14][80];
 

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -576,7 +576,7 @@ void qtc_main_panel(int direction) {
 	    // Left Arrow
 	    case KEY_LEFT:
 		if (DIRCLAUSE) {
-		    if (curpos < curfieldlen) {	// curpos is a shift, means lenght - position
+		    if (curpos < curfieldlen) {	// curpos is a shift, means length - position
 			curpos++;
 			showfield(activefield);
 		    }

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -135,7 +135,7 @@ void write_qtclog_fm_cabr(char *qtcrcall, struct read_qtc_t  qtc_line) {
 	    strncpy(ttime, qsos[qtc_curr_call_nr] + 17, 2);
 	    strncpy(ttime + 2, qsos[qtc_curr_call_nr] + 20, 2);
 	    ttime[4] = '\0';
-	    // check the call was't sent, and call and time are equals
+	    // check the call wasn't sent, and call and time are equals
 	    if (qsoflags_for_qtc[qtc_curr_call_nr] == 0 &&
 		    (strcmp(thiscall, qtc_line.qtc_call) == 0) &&
 		    (strcmp(ttime, qtc_line.qtc_time)) == 0) {
@@ -174,7 +174,7 @@ void write_qtclog_fm_cabr(char *qtcrcall, struct read_qtc_t  qtc_line) {
  *
  * walk through the lines which starts with QSO/X-QSO, and
  * build a virtual QSO; then it calls the existing functions
- * to add to the real log, used by the Cabrillo datas (eg. freq,
+ * to add to the real log, used by the Cabrillo data (eg. freq,
  * date, time, band, ...) instead of the real
  */
 
@@ -359,7 +359,7 @@ void cab_qso_to_tlf(char *line, struct cabrillo_desc *cabdesc) {
 
     }
 
-    // strip trailing exchange separators and change them to the specfied value
+    // strip trailing exchange separators and change them to the specified value
     // note: it assumes that exchanges do not contain spaces
     g_strchomp(qso->comment);
     if (cabdesc->exchange_separator != NULL) {

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -56,7 +56,7 @@ char short_number(char c) {
 }
 
 /*
- * Replace occurences of 'what' in 'buf' by 'rep'.
+ * Replace occurrences of 'what' in 'buf' by 'rep'.
  * The amount of bytes assigned to 'buf' is 'size'.
  * This includes the terminating \0, i.e. max length of 'buf' is 'size'-1
  * Replacements are done in-place, no other memory area than 'buf' is used.
@@ -127,7 +127,7 @@ void replace_n(char *buf, int size, const char *what, const char *rep,
 		// would be longer than (size-1), shift only a part
 		n = buf + size - 1 - dst;
 		if (n <= 0) {
-		    // even a part wont fit; no operation
+		    // even a part won't fit; no operation
 		    n = 0;
 		    overflow = 1;
 		}
@@ -181,7 +181,7 @@ void ExpandMacro(void) {
 	    early_started = 0;
 //                              sending_call = 0;
 	}
-	replace_1(buffer, BUFSIZE, "@", p);   /* his call, 1st occurence */
+	replace_1(buffer, BUFSIZE, "@", p);   /* his call, 1st occurrence */
 	replace_all(buffer, BUFSIZE, "@",
 		    hiscall);   /* his call, further occurrences */
     }

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -361,7 +361,7 @@ void showscore(void) {
 
 }
 
-/** formated print of integer number 0..9999 */
+/** formatted print of integer number 0..9999 */
 void printfield(int y, int x, int number) {
     attron(COLOR_PAIR(C_LOG));
 

--- a/src/sunup.c
+++ b/src/sunup.c
@@ -26,9 +26,9 @@
 #define RADIAN  (180.0 / M_PI)
 
 
-/** Compute sun up and down at given lattitude
+/** Compute sun up and down at given latitude
  *
- * \param lat - Lattitude
+ * \param lat - Latitude
  * \param sunrise - local sunrise in hours
  * \param sundown - local sundown in hours
  */
@@ -53,7 +53,7 @@ void sunup(double DEST_Lat, double *sunrise, double *sundown) {
     if (total_days <= 0.0)
 	total_days += 365.25;
 
-    /* calculate todays lattitude of the sun */
+    /* calculate todays latitude of the sun */
     sun_lat = asin(sin(23.439 / RADIAN) *
 		   sin(((total_days - 90.086) / 365.25) * 360 / RADIAN)) * RADIAN;
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -147,7 +147,7 @@ enum {
 
 /** my station info
  *
- * contains all informations about my station */
+ * contains all information about my station */
 typedef struct {
     char call[20];
     int countrynr;
@@ -160,7 +160,7 @@ typedef struct {
 
 /** worked station
  *
- * contains all informations about an already worked station */
+ * contains all information about an already worked station */
 typedef struct {
     char call[20]; 		/**< call of the station */
     char exchange[24]; 		/**< the last exchange */

--- a/test/ReadMe.adoc
+++ b/test/ReadMe.adoc
@@ -12,7 +12,7 @@ The setup is as follows
 *   Each test can have setup/teardown functions (*setup_AA()* and
     *teardown_AA()*) or there can be common (*_default*) s/t functions.
 **      These functions are used by *cmocka_unit_test_setup_teardown*
-*    A test group can have overall s/t funcions, they are used in
+*    A test group can have overall s/t functions, they are used in
     *cmocka_run_group_tests*
 *    A test group specifies which objects it has to be linked with using 
     *// OBJECT bbb.o* syntax

--- a/test/data.c
+++ b/test/data.c
@@ -134,7 +134,7 @@ char exchange_list[40] = "";
 int timeoffset = 0;
 int multi = 0;			/* 0 = SO , 1 = MOST, 2 = MM */
 int trxmode = CWMODE;
-/* RIG_MODE_NONE in hamlib/rig.h, but if hamlib not compiled, then no dependecy */
+/* RIG_MODE_NONE in hamlib/rig.h, but if hamlib not compiled, then no dependency */
 rmode_t rigmode = 0;
 rmode_t digi_mode = 0;
 bool mixedmode = false;
@@ -291,7 +291,7 @@ int k_ptt;
 char controllerport[80] = "/dev/ttyS0";
 int miniterm = 0;		/* is miniterm for digimode active? */
 char modem_mode[8];
-int commentfield = 0;		/* 1 if we are in comment/excahnge input */
+int commentfield = 0;		/* 1 if we are in comment/exchange input */
 
 /*-------------------------------------packet-------------------------------*/
 char spot_ptr[MAX_SPOTS][82];		/* Array of cluster spot lines */

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -107,7 +107,7 @@ static char *get_datetime(struct qso_t *qso) {
     return datetime_buf;    // note: returns a static buffer
 }
 
-/* export non public protoypes for test */
+/* export non public prototypes for test */
 int starts_with(char *line, char *start);
 void cab_qso_to_tlf(char *line, struct cabrillo_desc *cabdesc);
 extern struct read_qtc_t qtc_line;	/* make global for testability */

--- a/test/test_clusterinfo.c
+++ b/test/test_clusterinfo.c
@@ -29,7 +29,7 @@ freq_t node_frequencies[MAXNODES];
 pthread_mutex_t spot_ptr_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t bm_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-bm_config_t bm_config = { .livetime = 900 };
+bm_config_t bm_config = { .lifetime = 900 };
 
 GList *allspots = NULL; // not used yet
 

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -896,7 +896,7 @@ void test_bandmap(void **state) {
     assert_int_equal(rc, 0);
     assert_int_equal(cluster, MAP);
     assert_int_equal(bm_config.showdupes, 1);
-    assert_int_equal(bm_config.livetime, 900);
+    assert_int_equal(bm_config.lifetime, 900);
 }
 
 void test_bandmap_d100(void **state) {
@@ -904,7 +904,7 @@ void test_bandmap_d100(void **state) {
     assert_int_equal(rc, 0);
     assert_int_equal(cluster, MAP);
     assert_int_equal(bm_config.showdupes, 0);
-    assert_int_equal(bm_config.livetime, 100);
+    assert_int_equal(bm_config.lifetime, 100);
 }
 
 void test_cwspeed(void **state) {

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -749,7 +749,7 @@ should work.
 This also works under VNC.
 .
 .P
-Certain key combinations will probably not be useable as the Linux console
+Certain key combinations will probably not be usable as the Linux console
 consumes Alt-F1 through
 .RI Alt-F x
 (often F7, but could be greater) for switching its virtual consoles.
@@ -1281,7 +1281,7 @@ looks for a spot.
 Suspend @PACKAGE_NAME@ returning to shell prompt.
 .
 To return to @PACKAGE_NAME@ use the \(oqfg\(cq command (Bourne Shell) or the
-eqivalent command for your shell.
+equivalent command for your shell.
 .
 .TP
 .BR Alt-0 ... Alt-9


### PR DESCRIPTION
This PR fixes some spelling errors in documentation and in comments, ignoring some files.
The tool that I used suggested also to replace livetime with lifetime, which seems safe to do. Let me know if you prefer to keep some files unchanged.

Fixed with:
`codespell --ignore-words-list=br,creat,fo,hel,ket,nd,te,ue,vie --skip=config.*,depcomp,*.m4,./share/* --interactive=2 --write-changes`
and some manual editing.
