### PR TITLE
Fix silently truncating Cabrillo fields

### DIFF
--- a/share/cabrillo.fmt
+++ b/share/cabrillo.fmt
@@ -1,8 +1,9 @@
 # Cabrillo format descriptions for various contests
 
 # used for ARRL and CQ contests, RDXC, Oceania DX Contest, AP Sprint and others
+# (using default 14-char wide exchanges)
 [UNIVERSAL]
-QSO=FREQ,5;MODE,2;DATE,10;TIME,4;MYCALL,13;RST_S,3;EXC_S,6;HISCALL,13;RST_R,3;EXCH,6
+QSO=FREQ,5;MODE,2;DATE,10;TIME,4;MYCALL,13;RST_S,3;EXC_S,14;HISCALL,13;RST_R,3;EXCH,14
 
 # used for CQWW (mostly as above but includes number of used TX)
 [CQWW]

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -485,7 +485,7 @@ static bool process_record(struct linedata_t *qso,
 
     bool ok = true;
     if (buffer[0] == '!') {
-        g_strchomp(buffer);
+	g_strchomp(buffer);
 	info(buffer + 1);   // show error message
 	sleep(2);
 	ok = false;

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -76,6 +76,8 @@ struct linedata_t *parse_logline(char *buffer) {
     ptr-> freq = qso->freq;
     ptr-> tx = qso->tx;
 
+    g_strstrip(ptr->comment);   // remove trailing spaces
+
     g_free(qso);	/* free qso_t struct but not the
 			   allocated string copies */
     return ptr;
@@ -241,14 +243,17 @@ const char *to_mode[] = {
 
 /* add 'src' to 'dst' with max. 'len' chars left padded */
 void add_lpadded(char *dst, char *src, int len) {
-    char *field;
-    int l;
 
-    field = g_malloc(len + 1);
-    strcat(dst, " ");
+    int l = strlen(src);
+    if (l > len) {
+	sprintf(dst, "!ERROR: field too wide (%s)", src);  // overwrites buffer
+	return;
+    }
+
+    strcat(dst, " ");   // add delimiter
+
+    char *field = g_malloc(len + 1);
     memset(field, ' ', len);
-    l = strlen(src);
-    if (l > len) l = len;
     memcpy(field + len - l, src, l);
     field[len] = '\0';
     strcat(dst, field);
@@ -257,17 +262,20 @@ void add_lpadded(char *dst, char *src, int len) {
 
 /* add 'src' to 'dst' with max. 'len' char right padded */
 void add_rpadded(char *dst, char *src, int len) {
-    char *field;
-    int l;
 
-    field = g_malloc(len + 1);
-    strcat(dst, " ");
+    int l = strlen(src);
+    if (l > len) {
+	sprintf(dst, "!ERROR: field too wide (%s)", src);  // overwrites buffer
+	return;
+    }
+
+    strcat(dst, " ");   // add delimiter
+
+    char *field = g_malloc(len + 1);
     memset(field, ' ', len);
-    l = strlen(src);
-    if (l > len) l = len;
     memcpy(field, src, l);
     field[len] = '\0';
-    strcat(dst, field);
+    strcat(dst, field); // add field
     g_free(field);
 }
 
@@ -437,7 +445,9 @@ void prepare_line(struct linedata_t *qso, struct cabrillo_desc *desc,
 	    default:
 		; // no action
 	}
-
+	if (buf[0] == '!') {
+	    break;      // there was an error
+	}
     }
     strcat(buf, "\n"); 		/* closing nl */
 }
@@ -450,9 +460,38 @@ static void set_exchange_format() {
 	strcpy(exchange, "#");  // contest is using serial number
 	return;
     }
-    get_cabrillo_field_value(find_cabrillo_field(CBR_EXCHANGE), exchange, sizeof(exchange));
+    get_cabrillo_field_value(find_cabrillo_field(CBR_EXCHANGE), exchange,
+			     sizeof(exchange));
 }
 
+//
+// process QSO/QTC data according to cabdesc
+//  - fills buffer and writes it into fp2
+//  - qso data is freed
+// returns true on success
+//         false on error, with buffer containing
+//               the error text starting with an exclamation mark
+//
+static bool process_record(struct linedata_t *qso,
+			   struct cabrillo_desc *cabdesc,
+			   char *buffer, FILE *fp2) {
+
+    prepare_line(qso, cabdesc, buffer);
+    free_linedata(qso);
+
+    if (strlen(buffer) > 5) {
+	fputs(buffer, fp2);
+    }
+
+    bool ok = true;
+    if (buffer[0] == '!') {
+	info(buffer + 1);   // show error message
+	sleep(2);
+	ok = false;
+    }
+
+    return ok;
+}
 
 int write_cabrillo(void) {
 
@@ -536,14 +575,15 @@ int write_cabrillo(void) {
     qsonr = 0;
     qtcrecnr = 0;
     qtcsentnr = 0;
-    while ((qso = get_next_record(fp1))) {
+    bool ok = true;
+    while (ok && (qso = get_next_record(fp1))) {
 
 	qsonr++;
-	prepare_line(qso, cabdesc, buffer);
-
-	if (strlen(buffer) > 5) {
-	    fputs(buffer, fp2);
+	ok = process_record(qso, cabdesc, buffer, fp2);
+	if (!ok) {
+	    break;      // stop processing immediately
 	}
+
 	if (fpqtcrec != NULL && qtcrec == NULL) {
 	    qtcrec = get_next_qtc_record(fpqtcrec, RECV);
 	    if (qtcrec != NULL) {
@@ -558,11 +598,8 @@ int write_cabrillo(void) {
 	}
 	while (qtcrecnr == qsonr || qtcsentnr == qsonr) {
 	    if (qtcsent == NULL || (qtcrec != NULL && qtcrec->qsots < qtcsent->qsots)) {
-		prepare_line(qtcrec, cabdesc, buffer);
-		if (strlen(buffer) > 5) {
-		    fputs(buffer, fp2);
-		    free_linedata(qtcrec);
-		}
+		ok = process_record(qtcrec, cabdesc, buffer, fp2);
+
 		qtcrec = get_next_qtc_record(fpqtcrec, RECV);
 		if (qtcrec != NULL) {
 		    qtcrecnr = qtcrec->qso_nr;
@@ -570,11 +607,8 @@ int write_cabrillo(void) {
 		    qtcrecnr = 0;
 		}
 	    } else {
-		prepare_line(qtcsent, cabdesc, buffer);
-		if (strlen(buffer) > 5) {
-		    fputs(buffer, fp2);
-		    free_linedata(qtcsent);
-		}
+		ok = process_record(qtcsent, cabdesc, buffer, fp2);
+
 		qtcsent = get_next_qtc_record(fpqtcsent, SEND);
 		if (qtcsent != NULL) {
 		    qtcsentnr = qtcsent->qso_nr;
@@ -582,9 +616,12 @@ int write_cabrillo(void) {
 		    qtcsentnr = 0;
 		}
 	    }
+
+	    if (!ok) {
+		break;      // stop QTC processing, will exit main loop later
+	    }
 	}
 
-	free_linedata(qso);
     }
 
     fclose(fp1);

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -76,7 +76,7 @@ struct linedata_t *parse_logline(char *buffer) {
     ptr-> freq = qso->freq;
     ptr-> tx = qso->tx;
 
-    g_strstrip(ptr->comment);   // remove trailing spaces
+    g_strchomp(ptr->comment);   // remove trailing spaces
 
     g_free(qso);	/* free qso_t struct but not the
 			   allocated string copies */
@@ -485,6 +485,7 @@ static bool process_record(struct linedata_t *qso,
 
     bool ok = true;
     if (buffer[0] == '!') {
+        g_strchomp(buffer);
 	info(buffer + 1);   // show error message
 	sleep(2);
 	ok = false;

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -248,7 +248,7 @@ void test_prepare_line_universal(void **state) {
     free_cabfmt(desc);
 
     assert_string_equal(buf,
-			"QSO: 21012 CW 2021-01-02 0842 A1BCD         599 0711   A2XYZ         559 007   \n");
+			"QSO: 21012 CW 2021-01-02 0842 A1BCD         599 0711           A2XYZ         559 007           \n");
 }
 
 void test_prepare_line_too_wide(void **state) {
@@ -261,14 +261,14 @@ void test_prepare_line_too_wide(void **state) {
 	.qso_nr = 711, .mode = CWMODE,
 	.call = "A2XYZ", .freq = 21012845.6,
 	.rst_s = 599, .rst_r = 559,
-	.comment = "007 ABC"    // longer than 6 chars
+	.comment = "007 ABCDEFGHIJK"    // longer than 14 chars
     };
 
     char buf[200];
     prepare_line(&qso, desc, buf);
     free_cabfmt(desc);
 
-    assert_string_equal(buf, "!ERROR: field too wide (007 ABC)\n");
+    assert_string_equal(buf, "!ERROR: field too wide (007 ABCDEFGHIJK)\n");
 }
 
 void test_prepare_line_agcw(void **state) {
@@ -362,7 +362,7 @@ void test_get_nth_token_slash(void **state) {
 void test_cabToTlf_ParseQSO(void **state) {
     struct cabrillo_desc *desc;
     desc = read_cabrillo_format(formatfile, "UNIVERSAL");
-    cab_qso_to_tlf("QSO:  7002 RY 2016-02-13 2033 HA2OS         589 0008   K6ND          599 044",
+    cab_qso_to_tlf("QSO:  7002 RY 2016-02-13 2033 HA2OS         589 0008           K6ND          599 044",
 		   desc);
     free_cabfmt(desc);
     assert_non_null(qso_spy);
@@ -396,7 +396,7 @@ void test_cabToTlf_ParseQSO_agcw(void **state) {
 void test_cabToTlf_ParseXQSO(void **state) {
     struct cabrillo_desc *desc;
     desc = read_cabrillo_format(formatfile, "UNIVERSAL");
-    cab_qso_to_tlf("X-QSO: 14002 PH 2016-08-13 0033 HA2OS         589 0008   K6ND          599 044",
+    cab_qso_to_tlf("X-QSO: 14002 PH 2016-08-13 0033 HA2OS         589 0008           K6ND          599 044",
 		   desc);
     free_cabfmt(desc);
     assert_non_null(qso_spy);


### PR DESCRIPTION
Fixing #334:
When formatting a Cabrillo field (either right or left padded) the truncation is treated as an error. User is notified and exporting is stopped.
![image](https://user-images.githubusercontent.com/15141948/182677903-747f5e8d-58d1-4d3f-a937-43808540fbc0.png)

The same message is written into the Cabrillo file:
 ```
!ERROR: field too wide (0001 EU222)
END-OF-LOG:
```

QSO and QTC exporting has been moved into a common function `process_record()`. Length checking is done in `add_[rl]padded()` functions. They overwrite the line buffer with the error text.