### PR TITLE
Added RESENDCALL feature

### DIFF
--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -52,6 +52,8 @@ extern bool country_mult;
 extern struct qso_t *current_qso;
 extern char hiscall[20];
 extern char hiscall_sent[20];
+extern int resend_call;
+extern char sentcall[20];
 extern int total;
 extern int qso_points;
 extern int qsos_per_band[NBANDS];

--- a/src/logit.c
+++ b/src/logit.c
@@ -48,6 +48,7 @@
 #include "tlf_curses.h"
 #include "ui_utils.h"
 #include "cleanup.h"
+#include "utils.h"
 
 
 void refresh_comment(void);
@@ -166,6 +167,27 @@ void logit(void) {
 		    callreturn = 0;
 		} else if (defer_store > 1) {
 		    if ((cqmode == CQ) && iscontest) {
+			if (cqmode == CQ && resend_call != RESEND_NOT_SET) {
+			    if (strcmp(hiscall, sentcall) != 0) {
+				char tempmsg[21] = "";
+				char partial_call[20];
+				switch (resend_call) {
+				    case RESEND_FULL:
+					sprintf(tempmsg, "%s ", hiscall);
+					break;
+				    case RESEND_PARTIAL:
+					get_partial_callsign(sentcall, hiscall, partial_call);
+					sprintf(tempmsg, "%s ", partial_call);
+					break;
+				    default:
+					break;
+				}
+				if (tempmsg[0] != '\0') {
+				    sendmessage(tempmsg);
+				}
+			    }
+			    sentcall[0] = '\0';
+			}
 			send_standard_message(CQ_TU_MSG);	/* send cq return */
 			set_simulator_state(CALL);
 

--- a/src/main.c
+++ b/src/main.c
@@ -441,6 +441,10 @@ static const struct argp_option options[] = {
     { 0 }
 };
 
+/* resend call option, can be 0 (do not use), 1 (partial), 2 (full) */
+int resend_call = RESEND_NOT_SET;
+char sentcall[20] = "";     // storing the call what already sent
+
 /* parse a single option */
 static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     switch (key) {

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1025,6 +1025,24 @@ static int cfg_cabrillo_field(const cfg_arg_t arg) {
     return rc;
 }
 
+static int cfg_resend_call(const cfg_arg_t arg) {
+    char *str = g_ascii_strup(parameter, -1);
+    g_strstrip(str);
+
+    if (strcmp(str, "PARTIAL") == 0) {
+	resend_call = RESEND_PARTIAL;
+    } else if (strcmp(str, "FULL") == 0) {
+	resend_call = RESEND_FULL;
+    } else {
+	g_free(str);
+	error_details = g_strdup("must be PARTIAL or FULL");
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    g_free(str);
+    return PARSE_OK;
+}
+
 static config_t logcfg_configs[] = {
     {"CONTEST_MODE",        CFG_BOOL_TRUE(iscontest)},
     {"MIXED",               CFG_BOOL_TRUE(mixedmode)},
@@ -1189,6 +1207,7 @@ static config_t logcfg_configs[] = {
     {"UNIQUE_CALL_MULTI",   NEED_PARAM, cfg_unique_call_multi},
     {"DIGI_RIG_MODE",       NEED_PARAM, cfg_digi_rig_mode},
     {"CABRILLO-(.+)",       OPTIONAL_PARAM, cfg_cabrillo_field},
+    {"RESENDCALL",          NEED_PARAM, cfg_resend_call},
 
     {NULL}  // end marker
 };

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -182,6 +182,9 @@ void ExpandMacro(void) {
 	    early_started = 0;
 //                              sending_call = 0;
 	}
+	if (cqmode == CQ && resend_call != RESEND_NOT_SET) {
+	    strcpy(sentcall, hiscall);
+	}
 	replace_1(buffer, BUFSIZE, "@", p);   /* his call, 1st occurrence */
 	replace_all(buffer, BUFSIZE, "@",
 		    hiscall);   /* his call, further occurrences */

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -283,6 +283,13 @@ enum {
     MARKER_CALLS,	/* DOTS & CALLS */
 };
 
+/* Enums for RESENDCALL feature */
+enum {
+    RESEND_NOT_SET,		/* Resend feature not set */
+    RESEND_PARTIAL,		/* Resend partial hiscall */
+    RESEND_FULL,		/* Resend full hiscall again */
+};
+
 #define FREE_DYNAMIC_STRING(p)  if (p != NULL) {g_free(p); p = NULL;}
 
 #define LEN(array) (sizeof(array) / sizeof(array[0]))

--- a/src/utils.c
+++ b/src/utils.c
@@ -20,6 +20,9 @@
 #include <unistd.h>
 #include <glib.h>
 #include <glib/gstdio.h>
+#include <string.h>
+
+#include "getpx.h"
 
 /* \brief find named file in actual directory or in share
  *
@@ -42,4 +45,76 @@ char *find_available(char *filename) {
     return path;
 }
 
+/* \brief get a substring from corrected call to repeat it
+ *
+ * \returns a substring based on the sent and corrected callsign
+ */
+void get_partial_callsign(char *call1, char *call2, char *partial) {
 
+    size_t len1 = strlen(call1), len2 = strlen(call2);
+    unsigned int len = (len1 < len2) ? len1 : len2;
+    unsigned int i;
+    unsigned int plen, plen1, plen2;
+    int min = -1, max = -1;
+    char tpartial[20];
+
+
+    tpartial[0] = '\0';
+
+    char *pfx1 = get_wpx_pfx(call1);
+    char *pfx2 = get_wpx_pfx(call2);
+
+    plen1 = strlen(pfx1);
+    plen2 = strlen(pfx2);
+
+    plen = (plen1 > plen2) ? plen1 : plen2;
+
+    for (i = 0; i < len; i++) {
+	if (call1[i] != call2[i]) {
+	    if (min < 0) {
+		min = i;
+		max = i;
+	    }
+	    if (max < i) {
+		max = i;
+	    }
+	}
+    }
+
+    // if all existing chars are the same
+    // AB1CD / AB1CDE -> CDE
+    // AB1CDE / AB1CD -> 1CD
+    if (min == -1 && max == -1) {
+	if (len2 < len1) {  // if the new call is shorter
+	    plen--;         // include the last char of suffix
+	}
+	strncpy(tpartial, call2 + plen, len2 - plen + 1); // the full suffix
+	tpartial[len2 - plen + 1] = '\0';
+    } else {
+	// if there is only 1 diff, and it's at the end
+	// AB1CD / AB1CE -> CE
+	if (min == max && max == len2 - 1) {
+	    min--; // add the previous char too
+	}
+	if (len1 == len2) {
+	    // if the mismatch is in the prefix
+	    // AB1CD / AB2CD -> AB2
+	    if (max <= plen - 1) {
+		strncpy(tpartial, call2, plen);
+		tpartial[plen] = '\0';
+	    } else {
+		strncpy(tpartial, call2 + min, len2 - min + 1);
+		tpartial[len2 - min + 1] = '\0';
+	    }
+	} else {
+	    strncpy(tpartial, call2 + min, len2 - min + 1);
+	    tpartial[len2 - min + 1] = '\0';
+	}
+    }
+
+    strcpy(partial, tpartial);
+    free(pfx1);
+    free(pfx2);
+
+    return;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,5 +22,6 @@
 #define UTILS_H
 
 char *find_available(char *filename);
+void get_partial_callsign(char *call1, char *call2, char *partial);
 
 #endif /* UTILS_H */

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -2186,6 +2186,18 @@ and @PACKAGE_NAME@ if is in
 then the other station's callsign will be sent before \(lqDE\(rq, such as
 \(lqDL1A DE W1AW\(rq.
 .
+.TP
+.B RESENDCALL=\fIFULL\fR | \fIPARTIAL\fR
+Sends the partial or the full callsign again in RUN mode, and if the first
+recording was wrong. In case of \fIFULL\fR, the whole callsign will send again.
+If the value is \fIPARTIAL\fR, then Tlf figures out which part of callsign has
+to send. Eg.: if the received call in first case was
+.B AB1CD,
+but later hi corrects to
+.B AB1CB,
+then tlf sends 
+.B CB.
+.
 .SH RULES
 .
 The contest rules can be put into separate files.


### PR DESCRIPTION
This PR adds a new feature for Tlf, which missing me a lot.

Consider that you are participating on a contest in RUN mode. A station comes back, you type his callsign, press the `ENTER`, you send his call and the report. Then the station corrects his callsign, and sends the exchange. Now you must confirm that you changed the modified callsign.

This patch does this feature.

There is a new keyword with two possible values:
```
RESENDCALL=FULL | PARTIAL
```
In case of `FULL`, the whole callsign will send again, with `PARTIAL`, Tlf calculates a shortest clear part of callsign.

Here are few examples:

| First record  | Corrected | Send Partial |
| ---------------- | ------------- | ----------------- |
| WB6A          | W6BA      | W6B              |
| HA2OH        | HA2OS    | OS                |
| HA2MS        | HA2OS    | OS                |
| HA2MH        | HA2OS    |  OS               |
| OK2FHI       | OK1FHI    | OK1             |
| OK1FH        | OK1FHI    | FHI              |
| OK2FH        | OK1FHI    | 1FHI            |
| WB6AB       | WB6A       |     6A            |
