### PR TITLE
Use actual QSO mode for mode-based scoring

### DIFF
--- a/src/score.c
+++ b/src/score.c
@@ -135,9 +135,9 @@ int portable_doubles(int points, char *call) {
 
 
 /* apply points by mode */
-int scoreByMode() {
+int scoreByMode(struct qso_t *qso) {
 
-    switch (trxmode) {
+    switch (qso->mode) {
 	case CWMODE:
 	    return cwpoints;
 	case SSBMODE:
@@ -208,7 +208,7 @@ int scoreDefault(struct qso_t *qso) {
     int points;
 
     if (ssbpoints != 0 && cwpoints != 0)	//  e.g. arrl 10m contest
-	points = scoreByMode();
+	points = scoreByMode(qso);
     else
 	points = scoreByContinentOrCountry(qso);
 
@@ -303,7 +303,7 @@ int score_cqww(struct qso_t *qso) {
 int score_arrlfd(struct qso_t *qso) {
     int points;
 
-    if (trxmode == SSBMODE) {
+    if (qso->mode == SSBMODE) {
 	points = 1;
     } else {
 	points = 2;

--- a/test/test_score.c
+++ b/test/test_score.c
@@ -56,7 +56,7 @@ int setup_default(void **state) {
     strcpy(my.continent, "EU");
     my.countrynr = getctynr("DL");
 
-    trxmode = CWMODE;
+    qso.mode = CWMODE;
 
     setcontest("qso");
 
@@ -174,10 +174,10 @@ void test_cqww(void **state) {
 void test_arrl_fd(void **state) {
     setcontest("arrl_fd");
 
-    trxmode = CWMODE;
+    qso.mode = CWMODE;
     check_points(2);
 
-    trxmode = SSBMODE;
+    qso.mode = SSBMODE;
     check_points(1);
 
 }
@@ -214,9 +214,9 @@ void test_ssbcw(void **state) {
     check_points(0);
 
     cwpoints = 4;
-    trxmode = CWMODE;
+    qso.mode = CWMODE;
     check_points(4);
-    trxmode = SSBMODE;
+    qso.mode = SSBMODE;
     check_points(3);
 
     lowband_point_mult = true;
@@ -230,7 +230,7 @@ void test_ssbcw(void **state) {
     check_call_points("DL3XYZ/P", 12);
     portable_x2 = false;
 
-    trxmode = DIGIMODE;
+    qso.mode = DIGIMODE;
     check_points(0);
     ssbpoints = 0;
     check_points(0);


### PR DESCRIPTION
Fixes #341

On mid term we shall replace `trxmode` with `current_qso.mode` similarly to #336.