### PR TITLE
Use up/down arrows to increment/decrement serial number in exchange field

### DIFF
--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -64,6 +64,29 @@ static char section[MAX_SECTION_LENGTH + 1] = "";
 
 void exchange_edit(void);
 
+static void serial_up_down(char *exchange, int delta) {
+    /* length of serial part in "001" or "001 EU-001" */
+    int nr_len = strspn(exchange, "0123456789");
+    if (nr_len == 0 && nr_len > 5) {
+	return;
+    }
+    /* serial number, suffix ignored if any */
+    int nr = atoi(exchange);
+    nr += delta;
+    if (nr < 0 || nr > 99999) {
+	return;
+    }
+    /* preserve leading zeros, append old suffix */
+    char *buf = g_strdup_printf("%0*d%s", nr_len, nr, exchange + nr_len);
+    int len = strlen(buf);
+    /* length can change when overflowing 9 -> 10 */
+    if (len <= contest->exchange_width) {
+	strcpy(exchange, buf);
+    }
+    g_free(buf);
+}
+
+
 int getexchange(void) {
 
     int i;
@@ -266,20 +289,8 @@ int getexchange(void) {
 
 	    case KEY_UP:	/* Up/Down--increase/decrease serial number */
 	    case KEY_DOWN: {
-		int nr_len = strspn(comment, "0123456789"); /* length of serial part in "001" or "001 EU-001" */
-		if (nr_len > 0 && nr_len <= 5) {
-		    int nr = atoi(comment); /* serial number, suffix ignored if any */
-		    nr += (x == KEY_UP) ? 1 : -1;
-		    if (nr >= 0 && nr <= 99999) {
-			char *buf = g_strdup_printf("%0*d%s", nr_len, nr, comment+nr_len); /* preserve leading zeros, append old suffix */
-			int len = strlen(buf);
-			if (len <= contest->exchange_width) { /* length can change when overflowing 9 -> 10 */
-			    strcpy(comment, buf);
-			    i = len;
-			}
-                        g_free(buf);
-		    }
-		}
+		serial_up_down(comment, (x == KEY_UP) ? 1 : -1);
+		i = strlen(comment);
 		break;
 	    }
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -266,17 +266,18 @@ int getexchange(void) {
 
 	    case KEY_UP:	/* Up/Down--increase/decrease serial number */
 	    case KEY_DOWN: {
-		if (i > 0 && i <= 5 && strspn(comment, "0123456789") == i) { /* comment non-empty and only digits */
-		    int nr = atoi(comment);
+		int nr_len = strspn(comment, "0123456789"); /* length of serial part in "001" or "001 EU-001" */
+		if (nr_len > 0 && nr_len <= 5) {
+		    int nr = atoi(comment); /* serial number, suffix ignored if any */
 		    nr += (x == KEY_UP) ? 1 : -1;
 		    if (nr >= 0 && nr <= 99999) {
-                        char buf[10];
-			sprintf(buf, "%0*d", i, nr); /* preserve leading zeros */
-			int len = strlen(buf);       /* length can change when overflowing 9 -> 10 */
-                        if (len <= contest->exchange_width) {
-                            strcpy(comment, buf);
-                            i = len;
-                        }
+			char buf[sizeof(comment) + 1];
+			sprintf(buf, "%0*d%s", nr_len, nr, comment+nr_len); /* preserve leading zeros, append old suffix */
+			int len = strlen(buf);
+			if (len <= contest->exchange_width) { /* length can change when overflowing 9 -> 10 */
+			    strcpy(comment, buf);
+			    i = len;
+			}
 		    }
 		}
 		break;

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -67,7 +67,7 @@ void exchange_edit(void);
 static void serial_up_down(char *exchange, int delta) {
     /* length of serial part in "001" or "001 EU-001" */
     int nr_len = strspn(exchange, "0123456789");
-    if (nr_len == 0 && nr_len > 5) {
+    if (nr_len == 0 || nr_len > 5) {
 	return;
     }
     /* serial number, suffix ignored if any */

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -266,12 +266,17 @@ int getexchange(void) {
 
 	    case KEY_UP:	/* Up/Down--increase/decrease serial number */
 	    case KEY_DOWN: {
-		if (i > 0 && i <= contest->exchange_width && strspn(comment, "0123456789") == i) { /* comment non-empty and only digits */
+		if (i > 0 && i <= 5 && strspn(comment, "0123456789") == i) { /* comment non-empty and only digits */
 		    int nr = atoi(comment);
 		    nr += (x == KEY_UP) ? 1 : -1;
-		    if (nr >= 0) {
-			sprintf(comment, "%0*d", i, nr); /* preserve leading zeros */
-			i = strlen(comment); /* length can change when overflowing 9 -> 10 */
+		    if (nr >= 0 && nr <= 99999) {
+                        char buf[10];
+			sprintf(buf, "%0*d", i, nr); /* preserve leading zeros */
+			int len = strlen(buf);       /* length can change when overflowing 9 -> 10 */
+                        if (len <= contest->exchange_width) {
+                            strcpy(comment, buf);
+                            i = len;
+                        }
 		    }
 		}
 		break;

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -271,13 +271,13 @@ int getexchange(void) {
 		    int nr = atoi(comment); /* serial number, suffix ignored if any */
 		    nr += (x == KEY_UP) ? 1 : -1;
 		    if (nr >= 0 && nr <= 99999) {
-			char buf[sizeof(comment) + 1];
-			sprintf(buf, "%0*d%s", nr_len, nr, comment+nr_len); /* preserve leading zeros, append old suffix */
+			char *buf = g_strdup_printf("%0*d%s", nr_len, nr, comment+nr_len); /* preserve leading zeros, append old suffix */
 			int len = strlen(buf);
 			if (len <= contest->exchange_width) { /* length can change when overflowing 9 -> 10 */
 			    strcpy(comment, buf);
 			    i = len;
 			}
+                        g_free(buf);
 		    }
 		}
 		break;

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -257,8 +257,23 @@ int getexchange(void) {
 	    }
 
 	    case KEY_LEFT: {	/* Left Arrow--edit exchange field */
-		if (*comment != '\0')
+		if (*comment != '\0') {
 		    exchange_edit();
+		    i = strlen(comment);
+		}
+		break;
+	    }
+
+	    case KEY_UP:	/* Up/Down--increase/decrease serial number */
+	    case KEY_DOWN: {
+		if (i > 0 && i <= contest->exchange_width && strspn(comment, "0123456789") == i) { /* comment non-empty and only digits */
+		    int nr = atoi(comment);
+		    nr += (x == KEY_UP) ? 1 : -1;
+		    if (nr >= 0) {
+			sprintf(comment, "%0*d", i, nr); /* preserve leading zeros */
+			i = strlen(comment); /* length can change when overflowing 9 -> 10 */
+		    }
+		}
 		break;
 	    }
 

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1081,7 +1081,14 @@ to correct scoring afterward).
 .
 .TP
 .BR \[ua]\  (Up-Arrow)
-Edit last QSO: Insert, overwrite, and delete; + log view.
+In empty call input field: Edit last QSO: Insert, overwrite, and delete; + log view.
+.
+.IP
+Increment serial number in exchange input field.
+.
+.TP
+.BR \[da]\  (Down-Arrow)
+Decrement serial number in exchange input field.
 .
 .TP
 .BR =\  (Equals)


### PR DESCRIPTION
I've been meaning to implement this ever since I'm using tlf, but always forgot after the contest. Now finally took the time to do this during the WAEDC...

Now in S&P, you can enter the serial number some station got, and keep incrementing it by pressing "up" until the station finally logged you. (Works in LOG mode as well, but is probably less useful there.)