### PR TITLE
Fix scoring QTC points for WAE contest

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -700,7 +700,6 @@ static int databases_load() {
 	    showmsg("QTCs giving up");
 	    return EXIT_FAILURE;
 	}
-	readqtccalls();
     }
     // unset QTC_RECV_LAZY if mode is DIGIMODE
     if (trxmode == DIGIMODE) {
@@ -1028,6 +1027,9 @@ int main(int argc, char *argv[]) {
 
     nr_qsos = readcalls(logfile, true);   /* read the logfile and rebuild
 				            point and multiplier scoring */
+    if (qtcdirection > 0) {
+	readqtccalls();
+    }
 
     scroll_log();		/* show the last 5  log lines and
 				   set the next serial number */

--- a/src/main.c
+++ b/src/main.c
@@ -1025,8 +1025,9 @@ int main(int argc, char *argv[]) {
 
     show_station_info();
 
-    nr_qsos = readcalls(logfile, true);   /* read the logfile and rebuild
-				            point and multiplier scoring */
+    /* read the logfile and rebuild point and multiplier scoring */
+    /* see also log_read_n_score() for non-interactive variant */
+    nr_qsos = readcalls(logfile, true);
     if (qtcdirection > 0) {
 	readqtccalls();
     }


### PR DESCRIPTION
- Calling `readqtccalls()` only after `readcalls()` adds QTC points to
  the regular QSO points which are already counted by the later
  function.

- Due to different use of the 'interactive' parameter during startup we
  should not reuse `log_read_n_score()` here.

Will fix issue #310.