### PR TITLE
Improve editing

### DIFF
--- a/ToDo
+++ b/ToDo
@@ -36,7 +36,7 @@ Planned for later versions
 
 [ ] Do a complete rewrite of display related code in the long term to
     allow vertical AND horizontal resizing.
-
+[ ] Add undo functionality to editing last 5 QSOs (see PR #333)
 
 Internals
 ~~~~~~~~~

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -62,7 +62,7 @@ static field_t fields[] = {
         .pattern = "^\\s*\\S+\\s*$"},
     {.start = 44, .end = 46,                // sent RST
         .pattern = "^\\s*\\d+\\s*$"},
-    {.start = 49, .end = 52,                // rcvd RST
+    {.start = 49, .end = 51,                // rcvd RST
         .pattern = "^\\s*\\d+\\s*$"},
     {.start = 54,            .tab = true},  // exchange -- end set at runtime
 };

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -99,6 +99,17 @@ static void unhighlight_line(int row, char *line) {
     mvaddstr(7 + row, 0, ln);
 }
 
+/* flash a field */
+static void flash_field(int row, int column, char *value) {
+    attrset(COLOR_PAIR(C_DUPE));
+    mvaddstr(7 + row, column, value);
+    curs_set(0);        // hide cursor
+    refreshp();
+    usleep(200*1000);   // 200 ms
+    curs_set(1);        // show cursor
+    // note: line will be re-displayed in the main loop
+}
+
 
 /* get a copy of selected QSO into the buffer */
 static void get_qso(int nr, char *buffer) {
@@ -141,7 +152,11 @@ static bool field_valid() {
     int width = current_field->end - current_field->start + 1;
     g_strlcpy(value, editbuffer + current_field->start, width + 1);
 
-    return g_regex_match_simple(current_field->pattern, value, G_REGEX_CASELESS, 0);
+    bool valid = g_regex_match_simple(current_field->pattern, value, G_REGEX_CASELESS, 0);
+    if (!valid) {
+        flash_field(editline, current_field->start, value);
+    }
+    return valid;
 }
 
 

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -49,6 +49,8 @@ typedef struct {
     const char *pattern;
 } field_t;
 
+#define RST_PATTERN     "^\\s*(\\d+|-+)\\s*$"
+
 static field_t fields[] = {
     {.start = 0,  .end = 5, .tab = true,    // band+mode
         .pattern = "^[ 1]\\d{2}(CW |SSB|DIG)$"},
@@ -61,9 +63,9 @@ static field_t fields[] = {
     {.start = 29, .end = 29 + MAX_CALL_LENGTH - 1, .tab = true,   // call
         .pattern = "^\\s*\\S+\\s*$"},
     {.start = 44, .end = 46,                // sent RST
-        .pattern = "^\\s*\\d+\\s*$"},
+        .pattern = RST_PATTERN},
     {.start = 49, .end = 51,                // rcvd RST
-        .pattern = "^\\s*\\d+\\s*$"},
+        .pattern = RST_PATTERN},
     {.start = 54,            .tab = true},  // exchange -- end set at runtime
 };
 


### PR DESCRIPTION
Added flashing the edited field if the content is invalid. This is to remind the user that it's not TLF crashed (not possible to exit the field) but a correct value must be typed in. Could be handy when this happens at 3 a.m. ...
Fixed received RST field size and RST fields allow `---` to support the NO_RST case.