### PR TITLE
Use empty default proposed_exchange

### DIFF
--- a/src/recall_exchange.c
+++ b/src/recall_exchange.c
@@ -43,6 +43,8 @@ int get_proposed_exchange(void) {
     char *loc, *loc2;
     struct ie_list *current_ie;
 
+    proposed_exchange[0] = 0;   // default: empty (nothing found)
+
     if (strlen(hiscall) == 0)
 	return 0;
 


### PR DESCRIPTION
`get_proposed_exchange()` didn't have a default value for the no match case. Previously found value was used unless it was cleared via `cleanup_qso()`.
Ctrl-A or deleting using backspace does not call `cleanup_qso()`, hence the previous exchange value is kept.