### PR TITLE
Fix Cabrillo input window background color

### DIFF
--- a/src/nicebox.c
+++ b/src/nicebox.c
@@ -54,7 +54,7 @@ void nicebox(int y, int x, int height, int width, char *boxname) {
 void ask(char *buffer, char *what) {
 
     nicebox(14, 0, 1, 78, what);
-    attron(A_STANDOUT);
+    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
     mvaddstr(15, 1, spaces(78));
     move(15, 1);
 

--- a/src/nicebox.c
+++ b/src/nicebox.c
@@ -53,10 +53,9 @@ void nicebox(int y, int x, int height, int width, char *boxname) {
 
 void ask(char *buffer, char *what) {
 
-    attron(A_STANDOUT);
-    mvaddstr(15, 1, spaces(78));
     nicebox(14, 0, 1, 78, what);
     attron(A_STANDOUT);
+    mvaddstr(15, 1, spaces(78));
     move(15, 1);
 
     echo();


### PR DESCRIPTION
A minor cosmetic fix: the background of the first Cabrillo input window is green whereas the subsequent ones have cyan background.
![image](https://user-images.githubusercontent.com/15141948/184508152-74120e7d-64f5-453d-87f4-028d5ac04939.png)
![image](https://user-images.githubusercontent.com/15141948/184508164-759f15ea-8d19-4bfd-b5c6-a3cbd110269a.png)

The fixed version:
![image](https://user-images.githubusercontent.com/15141948/184508208-3a4df876-1aec-45fe-ab4a-bf3d8e5cffab.png)
![image](https://user-images.githubusercontent.com/15141948/184508220-cf022b3b-17f5-4752-9863-e62fa4a561ed.png)


