### PR TITLE
Fix wpx scoring

### DIFF
--- a/src/score.c
+++ b/src/score.c
@@ -114,12 +114,12 @@ bool is_in_continentlist(char *continent) {
 
 /* apply bandweight scoring *
  * at the moment only LOWBAND_DOUBLES (<30m) can be active */
-int apply_bandweight(int points) {
+int apply_bandweight(int points, int bandindex) {
 
-    if (lowband_point_mult && (bandinx < BANDINDEX_30))
+    if (lowband_point_mult && (bandindex < BANDINDEX_30))
 	points *= 2;
 
-    points *= bandweight_points[bandinx];
+    points *= bandweight_points[bandindex];
 
     return points;
 }
@@ -213,7 +213,7 @@ int scoreDefault(struct qso_t *qso) {
     else
 	points = scoreByContinentOrCountry(qso);
 
-    points = apply_bandweight(points);
+    points = apply_bandweight(points, qso->bandindex);
     points = portable_doubles(points, qso->call);
 
     return points;
@@ -232,7 +232,7 @@ int score_wpx(struct qso_t *qso) {
     }
 
     if ((strcmp(ctyinfo->continent, my.continent) == 0)
-	    && (bandinx > BANDINDEX_30)) {
+	    && (qso->bandindex > BANDINDEX_30)) {
 	if (strstr(my.continent, "NA") != NULL) {
 	    points = 2;
 	} else {
@@ -243,7 +243,7 @@ int score_wpx(struct qso_t *qso) {
     }
 
     if ((strcmp(ctyinfo->continent, my.continent) == 0)
-	    && (bandinx < BANDINDEX_30)) {
+	    && (qso->bandindex < BANDINDEX_30)) {
 	if (strstr(my.continent, "NA") != NULL) {
 	    points = 4;
 	} else {
@@ -252,13 +252,13 @@ int score_wpx(struct qso_t *qso) {
 	return points;
     }
     if ((strcmp(ctyinfo->continent, my.continent) != 0)
-	    && (bandinx > BANDINDEX_30)) {
+	    && (qso->bandindex > BANDINDEX_30)) {
 	points = 3;
 
 	return points;
     }
     if ((strcmp(ctyinfo->continent, my.continent) != 0)
-	    && (bandinx < BANDINDEX_30)) {
+	    && (qso->bandindex < BANDINDEX_30)) {
 	points = 6;
 
 	return points;

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -130,25 +130,25 @@ void test_wpx(void **state) {
     check_call_points("DL3ABC",1);
 
     /* different continents */
-    bandinx = BANDINDEX_20;
+    qso.bandindex = BANDINDEX_20;
     check_call_points("ZS6ABC",3);
 
-    bandinx = BANDINDEX_40;
+    qso.bandindex = BANDINDEX_40;
     check_call_points("ZS6ABC",6);
 
     /* same continent, not NA */
-    bandinx = BANDINDEX_20;
+    qso.bandindex = BANDINDEX_20;
     check_call_points("HB9ABC",1);
 
-    bandinx = BANDINDEX_40;
+    qso.bandindex = BANDINDEX_40;
     check_call_points("HB9ABC",2);
 
     /* same continent, NA */
     strcpy(my.continent, "NA");
-    bandinx = BANDINDEX_20;
+    qso.bandindex = BANDINDEX_20;
     check_call_points("VE3ABC",2);
 
-    bandinx = BANDINDEX_40;
+    qso.bandindex = BANDINDEX_40;
     check_call_points("VE3ABC",4);
 
 }
@@ -221,9 +221,9 @@ void test_ssbcw(void **state) {
     check_points(3);
 
     lowband_point_mult = true;
-    bandinx = BANDINDEX_30;
+    qso.bandindex = BANDINDEX_30;
     check_points(3);
-    bandinx = BANDINDEX_40;
+    qso.bandindex = BANDINDEX_40;
     check_points(6);
 
     portable_x2 = true;


### PR DESCRIPTION
Lately scoring wpx used actual bandindex value from rig instead of the
value from the evaluated qso. That led to errors during any time we did a
re scoring (on startup, after edit of last qso or :rescore command).

Furthermore fix also bandwidth handling which had the same problem.