### PR TITLE
Make buffer long enough to accommodate long lines of aliases

### DIFF
--- a/src/addmult.c
+++ b/src/addmult.c
@@ -336,7 +336,7 @@ void add_mult_line(char *line) {
 int init_and_load_multipliers(void) {
 
     FILE *cfp;
-    char s_inputbuffer[186] = "";
+    char s_inputbuffer[700] = "";
     char *mults_location;
 
     if (mults_possible) {
@@ -364,7 +364,7 @@ int init_and_load_multipliers(void) {
 	return 0;       // couldn't open file
     }
 
-    while (fgets(s_inputbuffer, 85, cfp) != NULL) {
+    while (fgets(s_inputbuffer, 300, cfp) != NULL) {
 
 	/* strip leading and trailing whitespace */
 	g_strstrip(s_inputbuffer);

--- a/src/addmult.c
+++ b/src/addmult.c
@@ -336,7 +336,7 @@ void add_mult_line(char *line) {
 int init_and_load_multipliers(void) {
 
     FILE *cfp;
-    char s_inputbuffer[700] = "";
+    char s_inputbuffer[2000] = "";
     char *mults_location;
 
     if (mults_possible) {
@@ -364,7 +364,7 @@ int init_and_load_multipliers(void) {
 	return 0;       // couldn't open file
     }
 
-    while (fgets(s_inputbuffer, 300, cfp) != NULL) {
+    while (fgets(s_inputbuffer, sizeof(s_inputbuffer), cfp) != NULL) {
 
 	/* strip leading and trailing whitespace */
 	g_strstrip(s_inputbuffer);


### PR DESCRIPTION
Long line of aliases for CQP is cut by short buffer.
I'm not sure about the exact buffer length though. Please advise.

CA:ALAM,ALPI,AMAD,BUTT,CALA,COLU,CCOS,DELN,ELDO,FRES,GLEN,HUMB,IMPE,INYO,KERN,KING,LAKE,LASS,LANG,MADE,MARN,MARP,MEND,MERC,MODO,MONO,MONT,NAPA,NEVA,ORAN,PLAC,PLUM,RIVE,SACR,SBEN,SBER,SDIE,SFRA,SJOA,SLUI,SMAT,SBAR,SCLA,SCRU,SHAS,SIER,SISK,SOLA,SONO,STAN,SUTT,TEHA,TRIN,TULA,TUOL,VENT,YOLO,YUBA
