### PR TITLE
Add NO_LEADING_ZEROS_SERIAL config

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -141,7 +141,7 @@ bool serial_section_mult = false;
 bool serial_or_section = false;	/* exchange is serial OR section, like HA-DX */
 bool serial_grid4_mult = false;
 bool qso_once = false;
-bool noleadingzeros;
+bool noleadingzeros = false;
 bool ctcomp = false;
 bool nob4 = false;		// allow auto b4
 bool ignoredupe = false;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1108,6 +1108,7 @@ static config_t logcfg_configs[] = {
     {"WYSIWYG_ONCE",	    CFG_BOOL_TRUE(wysiwyg_once)},
     {"RIT_CLEAR",	    CFG_BOOL_TRUE(rit)},
     {"SHORT_SERIAL",	    CFG_INT_ONE(shortqsonr)},
+    {"NO_LEADING_ZEROS_SERIAL",	    CFG_BOOL_TRUE(noleadingzeros)},
     {"SCOREWINDOW",	    CFG_BOOL_TRUE(showscore_flag)},
     {"CHECKWINDOW",	    CFG_BOOL_TRUE(searchflg)},
     {"SEND_DE",		    CFG_BOOL_TRUE(demode)},

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -340,7 +340,6 @@ void setcontest(char *name) {
     showscore_flag = true;
     searchflg = true;
     sectn_mult = false;
-    noleadingzeros = false;
 
     w_cty = getctynr(wcall);
     ve_cty = getctynr(vecall);

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -434,6 +434,7 @@ static bool_true_t bool_trues[] = {
     {"QTCREC_RECORD", &qtcrec_record},
     {"QTC_AUTO_FILLTIME", &qtc_auto_filltime},
     {"QTC_RECV_LAZY", &qtc_recv_lazy},
+    {"NO_LEADING_ZEROS_SERIAL", &noleadingzeros},
 };
 
 void test_bool_trues(void **state) {

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -2282,6 +2282,10 @@ Uses short form for serial number (9=N, 0=T).
 Uses long form for serial number (default).
 .
 .TP
+.B NO_LEADING_ZEROS_SERIAL
+Disables sending leading zeros in serial number.
+.
+.TP
 .B NO_RST
 Do not use RST in contest, such as for CW Open, ARRL Sweepstakes, ARRL Field
 Day, or various QSO parties and such events.


### PR DESCRIPTION
Some contests discourage sending leading zeros. It would be nice to have it configurable.