### PR TITLE
Add a way to check for a new multiplier based on a spot

### DIFF
--- a/src/addcall.c
+++ b/src/addcall.c
@@ -54,7 +54,8 @@
 #include "zone_nr.h"
 
 
-/* collect all relevant data for the actual QSO into a qso_t structure */
+/* collect all relevant data for the actual QSO into a new qso_t structure */
+//TODO rename this function to duplicate_current_qso()
 struct qso_t *collect_qso_data(void) {
     struct qso_t *qso = g_malloc0(sizeof(struct qso_t));
     qso->call = g_strdup(hiscall);
@@ -62,7 +63,7 @@ struct qso_t *collect_qso_data(void) {
     qso->bandindex = bandinx;
     qso->freq = freq;
     qso->timestamp = get_time();
-    qso->comment = g_strdup(comment);
+    qso->comment = g_strdup(current_qso.comment);
     qso->qso_nr = qsonum;
     qso->rst_s = atoi(sent_rst);
     qso->rst_r = atoi(recvd_rst);

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -64,6 +64,7 @@ struct qso_t *collect_qso_data(void) {
     qso->freq = freq;
     qso->timestamp = get_time();
     qso->comment = g_strdup(current_qso.comment);
+    qso->mult1_value = g_strdup(current_qso.mult1_value);
     qso->qso_nr = qsonum;
     qso->rst_s = atoi(sent_rst);
     qso->rst_r = atoi(recvd_rst);

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -58,7 +58,7 @@
 //TODO rename this function to duplicate_current_qso()
 struct qso_t *collect_qso_data(void) {
     struct qso_t *qso = g_malloc0(sizeof(struct qso_t));
-    qso->call = g_strdup(hiscall);
+    qso->call = g_strdup(current_qso.call);
     qso->mode = trxmode;
     qso->bandindex = bandinx;
     qso->freq = freq;

--- a/src/addcall.c
+++ b/src/addcall.c
@@ -207,7 +207,7 @@ int addcall(struct qso_t *qso) {
 	}
     }
 
-    addmult(qso);           /* for wysiwyg */
+    new_mult = addmult(qso);           /* for wysiwyg */
 
     return cty;
 }

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -418,14 +418,13 @@ static pthread_mutex_t mult_mutex = PTHREAD_MUTEX_INITIALIZER;
  * \param band	      - the bandindex we are on
  * \param mult_mode   - MULT_BAND -> check also if new band
  * \param check_only  - do not record mult, only check it
- * \return	      - index in mults[] array if new mult or new on band
+ * \return	      - index into mults[] array if new mult or on new band
  *			(-1 if multiplier is an empty string or not new)
  */
 int remember_multi(char *multiplier, int band, int mult_mode, bool check_only) {
     /* search multbuffer in mults array */
     bool found = false;
     int index = -1;
-
     if (multiplier == NULL || *multiplier == '\0' || mult_mode == MULT_NONE)
 	return -1;      /* ignore if empty string or disabled */
 

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -39,9 +39,7 @@
 
 GPtrArray *mults_possible;
 
-enum { ALL_BAND, PER_BAND };
-
-int mult1_mode = PER_BAND;  //FIXME configure
+int mult1_mode = MULT_BAND;  //FIXME configure
 
 /*
  * \return	      - index in mults[] array if new mult or new on band
@@ -60,7 +58,7 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
 
 	idx = get_exact_mult_index(qso->mult1_value);
 	if (idx >= 0) {
-	    remember_multi(get_mult(idx), qso->bandindex, ALL_BAND, check_only);
+	    remember_multi(get_mult(idx), qso->bandindex, MULT_ALL, check_only);
 	    // NOTE: return value not used, new mult is not marked in log
 	}
     }
@@ -72,7 +70,7 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
 	idx = get_exact_mult_index(qso->mult1_value);
 	if (idx >= 0) {
 	    mult_index =
-		remember_multi(get_mult(idx), qso->bandindex, PER_BAND, check_only);
+		remember_multi(get_mult(idx), qso->bandindex, MULT_BAND, check_only);
 	}
     }
 
@@ -83,7 +81,7 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
 	idx = get_exact_mult_index(qso->mult1_value);
 	if (idx >= 0) {
 	    mult_index =
-		remember_multi(get_mult(idx), qso->bandindex, ALL_BAND, check_only);
+		remember_multi(get_mult(idx), qso->bandindex, MULT_ALL, check_only);
 	}
     }
 
@@ -93,28 +91,28 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
 	idx = get_exact_mult_index(qso->mult1_value);
 	if (idx >= 0) {
 	    mult_index =
-		remember_multi(get_mult(idx), qso->bandindex, PER_BAND, check_only);
+		remember_multi(get_mult(idx), qso->bandindex, MULT_BAND, check_only);
 	}
     }
 
     // --------------------wysiwyg----------------
     else if (wysiwyg_once) {
-	mult_index = remember_multi(stripped_comment, qso->bandindex, ALL_BAND,
+	mult_index = remember_multi(stripped_comment, qso->bandindex, MULT_ALL,
 				    check_only);
     }
 
     else if (wysiwyg_multi) {
-	mult_index = remember_multi(stripped_comment, qso->bandindex, PER_BAND,
+	mult_index = remember_multi(stripped_comment, qso->bandindex, MULT_BAND,
 				    check_only);
     }
 
     /* -------------- unique call multi -------------- */
-    else if (unique_call_multi == UNIQUECALL_ALL) {
-	mult_index = remember_multi(qso->call, qso->bandindex, ALL_BAND, check_only);
+    else if (unique_call_multi == MULT_ALL) {
+	mult_index = remember_multi(qso->call, qso->bandindex, MULT_ALL, check_only);
     }
 
-    else if (unique_call_multi == UNIQUECALL_BAND) {
-	mult_index = remember_multi(qso->call, qso->bandindex, PER_BAND, check_only);
+    else if (unique_call_multi == MULT_BAND) {
+	mult_index = remember_multi(qso->call, qso->bandindex, MULT_BAND, check_only);
     }
 
     // -----------   default: use mult1   -----------
@@ -164,7 +162,7 @@ void addmult_lan(void) {
 	}
 
 	if (idx >= 0) {
-	    remember_multi(get_mult(idx), bandinx, ALL_BAND, check_only);
+	    remember_multi(get_mult(idx), bandinx, MULT_ALL, check_only);
 	}
     }
 
@@ -173,26 +171,26 @@ void addmult_lan(void) {
 	g_strlcpy(stripped_comment, lan_logline + 54, 15);
 	g_strchomp(stripped_comment);
 
-	new_mult = remember_multi(stripped_comment, bandinx, ALL_BAND, check_only);
+	new_mult = remember_multi(stripped_comment, bandinx, MULT_ALL, check_only);
     }
 
     if (wysiwyg_multi) {
 	g_strlcpy(stripped_comment, lan_logline + 54, 15);
 	g_strchomp(stripped_comment);
 
-	new_mult = remember_multi(stripped_comment, bandinx, PER_BAND, check_only);
+	new_mult = remember_multi(stripped_comment, bandinx, MULT_BAND, check_only);
     }
 
     /* -------------- unique call multi -------------- */
     g_strlcpy(multi_call, lan_logline + 68, 10);
     g_strchomp(multi_call);
 
-    if (unique_call_multi == UNIQUECALL_ALL) {
-	new_mult = remember_multi(multi_call, bandinx, ALL_BAND, check_only);
+    if (unique_call_multi == MULT_ALL) {
+	new_mult = remember_multi(multi_call, bandinx, MULT_ALL, check_only);
     }
 
-    if (unique_call_multi == UNIQUECALL_BAND) {
-	new_mult = remember_multi(multi_call, bandinx, PER_BAND, check_only);
+    if (unique_call_multi == MULT_BAND) {
+	new_mult = remember_multi(multi_call, bandinx, MULT_BAND, check_only);
     }
 
 }
@@ -418,7 +416,7 @@ static pthread_mutex_t mult_mutex = PTHREAD_MUTEX_INITIALIZER;
  *
  * \param multiplier  - the multiplier as a string
  * \param band	      - the bandindex we are on
- * \param mult_mode   - PER_BAND -> check also if new band
+ * \param mult_mode   - MULT_BAND -> check also if new band
  * \param check_only  - do not record mult, only check it
  * \return	      - index in mults[] array if new mult or new on band
  *			(-1 if multiplier is an empty string or not new)
@@ -447,7 +445,7 @@ int remember_multi(char *multiplier, int band, int mult_mode, bool check_only) {
 		    multscore[band]++;
 		}
 
-		if (mult_mode == PER_BAND) {
+		if (mult_mode == MULT_BAND) {
 		    index = i;  // new band
 		}
 	    }

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -39,8 +39,6 @@
 
 GPtrArray *mults_possible;
 
-int mult1_mode = MULT_BAND;  //FIXME configure
-
 /*
  * \return	      - index in mults[] array if new mult or new on band
  *			-1 if not a (new) mult
@@ -111,9 +109,15 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
 	mult_index = remember_multi(qso->call, qso->bandindex, unique_call_multi, check_only);
     }
 
-    // -----------   default: use mult1   -----------
-    else {
-	mult_index = remember_multi(qso->mult1_value, qso->bandindex, mult1_mode,
+    /* ------------ grid mult (per band) ------------- */
+    else if (serial_grid4_mult) {
+	mult_index = remember_multi(qso->mult1_value, qso->bandindex, MULT_BAND,
+				    check_only);
+    }
+
+    // -----------   generic: use mult1   -----------
+    else if (generic_mult != MULT_NONE) {
+	mult_index = remember_multi(qso->mult1_value, qso->bandindex, generic_mult,
 				    check_only);
     }
 

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -107,12 +107,8 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
     }
 
     /* -------------- unique call multi -------------- */
-    else if (unique_call_multi == MULT_ALL) {
-	mult_index = remember_multi(qso->call, qso->bandindex, MULT_ALL, check_only);
-    }
-
-    else if (unique_call_multi == MULT_BAND) {
-	mult_index = remember_multi(qso->call, qso->bandindex, MULT_BAND, check_only);
+    else if (unique_call_multi != MULT_NONE) {
+	mult_index = remember_multi(qso->call, qso->bandindex, unique_call_multi, check_only);
     }
 
     // -----------   default: use mult1   -----------

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -41,7 +41,6 @@ GPtrArray *mults_possible;
 
 enum { ALL_BAND, PER_BAND };
 
-char mult1_value[40];       //FIXME move to qso_t
 int mult1_mode = PER_BAND;  //FIXME configure
 
 /*
@@ -59,7 +58,7 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
     // --------------------------- arrlss ------------------------------------
     if (CONTEST_IS(ARRL_SS)) {
 
-	idx = get_exact_mult_index(mult1_value);
+	idx = get_exact_mult_index(qso->mult1_value);
 	if (idx >= 0) {
 	    remember_multi(get_mult(idx), qso->bandindex, ALL_BAND, check_only);
 	    // NOTE: return value not used, new mult is not marked in log
@@ -70,7 +69,7 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
     else if (serial_section_mult || sectn_mult) {
 
 	/* is it a mult? */
-	idx = get_exact_mult_index(mult1_value);
+	idx = get_exact_mult_index(qso->mult1_value);
 	if (idx >= 0) {
 	    mult_index =
 		remember_multi(get_mult(idx), qso->bandindex, PER_BAND, check_only);
@@ -81,7 +80,7 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
     else if (sectn_mult_once) {
 
 	/* is it a mult? */
-	idx = get_exact_mult_index(mult1_value);
+	idx = get_exact_mult_index(qso->mult1_value);
 	if (idx >= 0) {
 	    mult_index =
 		remember_multi(get_mult(idx), qso->bandindex, ALL_BAND, check_only);
@@ -91,7 +90,7 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
     // ------------------------------- section ----------------------------
     else if (dx_arrlsections && (countrynr == w_cty || countrynr == ve_cty)) {
 
-	idx = get_exact_mult_index(mult1_value);
+	idx = get_exact_mult_index(qso->mult1_value);
 	if (idx >= 0) {
 	    mult_index =
 		remember_multi(get_mult(idx), qso->bandindex, PER_BAND, check_only);
@@ -120,7 +119,7 @@ static int addmult_internal(struct qso_t *qso, bool check_only) {
 
     // -----------   default: use mult1   -----------
     else {
-	mult_index = remember_multi(mult1_value, qso->bandindex, mult1_mode,
+	mult_index = remember_multi(qso->mult1_value, qso->bandindex, mult1_mode,
 				    check_only);
     }
 
@@ -241,6 +240,9 @@ unsigned int get_matching_length(char *str, unsigned int n) {
 
 /* get mult index for exact match */
 int get_exact_mult_index(char *str) {
+    if (str == NULL) {
+	return -1;
+    }
     int len = strlen(str);
     if (len == 0) {
 	return -1;
@@ -426,7 +428,7 @@ int remember_multi(char *multiplier, int band, int mult_mode, bool check_only) {
     bool found = false;
     int index = -1;
 
-    if (*multiplier == '\0')
+    if (multiplier == NULL || *multiplier == '\0')
 	return -1;			/* ignore empty string */
 
     pthread_mutex_lock(&mult_mutex);

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -422,8 +422,8 @@ int remember_multi(char *multiplier, int band, int mult_mode, bool check_only) {
     bool found = false;
     int index = -1;
 
-    if (multiplier == NULL || *multiplier == '\0')
-	return -1;			/* ignore empty string */
+    if (multiplier == NULL || *multiplier == '\0' || mult_mode == MULT_NONE)
+	return -1;      /* ignore if empty string or disabled */
 
     pthread_mutex_lock(&mult_mutex);
 

--- a/src/addmult.h
+++ b/src/addmult.h
@@ -35,14 +35,15 @@ typedef struct {
 } possible_mult_t;
 
 
-void addmult(struct qso_t *qso);
+int addmult(struct qso_t *qso);
+int check_mult(struct qso_t *qso);
 void addmult_lan(void);
 char *get_mult(int n);
 int get_mult_count(void);
 unsigned int get_matching_length(char *str, unsigned int n);
 int get_exact_mult_index(char *str);
 int init_and_load_multipliers(void);
-int remember_multi(char *multiplier, int band, int show_new_band);
+int remember_multi(char *multiplier, int band, int mult_mode, bool check_only);
 void init_mults();
 
 #endif /* ADDMULT_H */

--- a/src/addspot.c
+++ b/src/addspot.c
@@ -80,7 +80,7 @@ static freq_t ask_frequency() {
 
 void add_local_spot(void) {
 
-    if (strlen(hiscall) < 3) {
+    if (strlen(current_qso.call) < 3) {
 	return;
     }
 
@@ -88,9 +88,9 @@ void add_local_spot(void) {
 	freq = ask_frequency();
     }
 
-    add_to_spots(hiscall, freq);
+    add_to_spots(current_qso.call, freq);
 
-    hiscall[0] = '\0';
+    current_qso.call[0] = '\0';
 }
 
 
@@ -116,14 +116,14 @@ static bool spot_too_old(const struct qso_t *qso) {
 }
 
 /* Get call and frequency in Hz of spot.
- * First try to use hiscall as spot call. If empty use data from last qso if
+ * First try to use current_qso.call as spot call. If empty use data from last qso if
  * not to old.
  * If no frequency data available ask user.
  * Returns true if valid spot data found.
  */
 static bool get_spot_data(char **spot_call, freq_t *spot_freq) {
-    if (strlen(hiscall) > 2) {
-	*spot_call = g_strdup(hiscall);
+    if (strlen(current_qso.call) > 2) {
+	*spot_call = g_strdup(current_qso.call);
 	if (trx_control) {
 	    *spot_freq = freq;
 	} else {

--- a/src/calledit.c
+++ b/src/calledit.c
@@ -45,17 +45,17 @@ void calledit(void) {
     int cnt = 0, insertflg = 0;
     char call1[30], call2[10];
 
-    l = strlen(hiscall);
+    l = strlen(current_qso.call);
     b = l - 1;
 
 
-    while ((i != ESCAPE) && (b <= strlen(hiscall))) {
+    while ((i != ESCAPE) && (b <= strlen(current_qso.call))) {
 
 	attroff(A_STANDOUT);
 	attron(COLOR_PAIR(C_HEADER));
 
 	mvaddstr(12, 29, "            ");
-	mvaddstr(12, 29, hiscall);
+	mvaddstr(12, 29, current_qso.call);
 	move(12, 29 + b);
 	/* no refreshp() here as getch() calls wrefresh() for the
 	 * panel with last output (whre the cursor should go */
@@ -95,7 +95,7 @@ void calledit(void) {
 
 	    // Right arrow
 	} else if (i == KEY_RIGHT) {
-	    if (b < strlen(hiscall) - 1) {
+	    if (b < strlen(current_qso.call) - 1) {
 		b++;
 	    } else
 		break;		/* stop edit */
@@ -103,10 +103,10 @@ void calledit(void) {
 	    // <Delete>
 	} else if (i == KEY_DC) {
 
-	    l = strlen(hiscall);
+	    l = strlen(current_qso.call);
 
 	    for (j = b; j <= l; j++) {
-		hiscall[j] = hiscall[j + 1];	/* move to left incl. \0 */
+		current_qso.call[j] = current_qso.call[j + 1];	/* move to left incl. \0 */
 	    }
 
 	    update_info_line();
@@ -121,10 +121,10 @@ void calledit(void) {
 
 		b--;
 
-		l = strlen(hiscall);
+		l = strlen(current_qso.call);
 
 		for (j = b; j <= l; j++) {
-		    hiscall[j] = hiscall[j + 1];
+		    current_qso.call[j] = current_qso.call[j + 1];
 		}
 
 		update_info_line();
@@ -152,11 +152,11 @@ void calledit(void) {
 		i = g_ascii_toupper(i);
 
 		if (b <= 12) {
-		    strncpy(call1, hiscall, b);
-		    strncpy(call2, hiscall + b, strlen(hiscall) - (b - 1));
+		    strncpy(call1, current_qso.call, b);
+		    strncpy(call2, current_qso.call + b, strlen(current_qso.call) - (b - 1));
 		}
 
-		if (strlen(hiscall) + 1 == 12)
+		if (strlen(current_qso.call) + 1 == 12)
 		    break;	// leave insert mode
 
 		call1[b] = i;
@@ -165,10 +165,10 @@ void calledit(void) {
 		    strcat(call1, call2);
 		    if (strlen(call1) >= 12)
 			break;
-		    strcpy(hiscall, call1);
+		    strcpy(current_qso.call, call1);
 		}
 
-		if ((b < strlen(hiscall) - 1) && (b <= 12))
+		if ((b < strlen(current_qso.call) - 1) && (b <= 12))
 		    b++;
 		else
 		    break;
@@ -189,7 +189,7 @@ void calledit(void) {
     attron(COLOR_PAIR(C_HEADER));
 
     mvaddstr(12, 29, "            ");
-    mvaddstr(12, 29, hiscall);
+    mvaddstr(12, 29, current_qso.call);
     refreshp();
 
     attron(A_STANDOUT);
@@ -220,16 +220,16 @@ int insert_char(int curposition) {
 	    ichr = ichr - 32;
 
 	if (curposition <= 10) {
-	    strncpy(call1, hiscall, curposition);
+	    strncpy(call1, current_qso.call, curposition);
 	}
 
 	if (curposition <= 10) {
-	    strncpy(call2, hiscall + curposition,
-		    strlen(hiscall) - (curposition - 1));
+	    strncpy(call2, current_qso.call + curposition,
+		    strlen(current_qso.call) - (curposition - 1));
 	}
 
 	// Too long!
-	if (strlen(hiscall) + 1 == MAX_CALL_LENGTH)
+	if (strlen(current_qso.call) + 1 == MAX_CALL_LENGTH)
 	    break;		// leave insert mode
 
 	// Accept A-Z or / and 1-9
@@ -239,9 +239,9 @@ int insert_char(int curposition) {
 	    call1[curposition + 1] = '\0';
 	    if ((strlen(call1) + strlen(call2)) < 12) {
 		strcat(call1, call2);
-		if (strlen(call1) + strlen(hiscall) >= 12)
+		if (strlen(call1) + strlen(current_qso.call) >= 12)
 		    break;
-		strcpy(hiscall, call1);
+		strcpy(current_qso.call, call1);
 	    }
 	} else
 	    break;
@@ -249,7 +249,7 @@ int insert_char(int curposition) {
 	attroff(A_STANDOUT);
 	attron(COLOR_PAIR(C_HEADER));
 
-	mvaddstr(12, 29, hiscall);
+	mvaddstr(12, 29, current_qso.call);
 	curposition++;
 	move(12, 29 + curposition);
 	refreshp();

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -138,7 +138,7 @@ int callinput(void) {
     struct grab_t {
 	enum grabstate_t state;
 	freq_t spotfreq;
-	char call[15];
+	char call[CALL_SIZE];
     };
 
     static struct grab_t grab =  { .state = NONE };
@@ -154,7 +154,7 @@ int callinput(void) {
     printcall();	/* print call input field */
     searchlog();
 
-    while (strlen(hiscall) <= MAX_CALL_LENGTH) {
+    while (strlen(current_qso.call) <= MAX_CALL_LENGTH) {
 
 	show_zones(bandinx);
 	update_info_line();
@@ -174,7 +174,7 @@ int callinput(void) {
 		show_rtty();
 	    }
 
-	    if (digikeyer == FLDIGI && fldigi_set_callfield == 1 && hiscall[0] != '\0') {
+	    if (digikeyer == FLDIGI && fldigi_set_callfield == 1 && current_qso.call[0] != '\0') {
 		freqstore = freq;
 		fldigi_set_callfield = 0;
 	    }
@@ -183,10 +183,10 @@ int callinput(void) {
 	     * (indicated by non-zero freqstore) check if he turns away
 	     * from frequency and if so add call to spot list */
 	    if (bmautoadd && freqstore != 0) {
-		if (strlen(hiscall) >= 3) {
+		if (strlen(current_qso.call) >= 3) {
 		    if (fabs(freq - freqstore) > 500) {
-			add_to_spots(hiscall, freqstore);
-			hiscall[0] = '\0';
+			add_to_spots(current_qso.call, freqstore);
+			current_qso.call[0] = '\0';
 			freqstore = 0;
 			break;
 		    }
@@ -196,10 +196,10 @@ int callinput(void) {
 	    /* if BMAUTOGRAB is active in S&P mode and input field is empty and a spot has
 	     * not already been grabbed here check if a spot is on freq
 	     * and pick it up if one found */
-	    if (bmautograb && cqmode == S_P && *hiscall == '\0' && grab.state == NONE) {
+	    if (bmautograb && cqmode == S_P && *current_qso.call == '\0' && grab.state == NONE) {
 		get_spot_on_qrg(grab.call, freq);
 		if (strlen(grab.call) >= 3) {
-		    strncpy(hiscall, grab.call, sizeof(hiscall));
+		    g_strlcpy(current_qso.call, grab.call, CALL_SIZE);
 		    grab.state = REACHED;
 		    grab.spotfreq = freq;
 		    freqstore = 0;
@@ -219,20 +219,20 @@ int callinput(void) {
 	     * then forget about it */
 	    if (fabs(freq - grab.spotfreq) > 500 && grab.state == REACHED) {
 		grab.state = NONE;
-		hiscall[0] = '\0';
+		current_qso.call[0] = '\0';
 		break;
 	    }
 
 
 	    /* make sure that the wrefresh() inside getch() shows the cursor
 	     * in the input field */
-	    wmove(stdscr, 12, 29 + strlen(hiscall));
+	    wmove(stdscr, 12, 29 + strlen(current_qso.call));
 	    x = key_poll();
 
 	}
 
 	/* special handling of some keycodes if call field is empty */
-	if (*hiscall == '\0') {
+	if (*current_qso.call == '\0') {
 	    // <Enter>, sends CQ message (F1), starts autoCQ, or sends S&P message.
 	    if (x == '\n' || x == KEY_ENTER) {
 		if (cqmode == CQ) {
@@ -292,7 +292,7 @@ int callinput(void) {
 
 		} else {
 
-		    if (strlen(hiscall) > 2) {
+		    if (strlen(current_qso.call) > 2) {
 			if ((CONTEST_IS(CQWW) || wazmult)
 				&& current_qso.comment[0] == '\0')
 			    strcpy(current_qso.comment, cqzone);
@@ -336,7 +336,7 @@ int callinput(void) {
 
 	    // <Home>, enter call edit when call field is not empty.
 	    case KEY_HOME: {
-		if ((*hiscall != '\0') && (ungetch(x) == OK)) {
+		if ((*current_qso.call != '\0') && (ungetch(x) == OK)) {
 		    calledit();
 		}
 
@@ -345,7 +345,7 @@ int callinput(void) {
 
 	    // Left Arrow, enter call edit when call field is not empty, or band down.
 	    case KEY_LEFT: {
-		if (*hiscall != '\0') {
+		if (*current_qso.call != '\0') {
 		    calledit();
 		} else {
 		    handle_bandswitch(BAND_DOWN);
@@ -435,13 +435,13 @@ int callinput(void) {
 
 	    // <Page-Up>, change RST if call field not empty, else increase CW speed.
 	    case KEY_PPAGE: {
-		if (change_rst && (strlen(hiscall) != 0)) {	// change RST
+		if (change_rst && (strlen(current_qso.call) != 0)) {	// change RST
 
 		    rst_sent_up();
 
 		    if (!no_rst)
 			mvaddstr(12, 44, sent_rst);
-		    mvaddstr(12, 29, hiscall);
+		    mvaddstr(12, 29, current_qso.call);
 
 		} else {	// change cw speed
 		    speedup();
@@ -456,13 +456,13 @@ int callinput(void) {
 
 	    // <Page-Down>, change RST if call field not empty, else decrease CW speed.
 	    case KEY_NPAGE: {
-		if (change_rst && (strlen(hiscall) != 0)) {
+		if (change_rst && (strlen(current_qso.call) != 0)) {
 
 		    rst_sent_down();
 
 		    if (!no_rst)
 			mvaddstr(12, 44, sent_rst);
-		    mvaddstr(12, 29, hiscall);
+		    mvaddstr(12, 29, current_qso.call);
 
 		} else {
 
@@ -477,7 +477,7 @@ int callinput(void) {
 	    // <Enter>, log QSO in CT mode, else test if B4 message should be sent.
 	    case '\n':
 	    case KEY_ENTER: {
-		if (strlen(hiscall) > 2 && ctcomp) {
+		if (strlen(current_qso.call) > 2 && ctcomp) {
 		    /* There seems to be a call, log it in CT mode but only if
 		     * the exchange field is not empty.
 		     */
@@ -491,12 +491,12 @@ int callinput(void) {
 		    }
 		}
 
-		if (strlen(hiscall) < 3 || nob4)
+		if (strlen(current_qso.call) < 3 || nob4)
 		    break;
 
 		/* check b4 QSO if call is long enough and 'nob4' off */
 
-		dupe = is_dupe(hiscall, bandinx, trxmode);
+		dupe = is_dupe(current_qso.call, bandinx, trxmode);
 
 		if (dupe == ISDUPE) {
 		    // XXX: Before digi_message, SSB mode sent CW here. - W8BSD
@@ -523,7 +523,7 @@ int callinput(void) {
 	    // Colon, prefix for entering commands or changing parameters.
 	    case ':': {
 		changepars();
-		hiscall[0] = '\0';
+		current_qso.call[0] = '\0';
 		x = 0;
 		clear_display();
 		attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
@@ -614,10 +614,10 @@ int callinput(void) {
 
 	    // Query, send call with " ?" appended or F5 message in voice mode.
 	    case '?': {
-		if (*hiscall != '\0') {
-		    strcat(hiscall, " ?");
+		if (*current_qso.call != '\0') {
+		    strcat(current_qso.call, " ?");
 		    send_standard_message(4);
-		    hiscall[strlen(hiscall) - 2] = '\0';
+		    current_qso.call[strlen(current_qso.call) - 2] = '\0';
 		}
 		x = -1;
 		break;
@@ -625,11 +625,11 @@ int callinput(void) {
 
 	    // <Backspace>, remove character left of cursor, move cursor left one position.
 	    case KEY_BACKSPACE: {
-		if (*hiscall != '\0') {
+		if (*current_qso.call != '\0') {
 		    getyx(stdscr, cury, curx);
 		    mvaddstr(cury, curx - 1, " ");
 		    move(cury, curx - 1);
-		    hiscall[strlen(hiscall) - 1] = '\0';
+		    current_qso.call[strlen(current_qso.call) - 1] = '\0';
 		}
 		break;
 	    }
@@ -968,16 +968,16 @@ int callinput(void) {
 	if (valid_call_char(x)) {
 	    x = g_ascii_toupper(x);
 
-	    if (strlen(hiscall) < MAX_CALL_LENGTH) {
+	    if (strlen(current_qso.call) < MAX_CALL_LENGTH) {
 		instring[0] = x;
 		instring[1] = '\0';
 		addch(x);
-		strcat(hiscall, instring);
+		strcat(current_qso.call, instring);
 		if (cqmode == CQ && cwstart > 0 &&
 			trxmode == CWMODE && iscontest) {
 		    /* early start keying after 'cwstart' characters but only
 		     * if input field contains at least one nondigit */
-		    if (strlen(hiscall) == cwstart && !plain_number(hiscall)) {
+		    if (strlen(current_qso.call) == cwstart && !plain_number(current_qso.call)) {
 			x = autosend();
 		    }
 		}
@@ -991,7 +991,7 @@ int callinput(void) {
 	    if (x == '\n' || x == KEY_ENTER) {
 		/* early start keying after 'Enter' but only if input field
 		 * contains at least two chars, one or more of it nondigit */
-		if (strlen(hiscall) >= 2 && !plain_number(hiscall)) {
+		if (strlen(current_qso.call) >= 2 && !plain_number(current_qso.call)) {
 		    x = autosend();
 		}
 	    }
@@ -1060,15 +1060,15 @@ int autosend() {
 
     early_started = 1;
     sending_call = 1;
-    sendmessage(hiscall);
+    sendmessage(current_qso.call);
     sending_call = 0;
-    strcpy(hiscall_sent, hiscall);
+    strcpy(hiscall_sent, current_qso.call);
 
     char_sent = 0; 			/* no char sent so far */
-    timeout_sent = (1.2 / GetCWSpeed()) * getCWdots(hiscall[char_sent]);
+    timeout_sent = (1.2 / GetCWSpeed()) * getCWdots(current_qso.call[char_sent]);
 
     timer = g_timer_new();
-    timeout = (1.2 / GetCWSpeed()) * cw_message_length(hiscall);
+    timeout = (1.2 / GetCWSpeed()) * cw_message_length(current_qso.call);
 
     x = -1;
     while ((x != ESCAPE) && (x != '\n' && x != KEY_ENTER)) {
@@ -1083,13 +1083,13 @@ int autosend() {
 		/* one char sent - display and set new timeout */
 		char_sent ++;
 		timeout_sent +=
-		    (1.2 / GetCWSpeed()) * getCWdots(hiscall[char_sent]);
+		    (1.2 / GetCWSpeed()) * getCWdots(current_qso.call[char_sent]);
 
 	    }
 
 	    /* make sure that the wrefresh() inside getch() shows the cursor
 	     * in the input field */
-	    wmove(stdscr, 12, 29 + strlen(hiscall));
+	    wmove(stdscr, 12, 29 + strlen(current_qso.call));
 	    x = key_poll();
 
 	}
@@ -1108,16 +1108,16 @@ int autosend() {
 	}
 
 
-	int len = strlen(hiscall);
+	int len = strlen(current_qso.call);
 	if (len < 13 && valid_call_char(x)) {
 	    char append[2];
 
 	    /* convert to upper case */
 	    x = g_ascii_toupper(x);
 
-	    /* insert into hiscall */
-	    hiscall[len] = x;
-	    hiscall[len + 1] = '\0';
+	    /* insert into current_qso.call */
+	    current_qso.call[len] = x;
+	    current_qso.call[len + 1] = '\0';
 
 	    /* display it  */
 	    printcall();
@@ -1195,7 +1195,7 @@ void send_bandswitch(freq_t freq) {
  **/
 void handle_bandswitch(int direction) {
     // make sure call field is empty and arrows are enabled
-    if (*hiscall != '\0' || no_arrows) {
+    if (*current_qso.call != '\0' || no_arrows) {
 	return;
     }
 

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -294,13 +294,13 @@ int callinput(void) {
 
 		    if (strlen(hiscall) > 2) {
 			if ((CONTEST_IS(CQWW) || wazmult)
-				&& (*comment == '\0'))
-			    strcpy(comment, cqzone);
+				&& current_qso.comment[0] == '\0')
+			    strcpy(current_qso.comment, cqzone);
 
-			if (itumult && (*comment == '\0'))
-			    strcpy(comment, ituzone);
+			if (itumult && current_qso.comment[0] == '\0')
+			    strcpy(current_qso.comment, ituzone);
 
-			if (*comment == '\0') {
+			if (current_qso.comment[0] == '\0') {
 			    x = -1;
 			} else {
 			    /* F4 (TU macro) */
@@ -481,7 +481,7 @@ int callinput(void) {
 		    /* There seems to be a call, log it in CT mode but only if
 		     * the exchange field is not empty.
 		     */
-		    if (comment[0] == '\0') {
+		    if (current_qso.comment[0] == '\0') {
 			x = -1;
 			break;
 		    } else {

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -500,7 +500,7 @@ int changepars(void) {
 
 	    attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
-	    move(12, 29 + strlen(hiscall));
+	    move(12, 29 + strlen(current_qso.call));
 	    break;
 
 	}
@@ -653,7 +653,7 @@ int changepars(void) {
     mvaddstr(12, 29, "            ");
     move(12, 29);
     refreshp();
-    hiscall[0] = '\0';
+    current_qso.call[0] = '\0';
 
     return (0);
 }

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -31,7 +31,7 @@
 
 void cleanup_qso(void) {
     hiscall[0] = '\0';	    /* reset hiscall and comment */
-    comment[0] = '\0';
+    current_qso.comment[0] = '\0';
     normalized_comment[0] = '\0';
     proposed_exchange[0] = '\0';
     rst_reset();;	    /* reset to 599 */

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -32,7 +32,7 @@
 void cleanup_qso(void) {
     hiscall[0] = '\0';	    /* reset hiscall and comment */
     current_qso.comment[0] = '\0';
-    normalized_comment[0] = '\0';
+    current_qso.normalized_comment[0] = '\0';
     proposed_exchange[0] = '\0';
     rst_reset();;	    /* reset to 599 */
     countrynr = 0;

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -30,7 +30,7 @@
 #include "write_keyer.h"
 
 void cleanup_qso(void) {
-    hiscall[0] = '\0';	    /* reset hiscall and comment */
+    current_qso.call[0] = '\0';	    /* reset current call and comment */
     current_qso.comment[0] = '\0';
     current_qso.normalized_comment[0] = '\0';
     proposed_exchange[0] = '\0';

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -686,7 +686,7 @@ int fldigi_get_log_serial_number() {
 
 	    // if the previous exchange isn't empty, but the current value is it,
 	    // that means the OP cleaned up the field, so we need to clean up it in Fldigi
-	    if (comment[0] == '\0' && tcomment[0] != '\0') {
+	    if (current_qso.comment[0] == '\0' && tcomment[0] != '\0') {
 		tcomment[0] = '\0';
 		rc = fldigi_xmlrpc_query(&result, &env, "log.set_exchange", "s", "");
 		if (rc != 0) {
@@ -695,10 +695,10 @@ int fldigi_get_log_serial_number() {
 	    }
 	    // otherwise we need to fill the Tlf exchange field
 	    else {
-		if (strlen(tempstr) > 0 && comment[0] == '\0') {
-		    strcpy(comment, tempstr);
-		    comment[strlen(tempstr)] = '\0';
-		    strcpy(tcomment, comment);
+		if (strlen(tempstr) > 0 && current_qso.comment[0] == '\0') {
+		    strcpy(current_qso.comment, tempstr);
+		    current_qso.comment[strlen(tempstr)] = '\0';
+		    strcpy(tcomment, current_qso.comment);
 		    refresh_comment();
 		}
 	    }

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -627,7 +627,7 @@ int fldigi_get_log_call() {
 
 	    // check the current call in Tlf; if the previous local callsign isn't empty,
 	    // that means the OP clean up the callsign field, so it needs to clean in Fldigi too
-	    if (hiscall[0] == '\0' && thiscall[0] != '\0') {
+	    if (current_qso.call[0] == '\0' && thiscall[0] != '\0') {
 		thiscall[0] = '\0';
 		rc = fldigi_xmlrpc_query(&result, &env, "log.set_call", "s", "");
 		if (rc != 0) {
@@ -637,12 +637,12 @@ int fldigi_get_log_call() {
 	    // otherwise, fill the callsign field in Tlf
 	    else {
 		if (strlen(tempstr) >= 3) {
-		    if (hiscall[0] == '\0') {
-			strcpy(hiscall, tempstr);
-			hiscall[strlen(tempstr)] = '\0';
-			strcpy(thiscall, hiscall);
+		    if (current_qso.call[0] == '\0') {
+			strcpy(current_qso.call, tempstr);
+			current_qso.call[strlen(tempstr)] = '\0';
+			strcpy(thiscall, current_qso.call);
 			printcall();
-			getctydata_pfx(hiscall);
+			getctydata_pfx(current_qso.call);
 			searchlog();
 			fldigi_set_callfield = 1;
 		    }

--- a/src/focm.c
+++ b/src/focm.c
@@ -49,7 +49,7 @@ int cont;
 
 
 int score_foc() {
-    return foc_score(hiscall);
+    return foc_score(current_qso.call);
 }
 
 /** FOC contest configuration */

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -513,11 +513,11 @@ static void checkexchange_cqww(char *comment, bool interactive) {
     g_match_info_free(match_info);
 
     // multiplier: zone
-    sprintf(normalized_comment, "%02d", zone);
-    g_strlcpy(mult1_value, normalized_comment, sizeof(normalized_comment));
+    sprintf(current_qso.normalized_comment, "%02d", zone);
+    g_strlcpy(mult1_value, current_qso.normalized_comment, COMMENT_SIZE);
 
     if (interactive) {
-	OnLowerSearchPanel(32, normalized_comment); // show current zone
+	OnLowerSearchPanel(32, current_qso.normalized_comment); // show current zone
     }
 }
 
@@ -601,7 +601,7 @@ static void checkexchange_arrlss(char *comment, bool interactive) {
 	OnLowerSearchPanel(8, buf);
     }
 
-    sprintf(normalized_comment, "%s %s %s %s", serial, precedent, check, section);
+    sprintf(current_qso.normalized_comment, "%s %s %s %s", serial, precedent, check, section);
     g_strlcpy(mult1_value, section, sizeof(section));   // multiplier: section
 }
 
@@ -670,7 +670,7 @@ static void checkexchange_serial_section(char *comment, bool interactive) {
     }
 
     if (serial[0] && section[0]) {
-	sprintf(normalized_comment, "%s %s", serial, section);
+	sprintf(current_qso.normalized_comment, "%s %s", serial, section);
 	g_strlcpy(mult1_value, section, sizeof(mult1_value));   // multiplier: section
     }
 }
@@ -719,7 +719,7 @@ static void checkexchange_sectn_mult(char *comment, bool interactive) {
     }
 
     if (section[0]) {
-	g_strlcpy(normalized_comment, section, sizeof(normalized_comment));
+	g_strlcpy(current_qso.normalized_comment, section, COMMENT_SIZE);
 	g_strlcpy(mult1_value, section, sizeof(mult1_value));   // multiplier: section
     }
 }
@@ -727,15 +727,16 @@ static void checkexchange_sectn_mult(char *comment, bool interactive) {
 /* ------------------------------------------------------------------------ */
 /*
     input: comment, interactive
-    output (global vars): section, mult1_value, normalized_comment
-    output (current_qso): callupdate
+    output (global vars): section, mult1_value
+    output (current_qso): callupdate, normalized_comment
+    //FIXME use qso_t arg instead of comment
     side effect: lower line of search panel updated if interactive
 */
 
 void checkexchange(char *comment, bool interactive) {
 
     current_qso.callupdate[0] = 0;
-    normalized_comment[0] = 0;
+    current_qso.normalized_comment[0] = 0;
     mult1_value[0] = 0;
 
     // ----------------------------cqww------------------------------

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -726,8 +726,7 @@ static void checkexchange_sectn_mult(struct qso_t *qso, bool interactive) {
 /* ------------------------------------------------------------------------ */
 /*
     input: comment, interactive
-    output (current_qso): callupdate, normalized_comment, section, mult1_value
-    //FIXME use qso_t arg instead of comment
+    output (qso): callupdate, normalized_comment, section, mult1_value
     side effect: lower line of search panel updated if interactive
 */
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -59,8 +59,6 @@
 #include "getexchange.h"
 
 
-static char section[MAX_SECTION_LENGTH + 1] = "";
-
 void exchange_edit(void);
 
 int getexchange(void) {
@@ -410,12 +408,12 @@ int getexchange(void) {
 
 	    }
 
-	    if (CONTEST_IS(ARRL_SS) && (x != TAB) && (strlen(section) < 2)) {
+	    if (CONTEST_IS(ARRL_SS) && (x != TAB) && (strlen(current_qso.section) < 2)) {
 		mvaddstr(13, 54, "section?");
 		mvaddstr(12, 54, current_qso.comment);
 		x = 0;
 	    } else if ((serial_section_mult || sectn_mult)
-		       && ((x != TAB) && (strlen(section) < 1))) {
+		       && ((x != TAB) && (strlen(current_qso.section) < 1))) {
 		if (!serial_or_section
 			|| (serial_or_section && country_found(hiscall))) {
 		    mvaddstr(13, 54, "section?");
@@ -539,7 +537,7 @@ static void checkexchange_arrlss(char *comment, bool interactive) {
 	regex = g_regex_new(PATTERN, 0, 0, NULL);
     }
 
-    section[0] = 0;
+    current_qso.section[0] = 0;
 
     GMatchInfo *match_info;
     g_regex_match(regex, comment, 0, &match_info);
@@ -586,7 +584,7 @@ static void checkexchange_arrlss(char *comment, bool interactive) {
 	index = g_match_info_fetch(match_info, 5);
 	if (index != NULL && index[0] != 0) {
 	    if (get_exact_mult_index(index) >= 0) {
-		g_strlcpy(section, index, sizeof(section));
+		g_strlcpy(current_qso.section, index, MAX_SECTION_LENGTH + 1);
 	    }
 	}
 	g_free(index);
@@ -597,12 +595,12 @@ static void checkexchange_arrlss(char *comment, bool interactive) {
     if (interactive) {
 	char buf[40];
 	sprintf(buf, " %4s %1s %2s %2s ", serial, precedent,
-		check, section);
+		check, current_qso.section);
 	OnLowerSearchPanel(8, buf);
     }
 
-    sprintf(current_qso.normalized_comment, "%s %s %s %s", serial, precedent, check, section);
-    g_strlcpy(mult1_value, section, sizeof(section));   // multiplier: section
+    sprintf(current_qso.normalized_comment, "%s %s %s %s", serial, precedent, check, current_qso.section);
+    g_strlcpy(mult1_value, current_qso.section, MAX_SECTION_LENGTH + 1);   // multiplier: section
 }
 
 static void checkexchange_serial_section(char *comment, bool interactive) {
@@ -619,7 +617,7 @@ static void checkexchange_serial_section(char *comment, bool interactive) {
 	regex = g_regex_new(PATTERN, 0, 0, NULL);
     }
 
-    section[0] = 0;
+    current_qso.section[0] = 0;
 
     GMatchInfo *match_info;
     g_regex_match(regex, comment, 0, &match_info);
@@ -640,7 +638,7 @@ static void checkexchange_serial_section(char *comment, bool interactive) {
 	index = g_match_info_fetch(match_info, 2);
 	if (index != NULL && index[0] != 0) {
 	    if (serial_grid4_mult || get_exact_mult_index(index) >= 0) {
-		g_strlcpy(section, index, sizeof(section));
+		g_strlcpy(current_qso.section, index, MAX_SECTION_LENGTH + 1);
 	    }
 	}
 	g_free(index);
@@ -655,23 +653,23 @@ static void checkexchange_serial_section(char *comment, bool interactive) {
     g_match_info_free(match_info);
 
     if (serial_grid4_mult) {
-        if (!check_qra(section)) {
-            section[0] = 0;
+        if (!check_qra(current_qso.section)) {
+            current_qso.section[0] = 0;
         }
-        if (strlen(section) > 4) {
-            section[4] = 0;     // mult is the first 4 chars only
+        if (strlen(current_qso.section) > 4) {
+            current_qso.section[4] = 0;     // mult is the first 4 chars only
         }
     }
 
     if (interactive) {
 	char buf[40];
-	sprintf(buf, " %*s ", -MAX_SECTION_LENGTH, section);
+	sprintf(buf, " %*s ", -MAX_SECTION_LENGTH, current_qso.section);
 	OnLowerSearchPanel(32, buf);
     }
 
-    if (serial[0] && section[0]) {
-	sprintf(current_qso.normalized_comment, "%s %s", serial, section);
-	g_strlcpy(mult1_value, section, sizeof(mult1_value));   // multiplier: section
+    if (serial[0] && current_qso.section[0]) {
+	sprintf(current_qso.normalized_comment, "%s %s", serial, current_qso.section);
+	g_strlcpy(mult1_value, current_qso.section, sizeof(mult1_value));   // multiplier: section
     }
 }
 
@@ -686,7 +684,7 @@ static void checkexchange_sectn_mult(char *comment, bool interactive) {
 	regex = g_regex_new(PATTERN, 0, 0, NULL);
     }
 
-    section[0] = 0;
+    current_qso.section[0] = 0;
 
     GMatchInfo *match_info;
     g_regex_match(regex, comment, 0, &match_info);
@@ -698,7 +696,7 @@ static void checkexchange_sectn_mult(char *comment, bool interactive) {
 	index = g_match_info_fetch(match_info, 1);
 	if (index != NULL && index[0] != 0) {
 	    if (get_exact_mult_index(index) >= 0) {
-		g_strlcpy(section, index, sizeof(section));
+		g_strlcpy(current_qso.section, index, MAX_SECTION_LENGTH + 1);
 	    }
 	}
 	g_free(index);
@@ -714,13 +712,13 @@ static void checkexchange_sectn_mult(char *comment, bool interactive) {
 
     if (interactive) {
 	char buf[40];
-	sprintf(buf, " %*s ", -MAX_SECTION_LENGTH, section);
+	sprintf(buf, " %*s ", -MAX_SECTION_LENGTH, current_qso.section);
 	OnLowerSearchPanel(32, buf);
     }
 
-    if (section[0]) {
-	g_strlcpy(current_qso.normalized_comment, section, COMMENT_SIZE);
-	g_strlcpy(mult1_value, section, sizeof(mult1_value));   // multiplier: section
+    if (current_qso.section[0]) {
+	g_strlcpy(current_qso.normalized_comment, current_qso.section, COMMENT_SIZE);
+	g_strlcpy(mult1_value, current_qso.section, sizeof(mult1_value));   // multiplier: section
     }
 }
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -88,15 +88,15 @@ int getexchange(void) {
 	recall_exchange();
 
     if ((CONTEST_IS(CQWW) || wazmult || itumult)
-	    && (*comment == '\0') && (strlen(hiscall) != 0)) {
+	    && (current_qso.comment[0] == '\0') && (strlen(hiscall) != 0)) {
 	if (itumult)
-	    strcpy(comment, ituzone);
+	    strcpy(current_qso.comment, ituzone);
 	else
-	    strcpy(comment, cqzone);
+	    strcpy(current_qso.comment, cqzone);
     }
-    if ((exc_cont) && (*comment == '\0')
+    if ((exc_cont) && (current_qso.comment[0] == '\0')
 	    && (strlen(hiscall) != 0)) {
-	strcpy(comment, continent);
+	strcpy(current_qso.comment, continent);
     }
 
     if (CONTEST_IS(STEWPERRY)) {
@@ -107,12 +107,12 @@ int getexchange(void) {
 
     commentfield = 1;
 
-    i = strlen(comment);
+    i = strlen(current_qso.comment);
     while (1) {
 
 	refresh_comment();
 
-	checkexchange(comment, true);
+	checkexchange(current_qso.comment, true);
 
 	if (call_update && strlen(callupdate) >= 3) {
 	    strcpy(hiscall, callupdate);
@@ -134,7 +134,7 @@ int getexchange(void) {
 
 	    /* make sure that the wrefresh() inside getch() shows the cursor
 	     * in the input field */
-	    wmove(stdscr, 12, 54 + strlen(comment));
+	    wmove(stdscr, 12, 54 + strlen(current_qso.comment));
 	    x = key_poll();
 	}
 
@@ -159,14 +159,14 @@ int getexchange(void) {
 	    }
 	    case CTRL_A: {	// Ctrl-A (^A)
 		add_local_spot();
-		*comment = '\0';
+		current_qso.comment[0] = '\0';
 		x = TAB;	// <Tab>
 		break;
 	    }
 
 	    case KEY_BACKSPACE: {	// Erase (^H or <Backspace>)
 		if (i >= 1) {
-		    comment[strlen(comment) - 1] = '\0';
+		    current_qso.comment[strlen(current_qso.comment) - 1] = '\0';
 		    i -= 1;
 		}
 		break;
@@ -174,9 +174,9 @@ int getexchange(void) {
 
 	    case ESCAPE: {                // <Escape>
 		stoptx();			/* stop sending CW */
-		if (comment[0] != '\0') {	/* if comment not empty */
+		if (current_qso.comment[0] != '\0') {	/* if comment not empty */
 		    /* drop exchange so far */
-		    comment[0] = '\0';
+		    current_qso.comment[0] = '\0';
 		    i = 0;
 		} else {
 		    /* back to callinput */
@@ -203,7 +203,7 @@ int getexchange(void) {
 	    /* '+', send TU and log in CT mode */
 	    case '+': {
 		if (ctcomp && (strlen(hiscall) > 2)) {
-		    if (comment[0] == '\0') {
+		    if (current_qso.comment[0] == '\0') {
 			x = -1;
 		    } else {
 			/* F4 (TU macro) */
@@ -257,7 +257,7 @@ int getexchange(void) {
 	    }
 
 	    case KEY_LEFT: {	/* Left Arrow--edit exchange field */
-		if (*comment != '\0')
+		if (current_qso.comment[0] != '\0')
 		    exchange_edit();
 		break;
 	    }
@@ -308,7 +308,7 @@ int getexchange(void) {
 		 * or not in contest */
 		if ((ctcomp) || (!iscontest)) {
 		    /* Don't log if exchange field is empty. */
-		    if (comment[0] == '\0') {
+		    if (current_qso.comment[0] == '\0') {
 			x = -1;
 		    } else {
 			/* Log without sending a message. */
@@ -326,7 +326,7 @@ int getexchange(void) {
 	    if (x >= ' ' && x <= 'Z') {
 		instring[0] = x;
 		addch(x);
-		strcat(comment, instring);
+		strcat(current_qso.comment, instring);
 		i++;
 		refreshp();
 	    }
@@ -336,108 +336,108 @@ int getexchange(void) {
 	if (x == '\n' || x == KEY_ENTER || x == TAB
 		|| x == CTRL_K || x == BACKSLASH) {
 
-	    if ((contest->exchange_serial && comment[0] >= '0'
-		    && comment[0] <= '9')) {	/* align serial nr. */
-		if (strlen(comment) == 1) {
-		    strcpy(commentbuf, comment);
-		    comment[0] = '\0';
-		    strcat(comment, "00");
-		    strcat(comment, commentbuf);
+	    if ((contest->exchange_serial && current_qso.comment[0] >= '0'
+		    && current_qso.comment[0] <= '9')) {	/* align serial nr. */
+		if (strlen(current_qso.comment) == 1) {
+		    strcpy(commentbuf, current_qso.comment);
+		    current_qso.comment[0] = '\0';
+		    strcat(current_qso.comment, "00");
+		    strcat(current_qso.comment, commentbuf);
 		}
 
-		if (strlen(comment) == 2) {
-		    strcpy(commentbuf, comment);
-		    comment[0] = '\0';
-		    strcat(comment, "0");
-		    strcat(comment, commentbuf);
+		if (strlen(current_qso.comment) == 2) {
+		    strcpy(commentbuf, current_qso.comment);
+		    current_qso.comment[0] = '\0';
+		    strcat(current_qso.comment, "0");
+		    strcat(current_qso.comment, commentbuf);
 		}
 
 	    }
 
 	    if (CONTEST_IS(WPX)) {	/* align serial nr. */
 
-		if ((strlen(comment) == 1) || (comment[1] == ' ')) {
-		    strcpy(commentbuf, comment);
-		    comment[0] = '\0';
-		    strcat(comment, "00");
-		    strcat(comment, commentbuf);
+		if ((strlen(current_qso.comment) == 1) || (current_qso.comment[1] == ' ')) {
+		    strcpy(commentbuf, current_qso.comment);
+		    current_qso.comment[0] = '\0';
+		    strcat(current_qso.comment, "00");
+		    strcat(current_qso.comment, commentbuf);
 		}
 
-		if ((strlen(comment) == 2) || (comment[2] == ' ')) {
-		    strcpy(commentbuf, comment);
-		    comment[0] = '\0';
-		    strcat(comment, "0");
-		    strcat(comment, commentbuf);
+		if ((strlen(current_qso.comment) == 2) || (current_qso.comment[2] == ' ')) {
+		    strcpy(commentbuf, current_qso.comment);
+		    current_qso.comment[0] = '\0';
+		    strcat(current_qso.comment, "0");
+		    strcat(current_qso.comment, commentbuf);
 		}
 
 	    }
 
 	    if (CONTEST_IS(SPRINT)) {
 
-		if ((comment[1] == ' ') && (comment[0] != ' ')) {
+		if ((current_qso.comment[1] == ' ') && (current_qso.comment[0] != ' ')) {
 
 		    strcpy(commentbuf, "00");
-		    commentbuf[2] = comment[0];
+		    commentbuf[2] = current_qso.comment[0];
 		    commentbuf[3] = '\0';
-		    strcat(commentbuf, comment + 1);
-		    strcpy(comment, commentbuf);
+		    strcat(commentbuf, current_qso.comment + 1);
+		    strcpy(current_qso.comment, commentbuf);
 		}
-		if ((comment[2] == ' ') && (comment[1] != ' ')) {
+		if ((current_qso.comment[2] == ' ') && (current_qso.comment[1] != ' ')) {
 
 		    strcpy(commentbuf, "0");
-		    commentbuf[1] = comment[0];
-		    commentbuf[2] = comment[1];
+		    commentbuf[1] = current_qso.comment[0];
+		    commentbuf[2] = current_qso.comment[1];
 		    commentbuf[3] = '\0';
-		    strcat(commentbuf, comment + 2);
-		    strcpy(comment, commentbuf);
+		    strcat(commentbuf, current_qso.comment + 2);
+		    strcpy(current_qso.comment, commentbuf);
 		}
 
 	    }
 
 	    if (CONTEST_IS(PACC_PA) && (countrynr != my.countrynr)) {
-		if (strlen(comment) == 1) {
-		    strcpy(commentbuf, comment);
-		    comment[0] = '\0';
-		    strcat(comment, "00");
-		    strcat(comment, commentbuf);
+		if (strlen(current_qso.comment) == 1) {
+		    strcpy(commentbuf, current_qso.comment);
+		    current_qso.comment[0] = '\0';
+		    strcat(current_qso.comment, "00");
+		    strcat(current_qso.comment, commentbuf);
 		}
 
-		if (strlen(comment) == 2) {
-		    strcpy(commentbuf, comment);
-		    comment[0] = '\0';
-		    strcat(comment, "0");
-		    strcat(comment, commentbuf);
+		if (strlen(current_qso.comment) == 2) {
+		    strcpy(commentbuf, current_qso.comment);
+		    current_qso.comment[0] = '\0';
+		    strcat(current_qso.comment, "0");
+		    strcat(current_qso.comment, commentbuf);
 		}
 
 	    }
 
 	    if (CONTEST_IS(ARRL_SS) && (x != TAB) && (strlen(section) < 2)) {
 		mvaddstr(13, 54, "section?");
-		mvaddstr(12, 54, comment);
+		mvaddstr(12, 54, current_qso.comment);
 		x = 0;
 	    } else if ((serial_section_mult || sectn_mult)
 		       && ((x != TAB) && (strlen(section) < 1))) {
 		if (!serial_or_section
 			|| (serial_or_section && country_found(hiscall))) {
 		    mvaddstr(13, 54, "section?");
-		    mvaddstr(12, 54, comment);
+		    mvaddstr(12, 54, current_qso.comment);
 		    refreshp();
 		}
 		break;
 
 	    } else if (CONTEST_IS(STEWPERRY)) {
-		if (check_qra(comment) == 0) {
+		if (check_qra(current_qso.comment) == 0) {
 		    mvaddstr(13, 54, "locator?");
-		    mvaddstr(12, 54, comment);
+		    mvaddstr(12, 54, current_qso.comment);
 		    break;
 		}
 		refreshp();
 		break;
 	    } else if (CONTEST_IS(CQWW) && trxmode == DIGIMODE && ((countrynr == w_cty)
 		       || (countrynr == ve_cty))) {
-		if (strlen(comment) < 5) {
+		if (strlen(current_qso.comment) < 5) {
 		    mvaddstr(13, 54, "state/prov?");
-		    mvaddstr(12, 54, comment);
+		    mvaddstr(12, 54, current_qso.comment);
 		    if (x == '\n' || x == KEY_ENTER || x == BACKSLASH) {
 			x = 0;
 		    } else {
@@ -779,14 +779,14 @@ void exchange_edit(void) {
     int i = 0, j;
     char comment2[27];
 
-    l = strlen(comment);
+    l = strlen(current_qso.comment);
     b = l - 1;
-    while ((i != ESCAPE) && (b <= strlen(comment))) {
+    while ((i != ESCAPE) && (b <= strlen(current_qso.comment))) {
 	attroff(A_STANDOUT);
 	attron(COLOR_PAIR(C_HEADER));
 
 	mvaddstr(12, 54, spaces(contest->exchange_width));
-	mvaddstr(12, 54, comment);
+	mvaddstr(12, 54, current_qso.comment);
 	move(12, 54 + b);
 
 	i = key_get();
@@ -799,7 +799,7 @@ void exchange_edit(void) {
 	    // Ctrl-E (^E) or <End>, move to end of comment field, exit edit mode.
 	} else if (i == CTRL_E || i == KEY_END) {
 
-	    b = strlen(comment);
+	    b = strlen(current_qso.comment);
 	    break;
 
 	    // Left arrow, move cursor left one position.
@@ -811,7 +811,7 @@ void exchange_edit(void) {
 	    // Right arrow, move cursor right one position.
 	} else if (i == KEY_RIGHT) {
 
-	    if (b < strlen(comment) - 1) {
+	    if (b < strlen(current_qso.comment) - 1) {
 		b++;
 	    } else
 		break;		/* stop edit */
@@ -820,10 +820,10 @@ void exchange_edit(void) {
 	    // shift all characters to the right of the cursor left one position.
 	} else if (i == KEY_DC) {
 
-	    l = strlen(comment);
+	    l = strlen(current_qso.comment);
 
 	    for (j = b; j <= l; j++) {
-		comment[j] = comment[j + 1];	/* move to left incl.\0 */
+		current_qso.comment[j] = current_qso.comment[j + 1];	/* move to left incl.\0 */
 	    }
 
 	    // <Backspace>, erase character to the left of the cursor,
@@ -833,10 +833,10 @@ void exchange_edit(void) {
 	    if (b > 0) {
 		b--;
 
-		l = strlen(comment);
+		l = strlen(current_qso.comment);
 
 		for (j = b; j <= l; j++) {
-		    comment[j] = comment[j + 1];
+		    current_qso.comment[j] = current_qso.comment[j + 1];
 		}
 	    }
 
@@ -850,13 +850,13 @@ void exchange_edit(void) {
 	    // Accept printable characters.
 	    if ((i >= ' ') && (i <= 'Z')) {
 
-		if (strlen(comment) < contest->exchange_width) {
+		if (strlen(current_qso.comment) < contest->exchange_width) {
 		    /* copy including trailing \0 */
-		    strncpy(comment2, comment + b, strlen(comment) - (b - 1));
+		    strncpy(comment2, current_qso.comment + b, strlen(current_qso.comment) - (b - 1));
 
-		    comment[b] = i;
-		    comment[b + 1] = '\0';
-		    strcat(comment, comment2);
+		    current_qso.comment[b] = i;
+		    current_qso.comment[b + 1] = '\0';
+		    strcat(current_qso.comment, comment2);
 
 		    b++;
 		}

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -513,7 +513,7 @@ static void checkexchange_cqww(struct qso_t *qso, bool interactive) {
 
     // multiplier: zone
     sprintf(qso->normalized_comment, "%02d", zone);
-    g_strlcpy(qso->mult1_value, qso->normalized_comment, COMMENT_SIZE);
+    g_strlcpy(qso->mult1_value, qso->normalized_comment, MULT_SIZE);
 
     if (interactive) {
 	OnLowerSearchPanel(32, qso->normalized_comment); // show current zone
@@ -601,7 +601,7 @@ static void checkexchange_arrlss(struct qso_t *qso, bool interactive) {
     }
 
     sprintf(qso->normalized_comment, "%s %s %s %s", serial, precedent, check, qso->section);
-    g_strlcpy(qso->mult1_value, qso->section, MAX_SECTION_LENGTH + 1);   // multiplier: section
+    g_strlcpy(qso->mult1_value, qso->section, MULT_SIZE);   // multiplier: section
 }
 
 static void checkexchange_serial_section(struct qso_t *qso, bool interactive) {

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -59,7 +59,6 @@
 #include "getexchange.h"
 
 
-char callupdate[MAX_CALL_LENGTH + 1];
 static char section[MAX_SECTION_LENGTH + 1] = "";
 
 void exchange_edit(void);
@@ -114,8 +113,8 @@ int getexchange(void) {
 
 	checkexchange(current_qso.comment, true);
 
-	if (call_update && strlen(callupdate) >= 3) {
-	    strcpy(hiscall, callupdate);
+	if (call_update && strlen(current_qso.callupdate) >= 3) {
+	    strcpy(hiscall, current_qso.callupdate);
 	    printcall();
 	}
 
@@ -507,7 +506,7 @@ static void checkexchange_cqww(char *comment, bool interactive) {
 	// get call fix
 	index = g_match_info_fetch(match_info, 2);
 	if (index != NULL) {
-	    g_strlcpy(callupdate, index, sizeof(callupdate));
+            g_strlcpy(current_qso.callupdate, index, MAX_CALL_LENGTH + 1);
 	}
 	g_free(index);
     }
@@ -570,7 +569,7 @@ static void checkexchange_arrlss(char *comment, bool interactive) {
 	// get call update
 	index = g_match_info_fetch(match_info, 3);
 	if (index != NULL && strchr("AKNWVC", index[0]) != NULL) {  // US/CA only
-	    g_strlcpy(callupdate, index, sizeof(callupdate));
+            g_strlcpy(current_qso.callupdate, index, MAX_CALL_LENGTH + 1);
 	}
 	g_free(index);
 
@@ -649,7 +648,7 @@ static void checkexchange_serial_section(char *comment, bool interactive) {
 	// get call update
 	index = g_match_info_fetch(match_info, 3);
 	if (index != NULL) {
-	    g_strlcpy(callupdate, index, sizeof(callupdate));
+            g_strlcpy(current_qso.callupdate, index, MAX_CALL_LENGTH + 1);
 	}
 	g_free(index);
     }
@@ -707,7 +706,7 @@ static void checkexchange_sectn_mult(char *comment, bool interactive) {
 	// get call update
 	index = g_match_info_fetch(match_info, 2);
 	if (index != NULL) {
-	    g_strlcpy(callupdate, index, sizeof(callupdate));
+            g_strlcpy(current_qso.callupdate, index, MAX_CALL_LENGTH + 1);
 	}
 	g_free(index);
     }
@@ -728,13 +727,14 @@ static void checkexchange_sectn_mult(char *comment, bool interactive) {
 /* ------------------------------------------------------------------------ */
 /*
     input: comment, interactive
-    output (global vars): section, callupdate, mult1_value, normalized_comment
+    output (global vars): section, mult1_value, normalized_comment
+    output (current_qso): callupdate
     side effect: lower line of search panel updated if interactive
 */
 
 void checkexchange(char *comment, bool interactive) {
 
-    callupdate[0] = 0;
+    current_qso.callupdate[0] = 0;
     normalized_comment[0] = 0;
     mult1_value[0] = 0;
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -85,14 +85,14 @@ int getexchange(void) {
 	recall_exchange();
 
     if ((CONTEST_IS(CQWW) || wazmult || itumult)
-	    && (current_qso.comment[0] == '\0') && (strlen(hiscall) != 0)) {
+	    && (current_qso.comment[0] == '\0') && (strlen(current_qso.call) != 0)) {
 	if (itumult)
 	    strcpy(current_qso.comment, ituzone);
 	else
 	    strcpy(current_qso.comment, cqzone);
     }
     if ((exc_cont) && (current_qso.comment[0] == '\0')
-	    && (strlen(hiscall) != 0)) {
+	    && (strlen(current_qso.call) != 0)) {
 	strcpy(current_qso.comment, continent);
     }
 
@@ -112,7 +112,7 @@ int getexchange(void) {
 	checkexchange(&current_qso, true);
 
 	if (call_update && strlen(current_qso.callupdate) >= 3) {
-	    strcpy(hiscall, current_qso.callupdate);
+	    strcpy(current_qso.call, current_qso.callupdate);
             current_qso.callupdate[0] = 0;
 	    printcall();
 	}
@@ -200,7 +200,7 @@ int getexchange(void) {
 
 	    /* '+', send TU and log in CT mode */
 	    case '+': {
-		if (ctcomp && (strlen(hiscall) > 2)) {
+		if (ctcomp && (strlen(current_qso.call) > 2)) {
 		    if (current_qso.comment[0] == '\0') {
 			x = -1;
 		    } else {
@@ -416,7 +416,7 @@ int getexchange(void) {
 	    } else if ((serial_section_mult || sectn_mult)
 		       && ((x != TAB) && (strlen(current_qso.section) < 1))) {
 		if (!serial_or_section
-			|| (serial_or_section && country_found(hiscall))) {
+			|| (serial_or_section && country_found(current_qso.call))) {
 		    mvaddstr(13, 54, "section?");
 		    mvaddstr(12, 54, current_qso.comment);
 		    refreshp();

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -278,7 +278,7 @@ int getexchange(void) {
 	    }
 
 	    case KEY_LEFT: {	/* Left Arrow--edit exchange field */
-		if (current_qso.comment[0] != '\0')
+		if (current_qso.comment[0] != '\0') {
 		    exchange_edit();
 		    i = strlen(current_qso.comment);
 		}

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -512,7 +512,7 @@ static void checkexchange_cqww(char *comment, bool interactive) {
 
     // multiplier: zone
     sprintf(current_qso.normalized_comment, "%02d", zone);
-    g_strlcpy(mult1_value, current_qso.normalized_comment, COMMENT_SIZE);
+    g_strlcpy(current_qso.mult1_value, current_qso.normalized_comment, COMMENT_SIZE);
 
     if (interactive) {
 	OnLowerSearchPanel(32, current_qso.normalized_comment); // show current zone
@@ -600,7 +600,7 @@ static void checkexchange_arrlss(char *comment, bool interactive) {
     }
 
     sprintf(current_qso.normalized_comment, "%s %s %s %s", serial, precedent, check, current_qso.section);
-    g_strlcpy(mult1_value, current_qso.section, MAX_SECTION_LENGTH + 1);   // multiplier: section
+    g_strlcpy(current_qso.mult1_value, current_qso.section, MAX_SECTION_LENGTH + 1);   // multiplier: section
 }
 
 static void checkexchange_serial_section(char *comment, bool interactive) {
@@ -669,7 +669,7 @@ static void checkexchange_serial_section(char *comment, bool interactive) {
 
     if (serial[0] && current_qso.section[0]) {
 	sprintf(current_qso.normalized_comment, "%s %s", serial, current_qso.section);
-	g_strlcpy(mult1_value, current_qso.section, sizeof(mult1_value));   // multiplier: section
+	g_strlcpy(current_qso.mult1_value, current_qso.section, MULT_SIZE);   // multiplier: section
     }
 }
 
@@ -718,15 +718,14 @@ static void checkexchange_sectn_mult(char *comment, bool interactive) {
 
     if (current_qso.section[0]) {
 	g_strlcpy(current_qso.normalized_comment, current_qso.section, COMMENT_SIZE);
-	g_strlcpy(mult1_value, current_qso.section, sizeof(mult1_value));   // multiplier: section
+	g_strlcpy(current_qso.mult1_value, current_qso.section, MULT_SIZE);   // multiplier: section
     }
 }
 
 /* ------------------------------------------------------------------------ */
 /*
     input: comment, interactive
-    output (global vars): section, mult1_value
-    output (current_qso): callupdate, normalized_comment
+    output (current_qso): callupdate, normalized_comment, section, mult1_value
     //FIXME use qso_t arg instead of comment
     side effect: lower line of search panel updated if interactive
 */
@@ -735,7 +734,7 @@ void checkexchange(char *comment, bool interactive) {
 
     current_qso.callupdate[0] = 0;
     current_qso.normalized_comment[0] = 0;
-    mult1_value[0] = 0;
+    current_qso.mult1_value[0] = 0;
 
     // ----------------------------cqww------------------------------
     if (CONTEST_IS(CQWW)) {

--- a/src/getexchange.h
+++ b/src/getexchange.h
@@ -21,9 +21,11 @@
 #ifndef GETEXCHANGE_H
 #define GETEXCHANGE_H
 
+#include "tlf.h"
+
 extern bool call_update;
 
-void checkexchange(char *comment, bool interactive);
+void checkexchange(struct qso_t *qso, bool interactive);
 int getexchange(void);
 
 #endif /* GETEXCHANGE_H */

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -96,7 +96,6 @@ extern bool itumult;
 
 extern char mult1_value[40];
 extern int new_mult;
-extern char normalized_comment[80];
 extern char proposed_exchange[80];
 
 extern char lan_logline[];

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -94,7 +94,6 @@ extern char ituzone[];
 extern char continent[];
 extern bool itumult;
 
-extern char mult1_value[40];
 extern int new_mult;
 extern char proposed_exchange[80];
 

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -50,10 +50,9 @@ extern bool iscontest;
 extern bool country_mult;
 
 extern struct qso_t current_qso;
-extern char hiscall[20];
-extern char hiscall_sent[20];
+extern char hiscall_sent[CALL_SIZE];
 extern int resend_call;
-extern char sentcall[20];
+extern char sentcall[CALL_SIZE];
 extern int total;
 extern int qso_points;
 extern int qsos_per_band[NBANDS];

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -49,7 +49,7 @@ extern bool iscontest;
 
 extern bool country_mult;
 
-extern struct qso_t *current_qso;
+extern struct qso_t current_qso;
 extern char hiscall[20];
 extern char hiscall_sent[20];
 extern int resend_call;
@@ -96,7 +96,6 @@ extern bool itumult;
 
 extern char mult1_value[40];
 extern int new_mult;
-extern char comment[80];
 extern char normalized_comment[80];
 extern char proposed_exchange[80];
 

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -75,6 +75,7 @@ extern bool pfxmult;
 extern bool pfxmultab;
 extern int minute_timer;
 extern int unique_call_multi;
+extern int generic_mult;
 
 extern char logline_edit[5][LOGLINELEN + 1];
 #define logline0 logline_edit[0]

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -43,11 +43,11 @@ freq_t grabspot(void) {
 	return 0;   // no trx control
     }
 
-    if (hiscall[0] == '\0') {
+    if (current_qso.call[0] == '\0') {
 	return 0;   // call input is empty
     }
 
-    spot *data = bandmap_lookup(hiscall);
+    spot *data = bandmap_lookup(current_qso.call);
 
     if (data == NULL) {
 	return 0;   // no spot found
@@ -89,7 +89,7 @@ static freq_t execute_grab(spot *data) {
     set_outfreq(f);
     send_bandswitch(f);
 
-    strcpy(hiscall, data->call);
+    strcpy(current_qso.call, data->call);
 
     /* if in CQ mode switch to S&P and remember QRG */
     if (cqmode == CQ) {

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -78,8 +78,8 @@ void log_to_disk(int from_lan) {
 	strcpy(last_rst, sent_rst);
 
 	// use normalized comment if available
-	if (strlen(normalized_comment) > 0) {
-	    strcpy(current_qso.comment, normalized_comment);
+	if (strlen(current_qso.normalized_comment) > 0) {
+	    strcpy(current_qso.comment, current_qso.normalized_comment);
 	}
 
 	restart_band_timer();

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -74,7 +74,7 @@ void log_to_disk(int from_lan) {
     if (!from_lan) {		// qso from this node
 
 	/* remember call and report for resend after qso (see callinput.c)  */
-	strcpy(lastcall, hiscall);
+	strcpy(lastcall, current_qso.call);
 	strcpy(last_rst, sent_rst);
 
 	// use normalized comment if available

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -79,20 +79,21 @@ void log_to_disk(int from_lan) {
 
 	// use normalized comment if available
 	if (strlen(normalized_comment) > 0) {
-	    strcpy(comment, normalized_comment);
+	    strcpy(current_qso.comment, normalized_comment);
 	}
 
 	restart_band_timer();
 
-	current_qso = collect_qso_data();
-	addcall(current_qso);		/* add call to dupe list */
+	struct qso_t *qso = collect_qso_data(); //TODO: move this after store_qso() call below
+	addcall(qso);		/* add call to dupe list */
 
-	score_qso(current_qso);
-	char *logline = makelogline(current_qso);
-	current_qso->logline = logline; /* remember formatted line in qso entry */
+	score_qso(qso);
+	char *logline = makelogline(qso);
+	qso->logline = logline; /* remember formatted line in qso entry */
 
 	store_qso(logline);
-	g_ptr_array_add(qso_array, current_qso);
+        //TODO: create a copy of current_qso
+	g_ptr_array_add(qso_array, qso);
 
 	// send qso to other nodes......
 	send_lan_message(LOGENTRY, logline);

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -172,6 +172,10 @@ void free_qso(struct qso_t *ptr) {
 	g_free(ptr->comment);
 	g_free(ptr->logline);
 	g_free(ptr->call);
+	g_free(ptr->mult1_value);
+	g_free(ptr->callupdate);
+	g_free(ptr->normalized_comment);
+	g_free(ptr->section);
 	g_free(ptr);
     }
 }

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -100,12 +100,10 @@ struct qso_t *parse_qso(char *buffer) {
     ptr->logline = g_strdup(buffer);
     ptr->qsots = 0;
 
-    if (log_is_comment(buffer)) {
-	ptr->is_comment = true;
+    ptr->is_comment = log_is_comment(buffer);
+    if (ptr->is_comment) {
 	return ptr;
     }
-
-    ptr->is_comment = false;
 
     /* split buffer into parts for linedata_t record and parse
      * them accordingly */
@@ -187,10 +185,10 @@ static void qso_free(gpointer data) {
 
 
 void free_qso_array() {
-   if (qso_array != NULL) {
+    if (qso_array != NULL) {
 	g_ptr_array_free(qso_array, TRUE);
 	qso_array = NULL;
-   }
+    }
 }
 
 void init_qso_array() {

--- a/src/logit.c
+++ b/src/logit.c
@@ -100,7 +100,7 @@ void logit(void) {
 		callreturn = getexchange();
 	    }
 
-	    if (callreturn == '\n' && strlen(hiscall) >= 3) {
+	    if (callreturn == '\n' && strlen(current_qso.call) >= 3) {
 		if ((current_qso.comment[0] == '\0') && iscontest
 			&& !ctcomp && !CONTEST_IS(DXPED))
 		    defer_store = 0;
@@ -185,7 +185,7 @@ void logit(void) {
 		}
 	    }
 
-	    if ((callreturn == BACKSLASH) && (*hiscall != '\0')) {
+	    if ((callreturn == BACKSLASH) && (*current_qso.call != '\0')) {
 		defer_store = 0;
 
 		log_qso();
@@ -199,7 +199,7 @@ void logit(void) {
 	    }
 
 	} else {	/* user entered frequency -> clear input field */
-	    hiscall[0] = '\0';
+	    current_qso.call[0] = '\0';
 	    HideSearchPanel();
 	}
     }
@@ -228,14 +228,14 @@ void change_mode(void) {
 }
 
 void resend_callsign() {
-    if (sentcall[0] != 0 && strcmp(hiscall, sentcall) != 0) {
-	char partial_call[21] = "";
+    if (sentcall[0] != 0 && strcmp(current_qso.call, sentcall) != 0) {
+	char partial_call[CALL_SIZE + 1] = "";
 	switch (resend_call) {
 	    case RESEND_FULL:
-		strcpy(partial_call, hiscall);
+		strcpy(partial_call, current_qso.call);
 		break;
 	    case RESEND_PARTIAL:
-		get_partial_callsign(sentcall, hiscall, partial_call);
+		get_partial_callsign(sentcall, current_qso.call, partial_call);
 		break;
 	    default:
 		break;

--- a/src/logit.c
+++ b/src/logit.c
@@ -50,7 +50,6 @@
 #include "cleanup.h"
 #include "utils.h"
 
-
 void refresh_comment(void);
 void change_mode(void);
 void resend_callsign(void);
@@ -94,7 +93,7 @@ void logit(void) {
 	    if ((trxmode == CWMODE || trxmode == DIGIMODE)
 		    && (callreturn == '\n') && ctcomp) {
 		callreturn = BACKSLASH;
-		strcpy(comment, cqzone);
+		strcpy(current_qso.comment, cqzone);
 	    }
 
 	    if ((callreturn == TAB || callreturn == SPACE)) {
@@ -102,7 +101,7 @@ void logit(void) {
 	    }
 
 	    if (callreturn == '\n' && strlen(hiscall) >= 3) {
-		if ((*comment == '\0') && iscontest
+		if ((current_qso.comment[0] == '\0') && iscontest
 			&& !ctcomp && !CONTEST_IS(DXPED))
 		    defer_store = 0;
 
@@ -121,9 +120,9 @@ void logit(void) {
 
 			if (recall_exchange() == -1) {
 			    if (itumult)
-				strcpy(comment, itustr);	/* fill in the ITUzone */
+				strcpy(current_qso.comment, itustr);	/* fill in the ITUzone */
 			    else
-				strcpy(comment, cqzone);	/* fill in the CQzone */
+				strcpy(current_qso.comment, cqzone);	/* fill in the CQzone */
 			}
 
 			refresh_comment();
@@ -141,8 +140,8 @@ void logit(void) {
 			&& (defer_store == 0)) {	/* S&P mode */
 
 		    if (CONTEST_IS(CQWW)) {
-			if (strlen(comment) == 0 && recall_exchange() == -1)
-			    strcpy(comment, cqzone);	/* fill in the zone */
+			if (strlen(current_qso.comment) == 0 && recall_exchange() == -1)
+			    strcpy(current_qso.comment, cqzone);	/* fill in the zone */
 
 			refresh_comment();
 
@@ -212,7 +211,7 @@ void refresh_comment(void) {
     attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
 
     mvaddstr(12, 54, spaces(contest->exchange_width));
-    mvaddstr(12, 54, comment);
+    mvaddstr(12, 54, current_qso.comment);
 }
 
 void change_mode(void) {

--- a/src/main.c
+++ b/src/main.c
@@ -639,6 +639,8 @@ static void init_variables() {
     current_qso.normalized_comment = g_malloc0(COMMENT_SIZE);
     g_free(current_qso.section);
     current_qso.section = g_malloc0(MAX_SECTION_LENGTH + 1);
+    g_free(current_qso.mult1_value);
+    current_qso.mult1_value = g_malloc0(MULT_SIZE);
 
     for (int i = 0; i < 25; i++) {
 	FREE_DYNAMIC_STRING(digi_message[i]);

--- a/src/main.c
+++ b/src/main.c
@@ -261,7 +261,6 @@ bool qtc_recv_lazy = false;
 
 struct qso_t current_qso;
 
-char hiscall[20];			/**< call of other station */
 char hiscall_sent[20] = "";		/**< part which was sent during early
 					  start */
 int cwstart = 0;			/**< number characters after which
@@ -996,9 +995,6 @@ int main(int argc, char *argv[]) {
     strcat(logline4, backgrnd_str);
 
     init_keyer_terminal();
-
-    hiscall[0] = '\0';
-
 
     if (isFirstStart()) {
 	/* first time called in this directory */

--- a/src/main.c
+++ b/src/main.c
@@ -177,9 +177,6 @@ char sent_rst[4] = "599";
 char recvd_rst[4] = "599";
 char last_rst[4] = "599";       /* Report for last QSO */
 
-/* TODO Maybe we can use the following */
-int mults_per_band = 1;		/* mults count per band */
-
 int shortqsonr = LONGCW;	/* 1  =  short  cw char in exchange */
 int cluster = NOCLUSTER;	/* 0 = OFF, 1 = FOLLOW, 2  = spots  3 = all */
 bool clusterlog = false;	/* clusterlog on/off */

--- a/src/main.c
+++ b/src/main.c
@@ -637,6 +637,8 @@ static void init_variables() {
     current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
     g_free(current_qso.normalized_comment);
     current_qso.normalized_comment = g_malloc0(COMMENT_SIZE);
+    g_free(current_qso.section);
+    current_qso.section = g_malloc0(MAX_SECTION_LENGTH + 1);
 
     for (int i = 0; i < 25; i++) {
 	FREE_DYNAMIC_STRING(digi_message[i]);

--- a/src/main.c
+++ b/src/main.c
@@ -275,7 +275,6 @@ char lastqsonr[5];
 char qsonrstr[5] = "0001";
 char band[NBANDS][4] =
 { "160", " 80", " 60", " 40", " 30", " 20", " 17", " 15", " 12", " 10", "???" };
-char normalized_comment[80];
 char proposed_exchange[80];
 char cqzone[3] = "";
 char ituzone[3] = "";
@@ -636,6 +635,8 @@ static void init_variables() {
     current_qso.comment = g_malloc0(COMMENT_SIZE);
     g_free(current_qso.callupdate);
     current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
+    g_free(current_qso.normalized_comment);
+    current_qso.normalized_comment = g_malloc0(COMMENT_SIZE);
 
     for (int i = 0; i < 25; i++) {
 	FREE_DYNAMIC_STRING(digi_message[i]);

--- a/src/main.c
+++ b/src/main.c
@@ -103,6 +103,7 @@ contest_config_t *contest = &config_qso;	/* contest configuration */
 bool sprint_mode = false;
 int minitest = 0;	/**< if set, length of minitest period in seconds */
 int unique_call_multi = MULT_NONE;  /* do we count calls as multiplier */
+int generic_mult = MULT_NONE;       /* whether to use mult1_value */
 
 
 int addcallarea;
@@ -627,6 +628,7 @@ static void init_variables() {
     shortqsonr = 0;
     tune_seconds = 6;   /* tune up for 6 s */
     unique_call_multi = MULT_NONE;
+    generic_mult = MULT_NONE;
 
     ctcomp = false;
     resend_call = RESEND_NOT_SET;

--- a/src/main.c
+++ b/src/main.c
@@ -631,6 +631,8 @@ static void init_variables() {
     ctcomp = false;
     resend_call = RESEND_NOT_SET;
 
+    g_free(current_qso.call);
+    current_qso.call = g_malloc0(CALL_SIZE);
     g_free(current_qso.comment);
     current_qso.comment = g_malloc0(COMMENT_SIZE);
     g_free(current_qso.callupdate);

--- a/src/main.c
+++ b/src/main.c
@@ -634,6 +634,8 @@ static void init_variables() {
 
     g_free(current_qso.comment);
     current_qso.comment = g_malloc0(COMMENT_SIZE);
+    g_free(current_qso.callupdate);
+    current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
 
     for (int i = 0; i < 25; i++) {
 	FREE_DYNAMIC_STRING(digi_message[i]);

--- a/src/main.c
+++ b/src/main.c
@@ -259,7 +259,7 @@ char qtc_cap_calls[40] = "";
 bool qtc_auto_filltime = false;
 bool qtc_recv_lazy = false;
 
-struct qso_t *current_qso;
+struct qso_t current_qso;
 
 char hiscall[20];			/**< call of other station */
 char hiscall_sent[20] = "";		/**< part which was sent during early
@@ -275,7 +275,6 @@ char lastqsonr[5];
 char qsonrstr[5] = "0001";
 char band[NBANDS][4] =
 { "160", " 80", " 60", " 40", " 30", " 20", " 17", " 15", " 12", " 10", "???" };
-char comment[80];
 char normalized_comment[80];
 char proposed_exchange[80];
 char cqzone[3] = "";
@@ -632,6 +631,9 @@ static void init_variables() {
 
     ctcomp = false;
     resend_call = RESEND_NOT_SET;
+
+    g_free(current_qso.comment);
+    current_qso.comment = g_malloc0(COMMENT_SIZE);
 
     for (int i = 0; i < 25; i++) {
 	FREE_DYNAMIC_STRING(digi_message[i]);

--- a/src/main.c
+++ b/src/main.c
@@ -102,7 +102,7 @@ contest_config_t *contest = &config_qso;	/* contest configuration */
 /* predefined contests */
 bool sprint_mode = false;
 int minitest = 0;	/**< if set, length of minitest period in seconds */
-int unique_call_multi = 0;          /* do we count calls as multiplier */
+int unique_call_multi = MULT_NONE;  /* do we count calls as multiplier */
 
 
 int addcallarea;
@@ -626,6 +626,7 @@ static void init_variables() {
     nodes = 0;
     shortqsonr = 0;
     tune_seconds = 6;   /* tune up for 6 s */
+    unique_call_multi = MULT_NONE;
 
     ctcomp = false;
     resend_call = RESEND_NOT_SET;

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -141,10 +141,11 @@ void prepare_fixed_part(char *logline, struct qso_t *qso) {
 	strcat(logline, khz);
 
     } else {
-	if (lan_active && contest->exchange_serial) {	// show qso nr
-	    strcat(logline, lastqsonr);
-	    lastqsonr[0] = '\0';
-	} else
+//FIXME: review usage of lastqsonr
+//	if (lan_active && contest->exchange_serial) {	// show qso nr
+//	    strcat(logline, lastqsonr);
+//	    lastqsonr[0] = '\0';
+//	} else
 	    strcat(logline, buf);
     }
 

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -291,6 +291,7 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
 
     } else if (wysiwyg_multi
 	       || unique_call_multi != MULT_NONE
+	       || generic_mult != MULT_NONE
 	       || serial_section_mult
 	       || sectn_mult
 	       || sectn_mult_once

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -233,8 +233,11 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
 
     FILL_TO(77);
 
-    if (iscontest) 		/* cut back to make room for mults */
-	logline[68] = '\0';
+    if (!iscontest) {
+        return;         // not a contest, we are done
+    }
+
+    logline[68] = '\0'; /* cut back to make room for mults */
 
     if (CONTEST_IS(WPX) || pfxmult || pfxmultab) {	/* wpx */
 	// include new pfx in log line
@@ -244,11 +247,9 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
 	}
 
 	FILL_TO(73);
-    }
 
-    if (CONTEST_IS(CQWW) || wazmult || itumult) {
+    } else if (CONTEST_IS(CQWW) || wazmult || itumult) {
 	/* ------------cqww --------------------- */
-	logline[68] = '\0';
 
 	if (new_cty != 0) {     //FIXME global
 	    if (dxcc_by_index(new_cty)->pfx[0] == '*')
@@ -272,7 +273,7 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
 	//----------------------------------end cqww-----------------
 
     } else if (CONTEST_IS(ARRLDX_USA)) {
-	logline[68] = '\0';
+
 	if (new_cty != 0) {
 	    strncat(logline, dxcc_by_index(new_cty) -> pfx, 9);
 
@@ -281,7 +282,6 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
 
     } else if (dx_arrlsections && (countrynr != w_cty)
 	       && (countrynr != ve_cty)) {
-	logline[68] = '\0';
 
 	if (new_cty != 0) {
 	    strncat(logline, dxcc_by_index(new_cty) -> pfx, 9);
@@ -296,8 +296,6 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
 	       || sectn_mult_once
 	       || serial_grid4_mult) {
 
-	logline[68] = '\0';
-
 	if (new_mult >= 0) {    //FIXME global
 	    strncat(logline, multis[new_mult].name, 9);
 
@@ -306,7 +304,6 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
 
     } else if (dx_arrlsections
 	       && ((countrynr == w_cty) || (countrynr == ve_cty))) {
-	logline[68] = '\0';
 
 	if (new_mult >= 0) {
 	    strncat(logline, multis[new_mult].name, 9);
@@ -315,8 +312,6 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
 	}
 
     } else if (CONTEST_IS(PACC_PA) || pfxnummultinr > 0) {
-
-	logline[68] = '\0';
 
 	if (new_cty != 0) {
 	    strncat(logline, dxcc_by_index(new_cty) -> pfx, 9);
@@ -329,10 +324,7 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
 	    addcallarea = 0;
 	}
 
-    } else if (iscontest
-	       && (country_mult || dx_arrlsections)) {
-
-	logline[68] = '\0';
+    } else if (country_mult || dx_arrlsections) {
 
 	if (new_cty != 0) {
 	    strncat(logline, dxcc_by_index(new_cty) -> pfx, 9);

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -290,7 +290,7 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
 	}
 
     } else if (wysiwyg_multi
-	       || (unique_call_multi != 0)
+	       || unique_call_multi != MULT_NONE
 	       || serial_section_mult
 	       || sectn_mult
 	       || sectn_mult_once

--- a/src/paccdx.c
+++ b/src/paccdx.c
@@ -59,11 +59,11 @@ int pacc_pa(void) {
 	    break;
     }
 
-    getpx(hiscall);
+    getpx(current_qso.call);
 
     pxnr = districtnumber(wpx_prefix);
 
-    getctydata(hiscall);
+    getctydata(current_qso.call);
 
     if (countrynr == w_cty) {
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1010,22 +1010,28 @@ static int cfg_minitest(const cfg_arg_t arg) {
     return PARSE_OK;
 }
 
-static int cfg_unique_call_multi(const cfg_arg_t arg) {
+static int set_multi_mode(const cfg_arg_t arg, int *config) {
     char *str = g_ascii_strup(parameter, -1);
     g_strstrip(str);
 
     if (strcmp(str, "ALL") == 0) {
-	unique_call_multi = MULT_ALL;
+	*config = MULT_ALL;
     } else if (strcmp(str, "BAND") == 0) {
-	unique_call_multi = MULT_BAND;
+	*config = MULT_BAND;
+    } else if (strcmp(str, "NONE") == 0) {
+	*config = MULT_NONE;
     } else {
 	g_free(str);
-	error_details = g_strdup("must be ALL or BAND");
+	error_details = g_strdup("must be ALL, BAND or NONE");
 	return PARSE_WRONG_PARAMETER;
     }
 
     g_free(str);
     return PARSE_OK;
+}
+
+static int cfg_unique_call_multi(const cfg_arg_t arg) {
+    return set_multi_mode(arg, &unique_call_multi);
 }
 
 static int cfg_digi_rig_mode(const cfg_arg_t arg) {

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1034,6 +1034,10 @@ static int cfg_unique_call_multi(const cfg_arg_t arg) {
     return set_multi_mode(arg, &unique_call_multi);
 }
 
+static int cfg_generic_mult(const cfg_arg_t arg) {
+    return set_multi_mode(arg, &generic_mult);
+}
+
 static int cfg_digi_rig_mode(const cfg_arg_t arg) {
     char *str = g_ascii_strup(parameter, -1);
     g_strstrip(str);
@@ -1258,6 +1262,7 @@ static config_t logcfg_configs[] = {
     {"DIGI_RIG_MODE",       NEED_PARAM, cfg_digi_rig_mode},
     {"CABRILLO-(.+)",       OPTIONAL_PARAM, cfg_cabrillo_field},
     {"RESEND_CALL",         NEED_PARAM, cfg_resend_call},
+    {"GENERIC_MULT",        NEED_PARAM, cfg_generic_mult},
 
     {NULL}  // end marker
 };

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1015,9 +1015,9 @@ static int cfg_unique_call_multi(const cfg_arg_t arg) {
     g_strstrip(str);
 
     if (strcmp(str, "ALL") == 0) {
-	unique_call_multi = UNIQUECALL_ALL;
+	unique_call_multi = MULT_ALL;
     } else if (strcmp(str, "BAND") == 0) {
-	unique_call_multi = UNIQUECALL_BAND;
+	unique_call_multi = MULT_BAND;
     } else {
 	g_free(str);
 	error_details = g_strdup("must be ALL or BAND");

--- a/src/printcall.c
+++ b/src/printcall.c
@@ -40,7 +40,7 @@ void printcall(void) {
     attron(COLOR_PAIR(C_INPUT) | attrib);
 
     mvaddstr(12, 29, spaces(MAX_CALL_LENGTH));
-    mvaddstr(12, 29, hiscall);
+    mvaddstr(12, 29, current_qso.call);
     if ((cqmode == CQ) && (cwstart > 0))
 	mvchgat(12, 29 + cwstart, 12 - cwstart,
 		attrib | A_UNDERLINE, C_INPUT, NULL);

--- a/src/qrb.c
+++ b/src/qrb.c
@@ -32,7 +32,7 @@ int get_qrb(double *range, double *bearing) {
     extern double DEST_Lat;
     extern double DEST_Long;
 
-    if (*hiscall == '\0')
+    if (*current_qso.call == '\0')
 	return -1;
 
     /* positive numbers are N and E

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -72,7 +72,6 @@ void recalc_qtclist();
 void show_rtty_lines();
 void fill_qtc_times(char *time);
 
-extern char hiscall[];
 extern char lastcall[];
 extern int trxmode;
 extern int digikeyer;
@@ -416,10 +415,10 @@ void qtc_main_panel(int direction) {
 
 
     /* fill the callsign fields of the current qtc direction structure
-     * with hiscall or the last call if hiscall is empty
+     * with current_qso.call or the last call if current_qso.call is empty
      */
-    if (strlen(hiscall) > 0) {
-	fill_qtc_callsign(direction, hiscall);
+    if (strlen(current_qso.call) > 0) {
+	fill_qtc_callsign(direction, current_qso.call);
     } else if (strlen(lastcall) > 0) {
 	fill_qtc_callsign(direction, lastcall);
     }

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -59,9 +59,9 @@ char qtcrecv_logfile_import[] = "IMPORT_QTC_recv.log";
 
 void concat_comment(char *dest, char *exchstr) {
     if (strlen(dest) > 0) {
-	g_strlcat(dest, " ", sizeof(comment));
+	g_strlcat(dest, " ", COMMENT_SIZE);
     }
-    g_strlcat(dest, exchstr, sizeof(comment));
+    g_strlcat(dest, exchstr, COMMENT_SIZE);
 }
 
 int qtcs_allowed(struct cabrillo_desc *cabdesc) {
@@ -242,7 +242,7 @@ void cab_qso_to_tlf(char *line, struct cabrillo_desc *cabdesc) {
     }
 
     struct qso_t *qso = g_malloc0(sizeof(struct qso_t));
-    qso->comment = g_malloc0(sizeof(comment));   // pre-allocate buffer for comment
+    qso->comment = g_malloc0(COMMENT_SIZE);   // pre-allocate buffer for comment
 
     qtcrcall[0] = '\0';
     qtcscall[0] = '\0';

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -78,7 +78,7 @@ int starts_with(char *line, char *start) {
 void write_log_fm_cabr(struct qso_t *qso) {
     qso->qso_nr = cablinecnt;
 
-    checkexchange(qso->comment, false);
+    checkexchange(qso, false);
     dupe = is_dupe(qso->call, qso->bandindex, qso->mode);
     addcall(qso);           /* add call to worked list and check it for dupe */
     score_qso(qso);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -138,7 +138,7 @@ int readcalls(const char *logfile, bool interactive) {
 
 	/* get the country number, not known at this point */
 	countrynr = getctydata(qso->call);
-	checkexchange(qso->comment, false);
+	checkexchange(qso, false);
 	if (qso->normalized_comment != NULL && strlen(qso->normalized_comment) > 0) {
 	    strcpy(qso->comment, qso->normalized_comment);
 	}
@@ -159,9 +159,10 @@ int readcalls(const char *logfile, bool interactive) {
 	g_free(logline);
 
         // drop transient fields
-        g_free(qso->callupdate);
-        g_free(qso->normalized_comment);
-        g_free(qso->section);
+        FREE_DYNAMIC_STRING(qso->callupdate);
+        FREE_DYNAMIC_STRING(qso->callupdate);
+        FREE_DYNAMIC_STRING(qso->normalized_comment);
+        FREE_DYNAMIC_STRING(qso->section);
 
 	g_ptr_array_add(qso_array, qso);
     }

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -131,7 +131,7 @@ int readcalls(const char *logfile, bool interactive) {
 
 	qso = parse_qso(inputbuffer);
 
-	if (log_is_comment(inputbuffer)) {
+	if (qso->is_comment) {
 	    g_ptr_array_add(qso_array, qso);
 	    continue;		/* skip further processing for note entry */
 	}
@@ -158,11 +158,10 @@ int readcalls(const char *logfile, bool interactive) {
 
 	g_free(logline);
 
-        // drop transient fields
-        FREE_DYNAMIC_STRING(qso->callupdate);
-        FREE_DYNAMIC_STRING(qso->callupdate);
-        FREE_DYNAMIC_STRING(qso->normalized_comment);
-        FREE_DYNAMIC_STRING(qso->section);
+	// drop transient fields
+	FREE_DYNAMIC_STRING(qso->callupdate);
+	FREE_DYNAMIC_STRING(qso->normalized_comment);
+	FREE_DYNAMIC_STRING(qso->section);
 
 	g_ptr_array_add(qso_array, qso);
     }
@@ -171,7 +170,7 @@ int readcalls(const char *logfile, bool interactive) {
 
     if (log_changed) {
 	bool ok = false;
-	if(interactive) {
+	if (interactive) {
 	    showmsg("Log changed due to rescoring. Do you want to save it? Y/(N)");
 	    ok = toupper(key_get()) == 'Y';
 	} else {

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -161,6 +161,7 @@ int readcalls(const char *logfile, bool interactive) {
         // drop transient fields
         g_free(qso->callupdate);
         g_free(qso->normalized_comment);
+        g_free(qso->section);
 
 	g_ptr_array_add(qso_array, qso);
     }

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -139,8 +139,8 @@ int readcalls(const char *logfile, bool interactive) {
 	/* get the country number, not known at this point */
 	countrynr = getctydata(qso->call);
 	checkexchange(qso->comment, false);
-	if (strlen(normalized_comment) > 0) {   //FIXME global
-	    strcpy(qso->comment, normalized_comment);
+	if (qso->normalized_comment != NULL && strlen(qso->normalized_comment) > 0) {
+	    strcpy(qso->comment, qso->normalized_comment);
 	}
 	dupe = is_dupe(qso->call, qso->bandindex, qso->mode);
 
@@ -157,6 +157,10 @@ int readcalls(const char *logfile, bool interactive) {
 	}
 
 	g_free(logline);
+
+        // drop transient fields
+        g_free(qso->callupdate);
+        g_free(qso->normalized_comment);
 
 	g_ptr_array_add(qso_array, qso);
     }

--- a/src/recall_exchange.c
+++ b/src/recall_exchange.c
@@ -67,7 +67,7 @@ int get_proposed_exchange(void) {
 
 	/* if no exchange could be recycled and no comment available
 	 * search initial exchange list (if available) */
-	if (strlen(comment) == 0 && main_ie_list != NULL) {
+	if (strlen(current_qso.comment) == 0 && main_ie_list != NULL) {
 
 	    current_ie = main_ie_list;
 
@@ -108,7 +108,7 @@ int get_proposed_exchange(void) {
 
 int recall_exchange(void) {
     /* respect content which is already in comment field */
-    if (strlen(comment) != 0)
+    if (strlen(current_qso.comment) != 0)
 	return 0;
 
     if (strlen(proposed_exchange) == 0) {
@@ -121,9 +121,9 @@ int recall_exchange(void) {
 	}
     }
 
-    strcpy(comment, proposed_exchange);
+    strcpy(current_qso.comment, proposed_exchange);
 
-    mvaddstr(12, 54, comment);  //TODO move this to UI code
+    mvaddstr(12, 54, current_qso.comment);  //TODO move this to UI code
     refreshp();
 
     return 1;

--- a/src/recall_exchange.c
+++ b/src/recall_exchange.c
@@ -30,12 +30,12 @@
 
 /** \brief Recall former exchange or lookup initial exchange file
  *
- * First search 'hiscall' in already worked stations (callarray). If not found
- * there lookup 'hiscall' in initial exchange file. If found somewhere copy
+ * First search 'current_qso.call' in already worked stations (callarray). If not found
+ * there lookup 'current_qso.call' in initial exchange file. If found somewhere copy
  * the according exchange into the 'comment' field.
  *
  * \return 1 - found, -1 - not found, 0 - call field was empty */
-
+//TODO: use qso argument
 int get_proposed_exchange(void) {
 
     int i, l;
@@ -45,17 +45,17 @@ int get_proposed_exchange(void) {
 
     proposed_exchange[0] = 0;   // default: empty (nothing found)
 
-    if (strlen(hiscall) == 0)
+    if (strlen(current_qso.call) == 0)
 	return 0;
 
-    l = strlen(hiscall);
+    l = strlen(current_qso.call);
 
     /* search backwards through list of worked stations */
     for (i = nr_worked - 1; i >= 0; i--) {
 
 	/* first search call in already worked stations */
 	/* call has to be exact -> la/dl1jbe/p must be the same again */
-	if ((strstr(worked[i].call, hiscall) == worked[i].call) &&
+	if ((strstr(worked[i].call, current_qso.call) == worked[i].call) &&
 		(*(worked[i].call + l) == '\0' || *(worked[i].call + l) == ' ')) {
 	    found = 1;
 	    strcpy(proposed_exchange, worked[i].exchange);
@@ -72,12 +72,12 @@ int get_proposed_exchange(void) {
 	    current_ie = main_ie_list;
 
 	    while (current_ie) {
-		/* call from IE_List has to be a substring of hiscall
+		/* call from IE_List has to be a substring of current_qso.call
 		 * but must be delimited on both sides by '/' or eos */
-		if ((loc = strstr(hiscall, current_ie->call)) != NULL) {
+		if ((loc = strstr(current_qso.call, current_ie->call)) != NULL) {
 
 		    loc2 = loc + strlen(current_ie->call);
-		    if (((loc == hiscall) || (*(loc - 1) == '/')) &&
+		    if (((loc == current_qso.call) || (*(loc - 1) == '/')) &&
 			    ((*loc2 == '\0') || (*loc2 == '/'))) {
 
 			found = 1;

--- a/src/rtty.c
+++ b/src/rtty.c
@@ -173,7 +173,7 @@ void show_rtty(void) {
     if (commentfield == 0) {
 	printcall();
     } else {
-	mvaddstr(12, 54, comment);
+	mvaddstr(12, 54, current_qso.comment);
     }
     refreshp();
     attron(A_STANDOUT);

--- a/src/score.c
+++ b/src/score.c
@@ -57,15 +57,15 @@ bool is_in_countrylist(int countrynr) {
 }
 
 
-/* check if hiscall is in COUNTRYLIST from logcfg.dat */
+/* check if current_qso.call is in COUNTRYLIST from logcfg.dat */
 // FIXME: *** this function does not use its argument ***
 bool country_found(char prefix[]) {
     char tmpcall[15];
 
-    if (strlen(hiscall) == 0) {
+    if (strlen(current_qso.call) == 0) {
 	strcpy(tmpcall, my.call);
     } else
-	strcpy(tmpcall, hiscall);
+	strcpy(tmpcall, current_qso.call);
 
     countrynr = getctydata(tmpcall);
 

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -214,7 +214,7 @@ int displayPartials(char *suggested_call) {
     char printres[14] = "";
     int suggested = 0;
 
-    const int hislen = strlen(hiscall);
+    const int hislen = strlen(current_qso.call);
 
     if (hislen < 2) {
 	return 0;   // input too short
@@ -257,7 +257,7 @@ int displayPartials(char *suggested_call) {
 	if (strlen(searchresult[k]) <= 2) {
 	    continue;   // too short (unlikely)
 	}
-	if (strstr(searchresult[k], hiscall) == NULL) {
+	if (strstr(searchresult[k], current_qso.call) == NULL) {
 	    continue;   // not matching
 	}
 
@@ -282,7 +282,7 @@ int displayPartials(char *suggested_call) {
     attron(modify_attr(COLOR_PAIR(C_LOG) | A_STANDOUT));
 
     // make 2 runs: fist look for calls starting with
-    // then the ones containing 'hiscall'
+    // then the ones containing 'current_qso.call'
     for (int run = 1; run <= 2; run++) {
 	for (k = 0; k < callmaster->len && !full; k++) {
 
@@ -290,9 +290,9 @@ int displayPartials(char *suggested_call) {
 
 	    int match;
 	    if (run == 1) { // starts with
-		match = (strncmp(mastercall, hiscall, hislen) == 0);
+		match = (strncmp(mastercall, current_qso.call, hislen) == 0);
 	    } else {        // contains
-		match = (strstr(mastercall, hiscall) != NULL);
+		match = (strstr(mastercall, current_qso.call) != NULL);
 	    }
 
 	    if (!match) {
@@ -324,9 +324,9 @@ void handlePartials(void) {
     * pressing tab in calledit() function
     */
     if ((nr_suggested == 1) && use_part && !block_part
-	    && strlen(suggested_call) > strlen(hiscall)) {
+	    && strlen(suggested_call) > strlen(current_qso.call)) {
 
-	strcpy(hiscall, suggested_call);
+	strcpy(current_qso.call, suggested_call);
 	beep();
     }
 }
@@ -418,14 +418,14 @@ void filterLog(const char *call) {
 
 
 /* helper functions to check filtered lines for match with
- * hiscall or actual band */
+ * current_qso.call or actual band */
 static bool call_matches(const char *line) {
     char buffer[20];
 
     g_strlcpy(buffer,  line + 12, 20);
     *strchrnul(buffer, ' ') = '\0';
 
-    return (strcmp(buffer, hiscall) == 0);
+    return (strcmp(buffer, current_qso.call) == 0);
 }
 
 static bool band_matches(const char *line) {
@@ -451,7 +451,7 @@ static bool line_matches_actual_qso(const char *line) {
 	    && (band_matches(line) || qso_once)
 	    && is_current_mode(line)) {
 
-	int found = lookup_worked(hiscall);
+	int found = lookup_worked(current_qso.call);
 	if (worked_in_current_minitest_period(found)) {
 	    return true;
 	}
@@ -599,7 +599,7 @@ void displayWorkedZonesCountries(int z) {
 
     if (CONTEST_IS(PACC_PA)) {
 
-	getpx(hiscall);
+	getpx(current_qso.call);
 	pxnr = districtnumber(wpx_prefix);
 
 	if ((countrynr == w_cty) ||
@@ -634,10 +634,10 @@ void displayWorkedZonesCountries(int z) {
     }
 
     if ((pfxnummultinr >= 0 || country_mult) && iscontest) {
-	getpx(hiscall);
+	getpx(current_qso.call);
 	pxnr = districtnumber(wpx_prefix);
 
-	getctydata(hiscall);
+	getctydata(current_qso.call);
 	pfxnumcntidx = -1;
 	int tbandidx = -1;
 
@@ -690,12 +690,12 @@ void searchlog() {
     }
 
     /* show checkwindow and partials */
-    if (strlen(hiscall) > 1 && searchflg) {
+    if (strlen(current_qso.call) > 1 && searchflg) {
 
 	ShowSearchPanel();
 	drawSearchWin();
 
-	filterLog(hiscall);
+	filterLog(current_qso.call);
 	displaySearchResults();
 
 
@@ -719,7 +719,7 @@ void searchlog() {
 
 	if (dupe == ISDUPE) {
 	    attrset(COLOR_PAIR(C_DUPE));
-	    mvaddstr(12, 29, hiscall);
+	    mvaddstr(12, 29, current_qso.call);
 	    refreshp();
 	    usleep(500000);
 	}

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -148,8 +148,8 @@ void displayCallInfo(dxcc_data *dx, char *pxstr) {
 
     if (CONTEST_IS(CQWW) || wazmult || itumult) {
 	char *zone_info = NULL;
-	if (normalized_comment[0] != 0) {
-	    zone_info = normalized_comment;
+	if (current_qso.normalized_comment[0] != 0) {
+	    zone_info = current_qso.normalized_comment;
 	} else if (proposed_exchange[0] != 0) {
 	    zone_info = proposed_exchange;
 	}

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -176,18 +176,18 @@ void ExpandMacro(void) {
 
 
     if (NULL != strstr(buffer, "@")) {
-	char *p = hiscall + strlen(hiscall_sent);
+	char *p = current_qso.call + strlen(hiscall_sent);
 	if (strlen(hiscall_sent) != 0) {
 	    hiscall_sent[0] = '\0';
 	    early_started = 0;
 //                              sending_call = 0;
 	}
 	if (cqmode == CQ && resend_call != RESEND_NOT_SET) {
-	    strcpy(sentcall, hiscall);
+	    strcpy(sentcall, current_qso.call);
 	}
 	replace_1(buffer, BUFSIZE, "@", p);   /* his call, 1st occurrence */
 	replace_all(buffer, BUFSIZE, "@",
-		    hiscall);   /* his call, further occurrences */
+		    current_qso.call);   /* his call, further occurrences */
     }
 
 

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -226,7 +226,7 @@ void ExpandMacro(void) {
     }
 
 
-    replace_all(buffer, BUFSIZE, "!", comment);
+    replace_all(buffer, BUFSIZE, "!", current_qso.comment);
 
     if (trxmode == DIGIMODE)
 	replace_all(buffer, BUFSIZE, "|", "\r");    /* CR */

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -47,7 +47,7 @@ int sendqrg(void) {
 	return 0;               /* nothing to do here */
     }
 
-    const freq_t trxqrg = atof(hiscall) * 1000.0;
+    const freq_t trxqrg = atof(current_qso.call) * 1000.0;
 
     int bandinx = freq2band(trxqrg);
 

--- a/src/sendspcall.c
+++ b/src/sendspcall.c
@@ -58,7 +58,7 @@ char *PrepareSPcall() {
 	    strcat(buf, "{ ");	/* => ctrl-t */
 	    strcat(buf, "|");	/* => CR */
 	    if (demode) {
-		strcat(buf, hiscall);
+		strcat(buf, current_qso.call);
 		strcat(buf, " DE ");
 	    }
 	    strcat(buf, my.call);
@@ -70,7 +70,7 @@ char *PrepareSPcall() {
 	} else {
 	    strcat(buf, "|");	/* => CR */
 	    if (demode) {
-		strcat(buf, hiscall);
+		strcat(buf, current_qso.call);
 		strcat(buf, " DE ");
 	    }
 	    strcat(buf, my.call);

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -37,6 +37,20 @@
 #include "score.h"
 #include "tlf.h"
 
+#include "getexchange.h"
+#include "addmult.h"
+#include "log_utils.h"
+
+// create a qso_t from a spot for multiplier checking
+static struct qso_t *qso_from_spot(spot *data) {
+    struct qso_t *qso = g_malloc0(sizeof(struct qso_t));
+    qso->call = g_strdup(data->call);
+    qso->comment = g_strdup("");    // TODO recall exchange if possible
+    qso->freq = data->freq;
+    qso->band = data->band;
+    return qso;
+}
+
 /* No Multiplier mark in bandmap for multis determined from comment field;
  * Code works also for modes with no multiplier at all */
 static bool no_multi(spot *data) {
@@ -112,7 +126,12 @@ bool general_ismulti(spot *data) {
 	return ((zones[data->cqzone] & inxes[band]) == 0);
     }
 
-    return false;
+    struct qso_t *qso = qso_from_spot(data);
+    checkexchange(qso, false);
+    bool new_mult = (check_mult(qso) >= 0);
+    free_qso(qso);
+
+    return new_mult;
 }
 
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -47,7 +47,7 @@ static struct qso_t *qso_from_spot(spot *data) {
     qso->call = g_strdup(data->call);
     qso->comment = g_strdup("");    // TODO recall exchange if possible
     qso->freq = data->freq;
-    qso->band = data->band;
+    qso->bandindex = data->band;    //FIXME: naming
     return qso;
 }
 

--- a/src/showinfo.c
+++ b/src/showinfo.c
@@ -78,7 +78,7 @@ static void showinfo_internal(int pfx_index) {
 }
 
 void update_info_line() {
-    int pfx_index = getctydata_pfx(hiscall);
+    int pfx_index = getctydata_pfx(current_qso.call);
     showinfo_internal(pfx_index);
 }
 

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -183,12 +183,14 @@ int get_nr_of_mults() {
 
 	return totalcountries;
     } else if (wysiwyg_once
-	       || sectn_mult_once
-	       || unique_call_multi == MULT_ALL) {
+	       || unique_call_multi == MULT_ALL
+	       || generic_mult == MULT_ALL
+	       || sectn_mult_once) {
 
 	return nr_multis;
     } else if (wysiwyg_multi
 	       || unique_call_multi == MULT_BAND
+	       || generic_mult == MULT_BAND
 	       || serial_section_mult
 	       || serial_grid4_mult
 	       || sectn_mult) {

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -182,13 +182,13 @@ int get_nr_of_mults() {
     } else if (CONTEST_IS(PACC_PA)) {
 
 	return totalcountries;
-    } else if ((wysiwyg_once)
+    } else if (wysiwyg_once
 	       || sectn_mult_once
-	       || (unique_call_multi == UNIQUECALL_ALL)) {
+	       || unique_call_multi == MULT_ALL) {
 
 	return nr_multis;
     } else if (wysiwyg_multi
-	       || (unique_call_multi == UNIQUECALL_BAND)
+	       || unique_call_multi == MULT_BAND
 	       || serial_section_mult
 	       || serial_grid4_mult
 	       || sectn_mult) {

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -644,7 +644,7 @@ void addtext(char *s) {
 	    if (dxtext[strlen(dxtext) - 1] == '\n')
 		dxtext[strlen(dxtext) - 1] = '\0';	// remove the newline
 	    mvaddstr(LINES - 1, 0, dxtext);
-	    mvaddstr(12, 29, hiscall);
+	    mvaddstr(12, 29, current_qso.call);
 	}
 	refreshp();
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -186,6 +186,7 @@ typedef struct {
     int qsos[PFXNUMBERS];
 } pfxnummulti_t;
 
+#define COMMENT_SIZE    80
 
 /* represents different parts of a qso line */
 struct qso_t {

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -211,6 +211,7 @@ struct qso_t {
     int qsots;
     char *callupdate;           // transient field, used in checkexchange
     char *normalized_comment;   // transient field
+    char *section;              // transient field
 };
 
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -209,6 +209,7 @@ struct qso_t {
     freq_t freq;
     int tx;
     int qsots;
+    char *callupdate;   // transient field used in checkexchange
 };
 
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -170,11 +170,12 @@ typedef struct {
 				  for all modes and bands */
 } worked_t;
 
+#define MULT_SIZE   12
 /** worked mults
  *
  * all information about worked multis */
 typedef struct {
-    char name[12];		/**< Multiplier */
+    char name[MULT_SIZE];	/**< Multiplier */
     int band;			/**< bitmap with bands the multi was worked */
 } mults_t;
 
@@ -209,6 +210,7 @@ struct qso_t {
     freq_t freq;
     int tx;
     int qsots;
+    char *mult1_value;
     char *callupdate;           // transient field, used in checkexchange
     char *normalized_comment;   // transient field
     char *section;              // transient field

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -125,8 +125,11 @@ enum {
 
 #define MAX_SECTION_LENGTH 4
 
-#define UNIQUECALL_ALL      1
-#define UNIQUECALL_BAND     2
+enum {
+    MULT_NONE,      // multiplier not used
+    MULT_ALL,       // multiplier counted once on all bands
+    MULT_BAND,      // multiplier counted once per each band
+};
 
 #define EXCLUDE_NONE 0
 #define EXCLUDE_CONTINENT 1

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -188,6 +188,7 @@ typedef struct {
 } pfxnummulti_t;
 
 #define COMMENT_SIZE    80
+#define CALL_SIZE       20
 
 /* represents different parts of a qso line */
 struct qso_t {
@@ -292,8 +293,8 @@ enum {
 /* Enums for RESEND_CALL feature */
 enum {
     RESEND_NOT_SET,		/* Resend feature not set */
-    RESEND_PARTIAL,		/* Resend partial hiscall */
-    RESEND_FULL,		/* Resend full hiscall again */
+    RESEND_PARTIAL,		/* Resend partial call */
+    RESEND_FULL,		/* Resend full call again */
 };
 
 #define FREE_DYNAMIC_STRING(p)  if (p != NULL) {g_free(p); p = NULL;}

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -209,7 +209,8 @@ struct qso_t {
     freq_t freq;
     int tx;
     int qsots;
-    char *callupdate;   // transient field used in checkexchange
+    char *callupdate;           // transient field, used in checkexchange
+    char *normalized_comment;   // transient field
 };
 
 

--- a/src/trx_memory.c
+++ b/src/trx_memory.c
@@ -30,7 +30,7 @@
 typedef struct {
     freq_t freq;
     cqmode_t cqmode;
-    char hiscall[20];
+    char hiscall[CALL_SIZE];
 } mem_t;
 
 static mem_t trxmem = {.freq = 0, .cqmode = NONE};
@@ -39,7 +39,7 @@ static mem_t trxmem = {.freq = 0, .cqmode = NONE};
 void memory_store() {
     trxmem.freq = freq;
     trxmem.cqmode = cqmode;
-    strcpy(trxmem.hiscall, hiscall);
+    strcpy(trxmem.hiscall, current_qso.call);
 
     force_show_freq = true;
 }
@@ -52,7 +52,7 @@ void memory_recall() {
     set_outfreq(trxmem.freq);
     send_bandswitch(trxmem.freq);
     cqmode = trxmem.cqmode;
-    strcpy(hiscall, trxmem.hiscall);
+    strcpy(current_qso.call, trxmem.hiscall);
 
     force_show_freq = true;
 }
@@ -84,7 +84,7 @@ void memory_swap() {
     freq_t tmp_freq = freq;
     cqmode_t tmp_cqmode = cqmode;
     char tmp_hiscall[sizeof(trxmem.hiscall)];
-    strcpy(tmp_hiscall, hiscall);
+    strcpy(tmp_hiscall, current_qso.call);
 
     memory_recall();
 

--- a/test/data.c
+++ b/test/data.c
@@ -403,7 +403,8 @@ int bandweight_multis[NBANDS] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 mults_t multis[MAX_MULTS]; 	/**< worked multis */
 int nr_multis = 0;      	/**< number of multis in multis[] */
 
-int unique_call_multi = 0;          /* do we count calls as multiplier */
+int unique_call_multi = MULT_NONE;  /* do we count calls as multiplier */
+int generic_mult = MULT_NONE;
 
 //////////////////
 char lan_logline[256];	    // defined in log_to_disk.c

--- a/test/data.c
+++ b/test/data.c
@@ -230,7 +230,6 @@ int qtcdirection = 0;
 int minitest = 0;
 
 struct qso_t current_qso;
-char hiscall[20];			/**< call of other station */
 char hiscall_sent[20] = "";		/**< part which was sent during early
 					  start */
 int cwstart = 0;			/**< number characters after which

--- a/test/data.c
+++ b/test/data.c
@@ -141,7 +141,6 @@ bool mixedmode = false;
 char sent_rst[4] = "599";
 char recvd_rst[4] = "599";
 char last_rst[4] = "599";       /* Report for last QSO */
-int mults_per_band = 1;		/* mults count per band */
 int shortqsonr = LONGCW;	/* 1  =  short  cw char in exchange */
 int cluster = NOCLUSTER;	/* 0 = OFF, 1 = FOLLOW, 2  = spots  3 = all */
 bool clusterlog = false;		/* clusterlog on/off */

--- a/test/data.c
+++ b/test/data.c
@@ -243,7 +243,6 @@ char lastcall[20];
 char qsonrstr[5] = "0001";
 char band[NBANDS][4] =
 { "160", " 80", " 60", " 40", " 30", " 20", " 17", " 15", " 12", " 10", "???" };
-char normalized_comment[80];
 char proposed_exchange[80];
 char mode[20] = "Log     ";
 char cqzone[3] = "";

--- a/test/data.c
+++ b/test/data.c
@@ -229,7 +229,7 @@ int qtcdirection = 0;
 
 int minitest = 0;
 
-struct qso_t *current_qso;
+struct qso_t current_qso;
 char hiscall[20];			/**< call of other station */
 char hiscall_sent[20] = "";		/**< part which was sent during early
 					  start */

--- a/test/data.c
+++ b/test/data.c
@@ -243,7 +243,6 @@ char lastcall[20];
 char qsonrstr[5] = "0001";
 char band[NBANDS][4] =
 { "160", " 80", " 60", " 40", " 30", " 20", " 17", " 15", " 12", " 10", "???" };
-char comment[80];
 char normalized_comment[80];
 char proposed_exchange[80];
 char mode[20] = "Log     ";

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -28,6 +28,8 @@
 
 void addmult(struct qso_t qso) {}
 void addmult_lan() {}
+void checkexchange(struct qso_t *qso, bool interactive) {}
+int check_mult(struct qso_t *qso) { return -1; }
 void clear_display() {}
 int pacc_pa(void) {
     return 0;

--- a/test/test_addcall.c
+++ b/test/test_addcall.c
@@ -75,6 +75,7 @@ int setup_default(void **state) {
     memset(zones, 0, sizeof(zones));
     memset(zonescore, 0, sizeof(zonescore));
 
+    current_qso.call = g_malloc0(CALL_SIZE);
     current_qso.comment = g_malloc0(COMMENT_SIZE);
 
     return 0;
@@ -99,7 +100,7 @@ int setup_addcall_pfxnum_notinList(void **state) {
 /* collect_qso_data */
 void test_collect(void **state) {
     struct qso_t *qso;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     strcpy(current_qso.comment, "Hi");
     time_t now = time(NULL);
     bandinx = BANDINDEX_80;
@@ -108,7 +109,7 @@ void test_collect(void **state) {
     qso = collect_qso_data();
     assert_non_null(qso);
 
-    assert_string_equal(qso->call, hiscall);
+    assert_string_equal(qso->call, current_qso.call);
     assert_string_equal(qso->comment, current_qso.comment);
     assert_int_equal(qso->bandindex, bandinx);
     assert_int_equal(qso->mode, CWMODE);
@@ -144,7 +145,7 @@ void test_veto_exclude_continent(void **state) {
 
 /* addcall */
 void test_add_to_worked(void **state) {
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     bandinx = BANDINDEX_10;
     strcpy(current_qso.comment, "Hi");
     time_t now = time(NULL);
@@ -162,14 +163,14 @@ void test_add_to_worked(void **state) {
 void test_add_to_worked_continentlistonly(void **state) {
     continentlist_only = true;
 
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     bandinx = BANDINDEX_10;
     strcpy(current_qso.comment, "Hi");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
 
-    strcpy(hiscall, "PY2BBB");
+    strcpy(current_qso.call, "PY2BBB");
 
     qso = collect_qso_data();
     addcall(qso);
@@ -180,7 +181,7 @@ void test_add_to_worked_continentlistonly(void **state) {
 }
 
 void test_addcall_nopfxnum(void **state) {
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
@@ -191,7 +192,7 @@ void test_addcall_nopfxnum(void **state) {
 
 void test_addcall_pfxnum_inList(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     time_t now = time(NULL);
 
     struct qso_t *qso = collect_qso_data();
@@ -208,7 +209,7 @@ void test_addcall_pfxnum_inList(void **state) {
 
 
 void test_addcall_pfxnum_notinList(void **state) {
-    strcpy(hiscall, "HA2BNL");
+    strcpy(current_qso.call, "HA2BNL");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
@@ -218,7 +219,7 @@ void test_addcall_pfxnum_notinList(void **state) {
 
 void test_addcall_continentlistonly(void **state) {
     continentlist_only = true;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
@@ -226,7 +227,7 @@ void test_addcall_continentlistonly(void **state) {
     assert_int_equal(nr_worked, 1);
     assert_int_equal(countryscore[qso->bandindex], 1);
 
-    strcpy(hiscall, "PY2BBB");  // SA is not in the list
+    strcpy(current_qso.call, "PY2BBB");  // SA is not in the list
 
     qso = collect_qso_data();
     addcall(qso);
@@ -237,7 +238,7 @@ void test_addcall_continentlistonly(void **state) {
 
 void test_addcall_exclude_continent(void **state) {
     exclude_multilist_type = EXCLUDE_CONTINENT;
-    strcpy(hiscall, "LZ1AB");       // EU is excluded
+    strcpy(current_qso.call, "LZ1AB");       // EU is excluded
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
@@ -245,7 +246,7 @@ void test_addcall_exclude_continent(void **state) {
     assert_int_equal(nr_worked, 1);
     assert_int_equal(countryscore[qso->bandindex], 0);  // not counted
 
-    strcpy(hiscall, "PY2BBB");
+    strcpy(current_qso.call, "PY2BBB");
 
     qso = collect_qso_data();
     addcall(qso);
@@ -256,7 +257,7 @@ void test_addcall_exclude_continent(void **state) {
 
 void test_addcall_exclude_country(void **state) {
     exclude_multilist_type = EXCLUDE_COUNTRY;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
@@ -264,7 +265,7 @@ void test_addcall_exclude_country(void **state) {
     assert_int_equal(nr_worked, 1);
     assert_int_equal(countryscore[qso->bandindex], 1);
 
-    strcpy(hiscall, "DL1AAA");  // DL is excluded
+    strcpy(current_qso.call, "DL1AAA");  // DL is excluded
 
     qso = collect_qso_data();
     addcall(qso);
@@ -331,7 +332,7 @@ void test_addcall2_pfxnum_notinList(void **state) {
 /* check country handling in addcall() */
 void test_add_unknown_country(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "12345");
+    strcpy(current_qso.call, "12345");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
@@ -342,7 +343,7 @@ void test_add_unknown_country(void **state) {
 
 void test_add_country(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
@@ -353,13 +354,13 @@ void test_add_country(void **state) {
 
 void test_add_country_2_band(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
 
     bandinx = BANDINDEX_15;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
 
     qso = collect_qso_data();
     addcall(qso);
@@ -371,12 +372,12 @@ void test_add_country_2_band(void **state) {
 
 void test_add_country_2_stations(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
 
-    strcpy(hiscall, "LZ3CD");
+    strcpy(current_qso.call, "LZ3CD");
 
     qso = collect_qso_data();
     addcall(qso);
@@ -387,12 +388,12 @@ void test_add_country_2_stations(void **state) {
 
 void test_add_2_countries(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
 
-    strcpy(hiscall, "DL1YZ");
+    strcpy(current_qso.call, "DL1YZ");
 
     qso = collect_qso_data();
     addcall(qso);
@@ -405,7 +406,7 @@ void test_add_2_countries(void **state) {
 /* check zone handling in addcall() */
 void test_add_unknown_zone(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "12345");
+    strcpy(current_qso.call, "12345");
     strcpy(current_qso.comment, "0");
 
     struct qso_t *qso = collect_qso_data();
@@ -417,7 +418,7 @@ void test_add_unknown_zone(void **state) {
 
 void test_add_zone(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     strcpy(current_qso.comment, "15");
 
     struct qso_t *qso = collect_qso_data();
@@ -429,14 +430,14 @@ void test_add_zone(void **state) {
 
 void test_add_zone_2_band(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     strcpy(current_qso.comment, "15");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
 
     bandinx = BANDINDEX_15;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
 
     qso = collect_qso_data();
     addcall(qso);
@@ -448,13 +449,13 @@ void test_add_zone_2_band(void **state) {
 
 void test_add_zone_2_stations(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     strcpy(current_qso.comment, "15");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
 
-    strcpy(hiscall, "LZ3CD");
+    strcpy(current_qso.call, "LZ3CD");
 
     qso = collect_qso_data();
     addcall(qso);
@@ -465,13 +466,13 @@ void test_add_zone_2_stations(void **state) {
 
 void test_add_2_zones(void **state) {
     bandinx = BANDINDEX_10;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     strcpy(current_qso.comment, "15");
 
     struct qso_t *qso = collect_qso_data();
     addcall(qso);
 
-    strcpy(hiscall, "DL1YZ");
+    strcpy(current_qso.call, "DL1YZ");
     strcpy(current_qso.comment, "14");
 
     qso = collect_qso_data();
@@ -580,7 +581,7 @@ void test_add2_2_zones(void **state) {
 /* special test for WARC bands */
 void test_add_warc(void **state) {
     bandinx = BANDINDEX_12;
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     strcpy(current_qso.comment, "15");
 
     struct qso_t *qso = collect_qso_data();

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -37,6 +37,8 @@ prefix_data *getctyinfo(char *call) {
     return NULL;
 }
 
+void checkexchange(struct qso_t *qso, bool interactive) {}
+
 contest_config_t config_focm;
 struct qso_t *this_qso;
 

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -127,19 +127,19 @@ void test_init_mults(void **state) {
 
 /* tests for remember_multi */
 void test_remember_mult_empty(void **state) {
-    assert_int_equal(remember_multi("", BANDINDEX_80, 0, false), -1);
+    assert_int_equal(remember_multi("", BANDINDEX_80, MULT_ALL, false), -1);
 }
 
 void test_remember_mult_one(void **state) {
-    assert_int_equal(remember_multi("abc", BANDINDEX_80, 0, false), 0);
+    assert_int_equal(remember_multi("abc", BANDINDEX_80, MULT_ALL, false), 0);
     assert_int_equal(nr_multis, 1);
     assert_string_equal(multis[0].name, "abc");
     assert_int_equal(multis[0].band, inxes[BANDINDEX_80]);
 }
 
 void test_remember_mult_two(void **state) {
-    assert_int_equal(remember_multi("abc", BANDINDEX_80, 0, false), 0);
-    assert_int_equal(remember_multi("def", BANDINDEX_80, 0, false), 1);
+    assert_int_equal(remember_multi("abc", BANDINDEX_80, MULT_ALL, false), 0);
+    assert_int_equal(remember_multi("def", BANDINDEX_80, MULT_ALL, false), 1);
     assert_int_equal(nr_multis, 2);
     assert_string_equal(multis[0].name, "abc");
     assert_string_equal(multis[1].name, "def");
@@ -148,16 +148,16 @@ void test_remember_mult_two(void **state) {
 }
 
 void test_remember_mult_same_2x(void **state) {
-    assert_int_equal(remember_multi("abc", BANDINDEX_80, 0, false), 0);
-    assert_int_equal(remember_multi("abc", BANDINDEX_160, 0, false), -1);
+    assert_int_equal(remember_multi("abc", BANDINDEX_80, MULT_ALL, false), 0);
+    assert_int_equal(remember_multi("abc", BANDINDEX_160, MULT_ALL, false), -1);
     assert_int_equal(nr_multis, 1);
     assert_string_equal(multis[0].name, "abc");
     assert_int_equal(multis[0].band, inxes[BANDINDEX_80] | inxes[BANDINDEX_160]);
 }
 
 void test_remember_mult_same_2x_newband(void **state) {
-    assert_int_equal(remember_multi("abc", BANDINDEX_80, 0, false), 0);
-    assert_int_equal(remember_multi("abc", BANDINDEX_160, 1, false), 0);
+    assert_int_equal(remember_multi("abc", BANDINDEX_80, MULT_ALL, false), 0);
+    assert_int_equal(remember_multi("abc", BANDINDEX_160, MULT_BAND, false), 0);
     assert_int_equal(nr_multis, 1);
     assert_string_equal(multis[0].name, "abc");
     assert_int_equal(multis[0].band, inxes[BANDINDEX_80] | inxes[BANDINDEX_160]);
@@ -165,26 +165,26 @@ void test_remember_mult_same_2x_newband(void **state) {
 
 /* check_only mode */
 void test_remember_check_mult_one(void **state) {
-    assert_int_equal(remember_multi("abc", BANDINDEX_80, 0, true), 0);
+    assert_int_equal(remember_multi("abc", BANDINDEX_80, MULT_ALL, true), 0);
     assert_int_equal(nr_multis, 0);
     assert_string_equal(multis[0].name, "");
     assert_int_equal(multis[0].band, 0);
 }
 
 void test_remember_check_mult_two(void **state) {
-    assert_int_equal(remember_multi("abc", BANDINDEX_80, 0, true), 0);
-    assert_int_equal(remember_multi("def", BANDINDEX_80, 0, true), 0);
+    assert_int_equal(remember_multi("abc", BANDINDEX_80, MULT_ALL, true), 0);
+    assert_int_equal(remember_multi("def", BANDINDEX_80, MULT_ALL, true), 0);
     assert_int_equal(nr_multis, 0);
 }
 
 void test_remember_check_mult_existing(void **state) {
     // first add "abc"
-    assert_int_equal(remember_multi("abc", BANDINDEX_80, 0, false), 0);
+    assert_int_equal(remember_multi("abc", BANDINDEX_80, MULT_ALL, false), 0);
     assert_int_equal(nr_multis, 1);
     assert_string_equal(multis[0].name, "abc");
     assert_int_equal(multis[0].band, inxes[BANDINDEX_80]);
     // then check it on another band
-    assert_int_equal(remember_multi("abc", BANDINDEX_160, 0, true), -1);
+    assert_int_equal(remember_multi("abc", BANDINDEX_160, MULT_ALL, true), -1);
     assert_int_equal(nr_multis, 1);
     assert_string_equal(multis[0].name, "abc");
     assert_int_equal(multis[0].band, inxes[BANDINDEX_80]);
@@ -192,12 +192,12 @@ void test_remember_check_mult_existing(void **state) {
 
 void test_remember_check_mult_existing_newband(void **state) {
     // first add "abc"
-    assert_int_equal(remember_multi("abc", BANDINDEX_80, 0, false), 0);
+    assert_int_equal(remember_multi("abc", BANDINDEX_80, MULT_ALL, false), 0);
     assert_int_equal(nr_multis, 1);
     assert_string_equal(multis[0].name, "abc");
     assert_int_equal(multis[0].band, inxes[BANDINDEX_80]);
-    // then check it on another band in PER_BAND mode
-    assert_int_equal(remember_multi("abc", BANDINDEX_160, 1, true), 0);
+    // then check it on another band in MULT_BAND mode
+    assert_int_equal(remember_multi("abc", BANDINDEX_160, MULT_BAND, true), 0);
     assert_int_equal(nr_multis, 1);
     assert_string_equal(multis[0].name, "abc");
     assert_int_equal(multis[0].band, inxes[BANDINDEX_80]);

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -83,6 +83,7 @@ int setup_default(void **state) {
     w_cty = 78;
 
     current_qso.comment = g_malloc0(COMMENT_SIZE);
+    current_qso.mult1_value = g_malloc0(MULT_SIZE);
 
     strcpy(multsfile, "");
 
@@ -93,9 +94,11 @@ int setup_default(void **state) {
     return 0;
 }
 
-void set_this_qso(char *exchange) {
+void set_this_qso(char *exchange, char *mult1) {
     strcpy(current_qso.comment, exchange);
+    free_qso(this_qso);
     this_qso = collect_qso_data();
+    this_qso->mult1_value = g_strdup(mult1);
 }
 
 
@@ -308,7 +311,7 @@ void test_match_length_match_alias2(void **state) {
 /* addmult tests */
 void test_wysiwyg_once(void **state) {
     wysiwyg_once = true;
-    set_this_qso("WAC   ");
+    set_this_qso("WAC   ", "");
     new_mult = addmult(this_qso);
     assert_true(new_mult >= 0);
     assert_string_equal(multis[0].name, "WAC");
@@ -317,7 +320,7 @@ void test_wysiwyg_once(void **state) {
 
 void test_wysiwyg_multi(void **state) {
     wysiwyg_multi = true;
-    set_this_qso("WAC   ");
+    set_this_qso("WAC   ", "");
     new_mult = addmult(this_qso);
     assert_true(new_mult >= 0);
     assert_string_equal(multis[0].name, "WAC");
@@ -326,7 +329,7 @@ void test_wysiwyg_multi(void **state) {
 
 void test_wysiwyg_multi_empty(void **state) {
     wysiwyg_multi = true;
-    set_this_qso("   ");
+    set_this_qso("   ", "");
     new_mult = addmult(this_qso);
     assert_int_equal(new_mult, -1);
 }
@@ -334,8 +337,7 @@ void test_wysiwyg_multi_empty(void **state) {
 void test_serial_grid4(void **state) {
     serial_grid4_mult = true;
     // NOTE: locator is limited to 4 chars in checkexchange()
-    strcpy(mult1_value, "JO60");
-    set_this_qso("");
+    set_this_qso("", "JO60");
     new_mult = addmult(this_qso);
     assert_true(new_mult >= 0);
     assert_string_equal(multis[0].name, "JO60");
@@ -345,8 +347,7 @@ void test_serial_grid4(void **state) {
 
 void test_serial_grid4_empty(void **state) {
     serial_grid4_mult = true;
-    strcpy(mult1_value, "");
-    set_this_qso("");
+    set_this_qso("", "");
     new_mult = addmult(this_qso);
     assert_int_equal(new_mult, -1);
 }
@@ -355,21 +356,19 @@ void test_arrlss(void **state) {
     setcontest("arrl_ss");
 
     setup_multis("SC\nSCV\n");
-    strcpy(mult1_value, "S");   // incomplete value (normally doesn't happen)
-    set_this_qso("");   // NOTE: mult1_value is not part of qso_t
+    set_this_qso("", "S");      // incomplete value (normally doesn't happen)
     addmult(this_qso);
     assert_int_equal(nr_multis, 0);
-    strcpy(mult1_value, "SCX"); // invalid mult
-    set_this_qso("");
+    set_this_qso("", "SCX");    // invalid mult
     addmult(this_qso);
     assert_int_equal(nr_multis, 0);
-    strcpy(mult1_value, "SCV");
+    set_this_qso("", "SCV");
     addmult(this_qso);
     assert_int_equal(nr_multis, 1);
-    strcpy(mult1_value, "KL");
+    set_this_qso("", "KL");
     addmult(this_qso);
     assert_int_equal(nr_multis, 1);
-    strcpy(mult1_value, "SC");
+    set_this_qso("", "SC");
     addmult(this_qso);
     assert_int_equal(nr_multis, 2);
     assert_string_equal(multis[0].name, "SCV");
@@ -379,14 +378,13 @@ void test_arrlss(void **state) {
 void test_serial_section_mult(void **state) {
     serial_section_mult = true;
     setup_multis("NE\nONE\n");
-    strcpy(mult1_value, "ONE");
-    set_this_qso("");   // NOTE: mult1_value is not part of qso_t
+    set_this_qso("", "ONE");
     addmult(this_qso);
-    strcpy(mult1_value, "023");
+    set_this_qso("", "023");
     addmult(this_qso);
-    strcpy(mult1_value, "NE");
+    set_this_qso("", "NE");
     addmult(this_qso);
-    strcpy(mult1_value, "SC");
+    set_this_qso("", "SC");
     addmult(this_qso);
     assert_int_equal(nr_multis, 2);
 }
@@ -395,14 +393,13 @@ void test_dx_arrlsections(void **state) {
     dx_arrlsections = true;
     countrynr = w_cty;
     setup_multis("NE\nONE\n");
-    strcpy(mult1_value, "ONE");
-    set_this_qso("");   // NOTE: mult1_value is not part of qso_t
+    set_this_qso("", "ONE");
     addmult(this_qso);
-    strcpy(mult1_value, "97A23SCV");
+    set_this_qso("", "97A23SCV");
     addmult(this_qso);
-    strcpy(mult1_value, "NE");
+    set_this_qso("", "NE");
     addmult(this_qso);
-    strcpy(mult1_value, "SC");
+    set_this_qso("", "SC");
     addmult(this_qso);
     assert_int_equal(nr_multis, 2);
 }
@@ -410,7 +407,7 @@ void test_dx_arrlsections(void **state) {
 /* check_mult tests */
 void test_check_wysiwyg_once(void **state) {
     wysiwyg_once = true;
-    set_this_qso("WAC   ");
+    set_this_qso("WAC   ", "");
     new_mult = check_mult(this_qso);
     assert_true(new_mult >= 0);
     assert_string_equal(multis[0].name, "");

--- a/test/test_addmult.c
+++ b/test/test_addmult.c
@@ -82,7 +82,7 @@ int setup_default(void **state) {
     ve_cty = 77;	/* random numbers just for test */
     w_cty = 78;
 
-    strcpy(comment, "");
+    current_qso.comment = g_malloc0(COMMENT_SIZE);
 
     strcpy(multsfile, "");
 
@@ -94,7 +94,7 @@ int setup_default(void **state) {
 }
 
 void set_this_qso(char *exchange) {
-    strcpy(comment, exchange);
+    strcpy(current_qso.comment, exchange);
     this_qso = collect_qso_data();
 }
 

--- a/test/test_contest.c
+++ b/test/test_contest.c
@@ -11,6 +11,7 @@
 // OBJECT ../src/getpx.o
 // OBJECT ../src/setcontest.o
 // OBJECT ../src/score.o
+// OBJECT ../src/log_utils.o
 
 /* dummys */
 int getctynr(char *checkcall) {
@@ -24,6 +25,9 @@ int getctydata(char *checkcall) {
 prefix_data *getctyinfo(char * call) {
     return NULL;
 }
+
+void checkexchange(struct qso_t *qso, bool interactive) {}
+int check_mult(struct qso_t *qso) { return -1; }
 
 contest_config_t config_focm;
 

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -24,6 +24,8 @@ int location_unknown(char *call);
 int getpfxindex(char *checkcallptr, char **normalized_call);
 int find_full_match(const char *call);
 int find_best_match(const char *call);
+void checkexchange(struct qso_t *qso, bool interactive) {}
+int check_mult(struct qso_t *qso) { return -1; }
 
 extern char countrylist[255][6];
 

--- a/test/test_getexchange.c
+++ b/test/test_getexchange.c
@@ -22,8 +22,6 @@
 // OBJECT ../src/ui_utils.o
 // OBJECT ../src/utils.o
 
-extern char callupdate[];
-
 bool lan_active = false;
 
 /* dummies */
@@ -52,6 +50,7 @@ void refresh_splitlayout() {}
 int setup_default(void **state) {
     serial_section_mult = false;
     sectn_mult = false;
+    current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
     return 0;
 }
 
@@ -187,7 +186,7 @@ void test_getexchange_arrlss(void **state) {
 	assert_string_equal(normalized_comment,
 			    getex_arrlss[i].expected_normalized_comment);
 	assert_string_equal(mult1_value, getex_arrlss[i].expected_mult1_value);
-	assert_string_equal(callupdate, getex_arrlss[i].expected_callupdate);
+        assert_string_equal(current_qso.callupdate, getex_arrlss[i].expected_callupdate);
 
 	g_free(input);
     }
@@ -259,7 +258,7 @@ void test_getexchange_cqww(void **state) {
 
 	assert_string_equal(normalized_comment,
 			    getex_cqww[i].expected_normalized_comment);
-	assert_string_equal(callupdate, getex_cqww[i].expected_callupdate);
+	assert_string_equal(current_qso.callupdate, getex_cqww[i].expected_callupdate);
 
 	g_free(input);
     }
@@ -339,7 +338,7 @@ void test_getexchange_serial_section(void **state) {
 	assert_string_equal(normalized_comment,
 			    getex_serial_section[i].expected_normalized_comment);
 	assert_string_equal(mult1_value, getex_serial_section[i].expected_mult1_value);
-	assert_string_equal(callupdate, getex_serial_section[i].expected_callupdate);
+	assert_string_equal(current_qso.callupdate, getex_serial_section[i].expected_callupdate);
 
 	g_free(input);
     }
@@ -411,7 +410,7 @@ void test_getexchange_sectn_mult(void **state) {
 	assert_string_equal(normalized_comment,
 			    getex_sectn_mult[i].expected_normalized_comment);
 	assert_string_equal(mult1_value, getex_sectn_mult[i].expected_mult1_value);
-	assert_string_equal(callupdate, getex_sectn_mult[i].expected_callupdate);
+	assert_string_equal(current_qso.callupdate, getex_sectn_mult[i].expected_callupdate);
 
 	g_free(input);
     }
@@ -429,7 +428,7 @@ void test_getexchange_serial_grid4(void **state) {
 
     assert_string_equal(normalized_comment, "  12 JN97");
     assert_string_equal(mult1_value, "JN97");
-    assert_string_equal(callupdate, "");
+    assert_string_equal(current_qso.callupdate, "");
 
     g_free(input);
 }

--- a/test/test_getexchange.c
+++ b/test/test_getexchange.c
@@ -6,6 +6,7 @@
 #include "../src/setcontest.h"
 #include "../src/addmult.h"
 #include "../src/ui_utils.h"
+#include "../src/log_utils.h"
 
 // OBJECT ../src/getexchange.o
 // OBJECT ../src/addmult.o
@@ -50,10 +51,6 @@ void refresh_splitlayout() {}
 int setup_default(void **state) {
     serial_section_mult = false;
     sectn_mult = false;
-    current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
-    current_qso.normalized_comment = g_malloc0(MAX_CALL_LENGTH + 1);
-    current_qso.section = g_malloc0(MAX_SECTION_LENGTH + 1);
-    current_qso.mult1_value = g_malloc0(MULT_SIZE);
     return 0;
 }
 
@@ -179,19 +176,18 @@ void test_getexchange_arrlss(void **state) {
     strcpy(multsfile, TOP_SRCDIR "/share/arrlsections");
     init_and_load_multipliers();
 
-    char *input;
-
     for (int i = 0; i < LEN(getex_arrlss); ++i) {
-	input = g_strdup_printf("%-20s", getex_arrlss[i].input);
+        struct qso_t *qso = g_malloc0(sizeof(struct qso_t));
+	qso->comment = g_strdup_printf("%-20s", getex_arrlss[i].input);
 
-	checkexchange(input, false);
+	checkexchange(qso, false);
 
-	assert_string_equal(current_qso.normalized_comment,
+	assert_string_equal(qso->normalized_comment,
 			    getex_arrlss[i].expected_normalized_comment);
-	assert_string_equal(current_qso.mult1_value, getex_arrlss[i].expected_mult1_value);
-        assert_string_equal(current_qso.callupdate, getex_arrlss[i].expected_callupdate);
+	assert_string_equal(qso->mult1_value, getex_arrlss[i].expected_mult1_value);
+        assert_string_equal(qso->callupdate, getex_arrlss[i].expected_callupdate);
 
-	g_free(input);
+	free_qso(qso);
     }
 }
 
@@ -252,18 +248,17 @@ static getex_cqww_t getex_cqww[] = {
 void test_getexchange_cqww(void **state) {
     contest = lookup_contest("CQWW");
 
-    char *input;
-
     for (int i = 0; i < LEN(getex_cqww); ++i) {
-	input = g_strdup(getex_cqww[i].input);
+        struct qso_t *qso = g_malloc0(sizeof(struct qso_t));
+	qso->comment = g_strdup_printf("%-20s", getex_cqww[i].input);
 
-	checkexchange(input, false);
+	checkexchange(qso, false);
 
-	assert_string_equal(current_qso.normalized_comment,
+	assert_string_equal(qso->normalized_comment,
 			    getex_cqww[i].expected_normalized_comment);
-	assert_string_equal(current_qso.callupdate, getex_cqww[i].expected_callupdate);
+	assert_string_equal(qso->callupdate, getex_cqww[i].expected_callupdate);
 
-	g_free(input);
+	free_qso(qso);
     }
 }
 
@@ -331,19 +326,18 @@ void test_getexchange_serial_section(void **state) {
     add_mult_line("67K89");
     add_mult_line("50ABCD");
 
-    char *input;
-
     for (int i = 0; i < LEN(getex_serial_section); ++i) {
-	input = g_strdup(getex_serial_section[i].input);
+        struct qso_t *qso = g_malloc0(sizeof(struct qso_t));
+	qso->comment = g_strdup_printf("%-20s", getex_serial_section[i].input);
 
-	checkexchange(input, false);
+	checkexchange(qso, false);
 
-	assert_string_equal(current_qso.normalized_comment,
+	assert_string_equal(qso->normalized_comment,
 			    getex_serial_section[i].expected_normalized_comment);
-	assert_string_equal(current_qso.mult1_value, getex_serial_section[i].expected_mult1_value);
-	assert_string_equal(current_qso.callupdate, getex_serial_section[i].expected_callupdate);
+	assert_string_equal(qso->mult1_value, getex_serial_section[i].expected_mult1_value);
+	assert_string_equal(qso->callupdate, getex_serial_section[i].expected_callupdate);
 
-	g_free(input);
+	free_qso(qso);
     }
 }
 
@@ -403,19 +397,18 @@ void test_getexchange_sectn_mult(void **state) {
     add_mult_line("67K89");
     add_mult_line("50ABCD");
 
-    char *input;
-
     for (int i = 0; i < LEN(getex_sectn_mult); ++i) {
-	input = g_strdup(getex_sectn_mult[i].input);
+        struct qso_t *qso = g_malloc0(sizeof(struct qso_t));
+	qso->comment = g_strdup_printf("%-20s", getex_sectn_mult[i].input);
 
-	checkexchange(input, false);
+	checkexchange(qso, false);
 
-	assert_string_equal(current_qso.normalized_comment,
+	assert_string_equal(qso->normalized_comment,
 			    getex_sectn_mult[i].expected_normalized_comment);
-	assert_string_equal(current_qso.mult1_value, getex_sectn_mult[i].expected_mult1_value);
-	assert_string_equal(current_qso.callupdate, getex_sectn_mult[i].expected_callupdate);
+	assert_string_equal(qso->mult1_value, getex_sectn_mult[i].expected_mult1_value);
+	assert_string_equal(qso->callupdate, getex_sectn_mult[i].expected_callupdate);
 
-	g_free(input);
+	free_qso(qso);
     }
 }
 
@@ -423,15 +416,14 @@ void test_getexchange_serial_grid4(void **state) {
     contest = lookup_contest("Unknown");
     serial_grid4_mult = true;
 
-    char *input;
+    struct qso_t *qso = g_malloc0(sizeof(struct qso_t));
+    qso->comment = g_strdup("012 JN97AB");
 
-    input = g_strdup("012 JN97AB");
+    checkexchange(qso, false);
 
-    checkexchange(input, false);
+    assert_string_equal(qso->normalized_comment, "  12 JN97");
+    assert_string_equal(qso->mult1_value, "JN97");
+    assert_string_equal(qso->callupdate, "");
 
-    assert_string_equal(current_qso.normalized_comment, "  12 JN97");
-    assert_string_equal(current_qso.mult1_value, "JN97");
-    assert_string_equal(current_qso.callupdate, "");
-
-    g_free(input);
+    free_qso(qso);
 }

--- a/test/test_getexchange.c
+++ b/test/test_getexchange.c
@@ -53,6 +53,7 @@ int setup_default(void **state) {
     current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
     current_qso.normalized_comment = g_malloc0(MAX_CALL_LENGTH + 1);
     current_qso.section = g_malloc0(MAX_SECTION_LENGTH + 1);
+    current_qso.mult1_value = g_malloc0(MULT_SIZE);
     return 0;
 }
 
@@ -187,7 +188,7 @@ void test_getexchange_arrlss(void **state) {
 
 	assert_string_equal(current_qso.normalized_comment,
 			    getex_arrlss[i].expected_normalized_comment);
-	assert_string_equal(mult1_value, getex_arrlss[i].expected_mult1_value);
+	assert_string_equal(current_qso.mult1_value, getex_arrlss[i].expected_mult1_value);
         assert_string_equal(current_qso.callupdate, getex_arrlss[i].expected_callupdate);
 
 	g_free(input);
@@ -339,7 +340,7 @@ void test_getexchange_serial_section(void **state) {
 
 	assert_string_equal(current_qso.normalized_comment,
 			    getex_serial_section[i].expected_normalized_comment);
-	assert_string_equal(mult1_value, getex_serial_section[i].expected_mult1_value);
+	assert_string_equal(current_qso.mult1_value, getex_serial_section[i].expected_mult1_value);
 	assert_string_equal(current_qso.callupdate, getex_serial_section[i].expected_callupdate);
 
 	g_free(input);
@@ -411,7 +412,7 @@ void test_getexchange_sectn_mult(void **state) {
 
 	assert_string_equal(current_qso.normalized_comment,
 			    getex_sectn_mult[i].expected_normalized_comment);
-	assert_string_equal(mult1_value, getex_sectn_mult[i].expected_mult1_value);
+	assert_string_equal(current_qso.mult1_value, getex_sectn_mult[i].expected_mult1_value);
 	assert_string_equal(current_qso.callupdate, getex_sectn_mult[i].expected_callupdate);
 
 	g_free(input);
@@ -429,7 +430,7 @@ void test_getexchange_serial_grid4(void **state) {
     checkexchange(input, false);
 
     assert_string_equal(current_qso.normalized_comment, "  12 JN97");
-    assert_string_equal(mult1_value, "JN97");
+    assert_string_equal(current_qso.mult1_value, "JN97");
     assert_string_equal(current_qso.callupdate, "");
 
     g_free(input);

--- a/test/test_getexchange.c
+++ b/test/test_getexchange.c
@@ -51,6 +51,7 @@ int setup_default(void **state) {
     serial_section_mult = false;
     sectn_mult = false;
     current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
+    current_qso.normalized_comment = g_malloc0(MAX_CALL_LENGTH + 1);
     return 0;
 }
 
@@ -183,7 +184,7 @@ void test_getexchange_arrlss(void **state) {
 
 	checkexchange(input, false);
 
-	assert_string_equal(normalized_comment,
+	assert_string_equal(current_qso.normalized_comment,
 			    getex_arrlss[i].expected_normalized_comment);
 	assert_string_equal(mult1_value, getex_arrlss[i].expected_mult1_value);
         assert_string_equal(current_qso.callupdate, getex_arrlss[i].expected_callupdate);
@@ -256,7 +257,7 @@ void test_getexchange_cqww(void **state) {
 
 	checkexchange(input, false);
 
-	assert_string_equal(normalized_comment,
+	assert_string_equal(current_qso.normalized_comment,
 			    getex_cqww[i].expected_normalized_comment);
 	assert_string_equal(current_qso.callupdate, getex_cqww[i].expected_callupdate);
 
@@ -335,7 +336,7 @@ void test_getexchange_serial_section(void **state) {
 
 	checkexchange(input, false);
 
-	assert_string_equal(normalized_comment,
+	assert_string_equal(current_qso.normalized_comment,
 			    getex_serial_section[i].expected_normalized_comment);
 	assert_string_equal(mult1_value, getex_serial_section[i].expected_mult1_value);
 	assert_string_equal(current_qso.callupdate, getex_serial_section[i].expected_callupdate);
@@ -407,7 +408,7 @@ void test_getexchange_sectn_mult(void **state) {
 
 	checkexchange(input, false);
 
-	assert_string_equal(normalized_comment,
+	assert_string_equal(current_qso.normalized_comment,
 			    getex_sectn_mult[i].expected_normalized_comment);
 	assert_string_equal(mult1_value, getex_sectn_mult[i].expected_mult1_value);
 	assert_string_equal(current_qso.callupdate, getex_sectn_mult[i].expected_callupdate);
@@ -426,7 +427,7 @@ void test_getexchange_serial_grid4(void **state) {
 
     checkexchange(input, false);
 
-    assert_string_equal(normalized_comment, "  12 JN97");
+    assert_string_equal(current_qso.normalized_comment, "  12 JN97");
     assert_string_equal(mult1_value, "JN97");
     assert_string_equal(current_qso.callupdate, "");
 

--- a/test/test_getexchange.c
+++ b/test/test_getexchange.c
@@ -52,6 +52,7 @@ int setup_default(void **state) {
     sectn_mult = false;
     current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
     current_qso.normalized_comment = g_malloc0(MAX_CALL_LENGTH + 1);
+    current_qso.section = g_malloc0(MAX_SECTION_LENGTH + 1);
     return 0;
 }
 

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -204,7 +204,8 @@ int setup_default(void **state) {
     qtcrec_record_command[0][0] = 0;
     qtcrec_record_command[1][0] = 0;
     qtcrec_record_command_shutdown[0] = 0;
-    unique_call_multi = 0;
+    unique_call_multi = MULT_NONE;
+    generic_mult = MULT_NONE;
     digi_mode = -1;
 
     for (int i = 0; i < SP_CALL_MSG; ++i) {
@@ -1409,6 +1410,25 @@ void test_unique_call_multi_band(void **state) {
     int rc = call_parse_logcfg("UNIQUE_CALL_MULTI=BAND");
     assert_int_equal(rc, PARSE_OK);
     assert_int_equal(unique_call_multi, MULT_BAND);
+}
+
+void test_generic_mult_none(void **state) {
+    generic_mult = MULT_ALL;
+    int rc = call_parse_logcfg("GENERIC_MULT=NONE");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(generic_mult, MULT_NONE);
+}
+
+void test_generic_mult_all(void **state) {
+    int rc = call_parse_logcfg("GENERIC_MULT=ALL");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(generic_mult, MULT_ALL);
+}
+
+void test_generic_mult_band(void **state) {
+    int rc = call_parse_logcfg("GENERIC_MULT=BAND");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(generic_mult, MULT_BAND);
 }
 
 void test_digi_rig_mode_usb(void **state) {

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -1392,6 +1392,13 @@ void test_tune_seconds(void **state) {
     assert_int_equal(tune_seconds, 73);
 }
 
+void test_unique_call_multi_none(void **state) {
+    unique_call_multi = MULT_ALL;
+    int rc = call_parse_logcfg("UNIQUE_CALL_MULTI=NONE");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(unique_call_multi, MULT_NONE);
+}
+
 void test_unique_call_multi_all(void **state) {
     int rc = call_parse_logcfg("UNIQUE_CALL_MULTI=ALL");
     assert_int_equal(rc, PARSE_OK);

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -31,6 +31,7 @@
 // OBJECT ../src/qrb.o
 // OBJECT ../src/setcontest.o
 // OBJECT ../src/cabrillo_utils.o
+// OBJECT ../src/log_utils.o
 
 // lancode.c
 int nodes = 0;
@@ -56,6 +57,9 @@ char *callmaster_filename = NULL;
 bool call_update = false;
 
 t_qtc_ry_line qtc_ry_lines[QTC_RY_LINE_NR];
+
+void checkexchange(struct qso_t *qso, bool interactive) {}
+int check_mult(struct qso_t *qso) { return -1; }
 
 contest_config_t config_focm;
 

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -1395,13 +1395,13 @@ void test_tune_seconds(void **state) {
 void test_unique_call_multi_all(void **state) {
     int rc = call_parse_logcfg("UNIQUE_CALL_MULTI=ALL");
     assert_int_equal(rc, PARSE_OK);
-    assert_int_equal(unique_call_multi, UNIQUECALL_ALL);
+    assert_int_equal(unique_call_multi, MULT_ALL);
 }
 
 void test_unique_call_multi_band(void **state) {
     int rc = call_parse_logcfg("UNIQUE_CALL_MULTI=BAND");
     assert_int_equal(rc, PARSE_OK);
-    assert_int_equal(unique_call_multi, UNIQUECALL_BAND);
+    assert_int_equal(unique_call_multi, MULT_BAND);
 }
 
 void test_digi_rig_mode_usb(void **state) {

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -143,6 +143,8 @@ int setup_default(void **state) {
     if (result == -1)
 	perror("chdir");
 
+    current_qso.call = g_malloc0(CALL_SIZE);
+
     memset(&my, 0, sizeof(my));
     memset(&bm_config, 0, sizeof(bm_config));
     memset(&pfxnummulti, 0, sizeof(pfxnummulti));

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -134,6 +134,7 @@ int setup_default(void **state) {
     pfxnummultinr = 2;
 
     strcpy(my.continent, "EU");
+    current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
 
     showmsg_spy = STRING_NOT_SET;
 

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -135,6 +135,7 @@ int setup_default(void **state) {
 
     strcpy(my.continent, "EU");
     current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
+    current_qso.normalized_comment = g_malloc0(COMMENT_SIZE);
 
     showmsg_spy = STRING_NOT_SET;
 

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -134,9 +134,6 @@ int setup_default(void **state) {
     pfxnummultinr = 2;
 
     strcpy(my.continent, "EU");
-    current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
-    current_qso.normalized_comment = g_malloc0(COMMENT_SIZE);
-    current_qso.mult1_value = g_malloc0(MULT_SIZE);
 
     showmsg_spy = STRING_NOT_SET;
 
@@ -170,28 +167,30 @@ void test_qso_array_init(void **state) {
 
 void test_readcalls_simple_log(void **state) {
     int lines;
-    gchar *qso = g_strdup(QSO1);
-    qso[LOGLINELEN - 1] = '\0';
+    gchar *qso_line = g_strndup(QSO1, LOGLINELEN - 1);
 
     write_log(LOGFILE);
     lines = readcalls(LOGFILE, true);
     assert_non_null(qso_array);
     assert_int_equal(lines, qso_array->len);
     assert_int_equal(lines, 1);
-    assert_string_equal(((struct qso_t *)g_ptr_array_index(qso_array, 0))->logline, qso);
-    assert_string_equal(((struct qso_t *)g_ptr_array_index(qso_array, 0))->call, "PY9BBB");
-    g_free(qso);
+    struct qso_t *qso = g_ptr_array_index(qso_array, 0);
+    assert_non_null(qso);
+    assert_string_equal(qso->logline, qso_line);
+    assert_string_equal(qso->call, "PY9BBB");
+    assert_null(qso->normalized_comment);
+    g_free(qso_line);
 }
 
 void test_readcalls_note(void **state) {
-    gchar *note = g_strdup(NOTE);
-    note[LOGLINELEN - 1] = '\0';
+    gchar *note = g_strndup(NOTE, LOGLINELEN - 1);
 
     write_log(LOGFILE);
     append_log_line(LOGFILE, NOTE);
     assert_int_equal(readcalls(LOGFILE, true), 2);;
 
     struct qso_t *qso = g_ptr_array_index(qso_array, 1);
+    assert_non_null(qso);
     assert_string_equal(qso->logline, note);
     assert_int_equal(qso->is_comment, true);
 

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -136,6 +136,7 @@ int setup_default(void **state) {
     strcpy(my.continent, "EU");
     current_qso.callupdate = g_malloc0(MAX_CALL_LENGTH + 1);
     current_qso.normalized_comment = g_malloc0(COMMENT_SIZE);
+    current_qso.mult1_value = g_malloc0(MULT_SIZE);
 
     showmsg_spy = STRING_NOT_SET;
 

--- a/test/test_recallexchange.c
+++ b/test/test_recallexchange.c
@@ -17,8 +17,9 @@ contest_config_t config_any = {
 
 int setup_default(void **state) {
     int result;
-    strcpy(hiscall, "N0ONE");
+    current_qso.call = g_malloc0(CALL_SIZE);
     current_qso.comment = g_malloc0(COMMENT_SIZE);
+    strcpy(current_qso.call, "N0ONE");
     strcpy(proposed_exchange, "");
 
     strcpy(worked[0].call, "DL1ABC");
@@ -35,7 +36,7 @@ int setup_default(void **state) {
 }
 
 void test_empty_call(void **state) {
-    strcpy(hiscall, "");
+    strcpy(current_qso.call, "");
     assert_int_equal(recall_exchange(), 0);
     assert_string_equal(current_qso.comment, "");
 }
@@ -52,14 +53,14 @@ void test_not_found(void **state) {
 }
 
 void test_from_worked(void **state) {
-    strcpy(hiscall, "DL1ABC");
+    strcpy(current_qso.call, "DL1ABC");
     assert_int_equal(recall_exchange(), 1);
     assert_string_equal(current_qso.comment, "51N13E");
 }
 
 void test_from_ielist(void **state) {
     main_ie_list = make_ie_list("data/ie_ok.txt");
-    strcpy(hiscall, "2E0AAA");
+    strcpy(current_qso.call, "2E0AAA");
     assert_int_equal(recall_exchange(), 1);
     assert_string_equal(current_qso.comment, "51N3W");
 }

--- a/test/test_recallexchange.c
+++ b/test/test_recallexchange.c
@@ -18,7 +18,7 @@ contest_config_t config_any = {
 int setup_default(void **state) {
     int result;
     strcpy(hiscall, "N0ONE");
-    strcpy(comment, "");
+    current_qso.comment = g_malloc0(COMMENT_SIZE);
     strcpy(proposed_exchange, "");
 
     strcpy(worked[0].call, "DL1ABC");
@@ -37,30 +37,30 @@ int setup_default(void **state) {
 void test_empty_call(void **state) {
     strcpy(hiscall, "");
     assert_int_equal(recall_exchange(), 0);
-    assert_string_equal(comment, "");
+    assert_string_equal(current_qso.comment, "");
 }
 
 void test_respect_nonempty_comment(void **state) {
-    strcpy(comment, "Hi");
+    strcpy(current_qso.comment, "Hi");
     assert_int_equal(recall_exchange(), 0);
-    assert_string_equal(comment, "Hi");
+    assert_string_equal(current_qso.comment, "Hi");
 }
 
 void test_not_found(void **state) {
     assert_int_equal(recall_exchange(), -1);
-    assert_string_equal(comment, "");
+    assert_string_equal(current_qso.comment, "");
 }
 
 void test_from_worked(void **state) {
     strcpy(hiscall, "DL1ABC");
     assert_int_equal(recall_exchange(), 1);
-    assert_string_equal(comment, "51N13E");
+    assert_string_equal(current_qso.comment, "51N13E");
 }
 
 void test_from_ielist(void **state) {
     main_ie_list = make_ie_list("data/ie_ok.txt");
     strcpy(hiscall, "2E0AAA");
     assert_int_equal(recall_exchange(), 1);
-    assert_string_equal(comment, "51N3W");
+    assert_string_equal(current_qso.comment, "51N3W");
 }
 

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -21,6 +21,8 @@
 // OBJECT ../src/setcontest.o
 // OBJECT ../src/utils.o
 
+void checkexchange(struct qso_t *qso, bool interactive) {}
+
 char *calc_continent(int zone);
 
 struct qso_t qso = { };

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -22,7 +22,6 @@
 // OBJECT ../src/utils.o
 
 char *calc_continent(int zone);
-char section[8] = "";       // defined in getexchange.c
 
 struct qso_t qso = { };
 
@@ -51,6 +50,8 @@ int setup_default(void **state) {
 
     static char filename[] =  TOP_SRCDIR "/share/cty.dat";
     assert_int_equal(load_ctydata(filename), 0);
+
+    current_qso.call = g_malloc0(CALL_SIZE);
 
     strcpy(my.qra, "jo60lx");
     strcpy(my.continent, "EU");
@@ -266,17 +267,17 @@ void test_in_countrylist_keeps_countrynr(void **state) {
 
 void test_country_found(void **state) {
     /* nothing to find in empty list */
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     assert_int_equal(country_found(""), 0);
-    strcpy(hiscall, "DL3XYZ");
+    strcpy(current_qso.call, "DL3XYZ");
     assert_int_equal(country_found(""), 0);
 
     init_countrylist();
-    strcpy(hiscall, "LZ1AB");
+    strcpy(current_qso.call, "LZ1AB");
     assert_int_equal(country_found(""), 0);
-    strcpy(hiscall, "DL3XYZ");
+    strcpy(current_qso.call, "DL3XYZ");
     assert_int_equal(country_found(""), 1);
-    strcpy(hiscall, "K3LA");
+    strcpy(current_qso.call, "K3LA");
     assert_int_equal(country_found(""), 1);
 }
 

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -136,6 +136,8 @@ int setup_default(void **state) {
 
     showmsg_spy = showstring_spy1 = showstring_spy2 = STRING_NOT_SET;
 
+    current_qso.call = g_malloc0(CALL_SIZE);
+
     contest = &config_qso;
     iscontest = false;
 
@@ -296,38 +298,38 @@ void test_bandstr2line(void **state) {
 /* testing pickup call suggestion for USEPARTIAL */
 void test_UsePartialFromLog(void **state) {
     use_part = true;
-    strcpy(hiscall, "K4DE");
-    filterLog(hiscall);
+    strcpy(current_qso.call, "K4DE");
+    filterLog(current_qso.call);
     handlePartials();
-    assert_string_equal(hiscall, "K4DEF");
+    assert_string_equal(current_qso.call, "K4DEF");
 }
 
 void test_UsePartialFromLogNotUnique(void **state) {
     use_part = true;
-    strcpy(hiscall, "UA");
-    filterLog(hiscall);
+    strcpy(current_qso.call, "UA");
+    filterLog(current_qso.call);
     handlePartials();
-    assert_string_equal(hiscall, "UA");
+    assert_string_equal(current_qso.call, "UA");
 }
 
 void test_UsePartialFromCallmaster(void **state) {
     write_callmaster("callmaster", "# data\nA1AA\nA2BB\n\n");
     load_callmaster();
     use_part = true;
-    strcpy(hiscall, "A1");
-    filterLog(hiscall);
+    strcpy(current_qso.call, "A1");
+    filterLog(current_qso.call);
     handlePartials();
-    assert_string_equal(hiscall, "A1AA");
+    assert_string_equal(current_qso.call, "A1AA");
 }
 
 void test_UsePartialNotUnique(void **state) {
     write_callmaster("callmaster", "# data\nA1AA\nLA3AA\nA3BB\n");
     load_callmaster();
     use_part = true;
-    strcpy(hiscall, "A3");
-    filterLog(hiscall);
+    strcpy(current_qso.call, "A3");
+    filterLog(current_qso.call);
     handlePartials();
-    assert_string_equal(hiscall, "A3");
+    assert_string_equal(current_qso.call, "A3");
 }
 
 void test_UsePartialNotUnique_only_callmaster(void **state) {
@@ -335,10 +337,10 @@ void test_UsePartialNotUnique_only_callmaster(void **state) {
     write_callmaster("callmaster", "# data\nA1AA\nA2HG\nHG3BB\n");
     load_callmaster();
     use_part = true;
-    strcpy(hiscall, "HG");  // not in log yet
-    filterLog(hiscall);
+    strcpy(current_qso.call, "HG");  // not in log yet
+    filterLog(current_qso.call);
     handlePartials();
-    assert_string_equal(hiscall, "HG");
+    assert_string_equal(current_qso.call, "HG");
 }
 
 /* test if partials display checks callmaster even if match was found in log */
@@ -347,9 +349,9 @@ void test_displayPartials_exact_callmaster(void **state) {
     // callmaster has also some UA3JKx calls
     write_callmaster("callmaster", "# data\nA1AA\nUA3JK\nUA3JKA\nUA3JKB\n");
     load_callmaster();
-    strcpy(hiscall, "UA3JK");   // already in log
+    strcpy(current_qso.call, "UA3JK");   // already in log
 
-    filterLog(hiscall);
+    filterLog(current_qso.call);
     handlePartials();
 
     check_mvprintw_output(2, 1, 1, "UA3JK");    // first - from log
@@ -373,9 +375,9 @@ void test_displayPartials(void **state) {
     // callmaster has also some UAs
     write_callmaster("callmaster", "# data\nA1AA\nF2UAA\nGW3UAB\n");
     load_callmaster();
-    strcpy(hiscall, "UA");
+    strcpy(current_qso.call, "UA");
 
-    filterLog(hiscall);
+    filterLog(current_qso.call);
     handlePartials();
 
     // check selected displayed values only (F2UAA must not be shown)

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -28,6 +28,8 @@
 // OBJECT ../src/score.o
 // OBJECT ../src/utils.o
 
+void checkexchange(struct qso_t *qso, bool interactive) {}
+
 char section[8] = "";       // defined in getexchange.c
 
 extern WINDOW *search_win;

--- a/test/test_sendbuf.c
+++ b/test/test_sendbuf.c
@@ -93,7 +93,8 @@ int setup_default(void **state) {
     strcpy(sent_rst, "579");
     shortqsonr = LONGCW;
     strcpy(qsonrstr, "0309");
-    strcpy(comment, "Alex");
+    current_qso.comment = g_malloc0(COMMENT_SIZE);
+    strcpy(current_qso.comment, "Alex");
     *message[SP_CALL_MSG] = '\0';
 
     return 0;

--- a/test/test_sendbuf.c
+++ b/test/test_sendbuf.c
@@ -81,6 +81,8 @@ void check_ExpandMacro(const char *input, const char *exp) {
 
 /* setup/teardown */
 int setup_default(void **state) {
+    current_qso.call = g_malloc0(CALL_SIZE);
+
     wkeyerbuffer[0] = '\0';
     data_ready = 0;
     simulator = false;
@@ -89,7 +91,7 @@ int setup_default(void **state) {
     cwkeyer = 1;
     digikeyer = 1;
     strcpy(my.call, "dl1jbe");
-    strcpy(hiscall, "lz1ab");
+    strcpy(current_qso.call, "lz1ab");
     strcpy(sent_rst, "579");
     shortqsonr = LONGCW;
     strcpy(qsonrstr, "0309");

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -35,7 +35,7 @@
 .
 .
 .\" Update the date when this page is committed.
-.TH TLF 1 "@PACKAGE_NAME@ @VERSION@, 2022-03-04" TLF "Ham radio"
+.TH TLF 1 "@PACKAGE_NAME@ @VERSION@, 2022-09-18" TLF "Ham radio"
 .
 .
 .SH NAME
@@ -2905,6 +2905,14 @@ means the callsign is a multiplier once per the contest, independent of band.
 .br
 .B BAND
 means the callsign counts as a multiplier per band.
+.
+.TP
+\fBGENERIC_MULT\fR=\fINONE\fR|\fIALL\fR|\fIBAND\fR
+Use generic multiplier determined by the contest plugin.
+.IP
+The argument specifies the multiplier counting rule (see above).
+Default value is NONE (disabled).
+.br
 .
 .SS Exchange
 The following parameters configure @PACKAGE_NAME@'s handling of the exchange.


### PR DESCRIPTION
This is going to be a longer PR with the goal to provide the possibility of marking new mults on bandmap for non built-in contests. Currently this feature is supported only for CQWW, WPX, ARRL DX, and the ones covered by `general_ismulti()`. There are a number of other contest that do not fit into these zone, prefix or country based rules.

Multiplier evaluation for a spot would go like this

- construct a `qso_t` object based on what is available (call, freq, optionally an guessed exchange)
- perform roughly the steps as when reading the log file in `readcalls()`, but instead of `addcall()` use `check_mult()` so that the QSO is not "logged" just the multiplier is evaluated
- based on the result mark spot as new multiplier

As most of the above functions involve manipulation of globals this has to be first ironed out. In particular, the current QSO data has to be moved into a `current_qso` object of type `qso_t`. This is the continuation of the earlier work to switch to consistently using `qso_t` and will be a multi-step process as there are many variables affected.

The first commit adds the basic multiplier checking functionality `check_mult()` by extending `remember_multi()`. The setting of global `new_mult` is factored out of `addmult()`.
