### PR TITLE
Drop nr_qsos variable

### DIFF
--- a/src/addspot.c
+++ b/src/addspot.c
@@ -100,7 +100,7 @@ void add_local_spot(void) {
 
 /* find last qso record in qso_array, return NULL if no one found */
 static struct qso_t *find_last_qso() {
-    int i = nr_qsos;
+    int i = NR_QSOS;
     while (i > 0) {
 	struct qso_t *last_qso = g_ptr_array_index(qso_array, i-1);
 	if (!last_qso->is_comment) {

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -512,13 +512,13 @@ int changepars(void) {
 	case 41: {		/* SYNC */
 	    if (strlen(synclogfile) > 0)
 		synclog(synclogfile);
-	    nr_qsos = log_read_n_score();
+	    log_read_n_score();
 	    scroll_log();
 	    clear_display();
 	    break;
 	}
 	case 42: {		/* RESCORE */
-	    nr_qsos = log_read_n_score();
+	    log_read_n_score();
 	    clear_display();
 	    scroll_log();
 	    break;

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -99,7 +99,7 @@ void delete_last_qtcs(char *call, char *bandmode) {
 	if ((int)qstatbuf.st_size > QTCSENTCALLPOS) {
 	    look = 1;
 	    qtclen = 0;
-	    s = nr_qsos;
+	    s = NR_QSOS;
 	    while (s >= 0 && qsoflags_for_qtc[s] != 1) {
 		s--;
 	    }
@@ -170,7 +170,7 @@ void delete_qso(void) {
 	    fsync(lfile);
 	    close(lfile);
 
-	    nr_qsos = log_read_n_score();
+	    log_read_n_score();
 	}
 	scroll_log();
     }

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -116,7 +116,7 @@ static void flash_field(int row, int column, char *value) {
 /* get a copy of selected QSO into the buffer */
 static void get_qso(int nr, char *buffer) {
 
-    assert(nr < nr_qsos);
+    assert(nr < NR_QSOS);
     strcpy(buffer, QSOS(nr));
     assert(strlen(buffer) == (LOGLINELEN - 1));
 }
@@ -126,7 +126,7 @@ static void putback_qso(int nr, char *buffer) {
     FILE *fp;
 
     assert(strlen(buffer) == (LOGLINELEN - 1));
-    assert(nr < nr_qsos);
+    assert(nr < NR_QSOS);
 
     if ((fp = fopen(logfile, "r+")) == NULL) {
 	TLF_LOG_WARN("Can not open logfile...");
@@ -168,13 +168,13 @@ static void check_store_and_get_next_line(int direction) {
     }
     unhighlight_line(editline, editbuffer);
     if (changed) {
-        putback_qso(nr_qsos - (NR_LINES - editline), editbuffer);
+        putback_qso(NR_QSOS - (NR_LINES - editline), editbuffer);
         needs_rescore = true;
         changed = false;
     }
     if (direction != 0) {
         editline += direction;
-        get_qso(nr_qsos - (NR_LINES - editline), editbuffer);
+        get_qso(NR_QSOS - (NR_LINES - editline), editbuffer);
     }
 }
 
@@ -183,12 +183,12 @@ void edit_last(void) {
 
     int j, b, k;
 
-    if (nr_qsos == 0)
+    if (NR_QSOS == 0)
 	return;			/* nothing to edit */
 
     stop_background_process();  // note: this freezes nr_qsos, as network is paused
 
-    const int topline = MAX(NR_LINES - nr_qsos, 0);
+    const int topline = MAX(NR_LINES - NR_QSOS, 0);
 
     // set current end of exchange field
     fields[FIELD_INDEX_EXCHANGE].end = fields[FIELD_INDEX_EXCHANGE].start + contest->exchange_width - 1;
@@ -199,7 +199,7 @@ void edit_last(void) {
 
     /* start with last QSO */
     editline = NR_LINES - 1;
-    get_qso(nr_qsos - (NR_LINES - editline), editbuffer);
+    get_qso(NR_QSOS - (NR_LINES - editline), editbuffer);
     changed = false;
     needs_rescore = false;
 

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -76,7 +76,7 @@ void logedit(void) {
     edit(logfile);
     checklogfile();
 
-    nr_qsos = log_read_n_score();
+    log_read_n_score();
 
     start_background_process();
 

--- a/src/genqtclist.c
+++ b/src/genqtclist.c
@@ -63,7 +63,7 @@ int genqtclist(char *callsign, int nrofqtc) {
 
     s = next_qtc_qso;
 
-    while (qtclist.count < qtclistlen && s < nr_qsos) {
+    while (qtclist.count < qtclistlen && s < NR_QSOS) {
 	if (strlen(callsign) == 0 ||
 		strncmp(QSOS(s) + 29, callsign, strlen(callsign)) != 0) {
 	    /* exclude current callsign */

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -14,8 +14,6 @@ extern mystation_t my;			// all about my station
 extern char whichcontest[];
 extern contest_config_t *contest;	// contest configuration
 
-extern int nr_qsos;			// number of lines in qsos[]
-
 extern GPtrArray *qso_array;		// array of parsed QSOs
 					// note that not every log line needs
 					// to be a QSO, it could also be a

--- a/src/last10.c
+++ b/src/last10.c
@@ -38,13 +38,13 @@ int last10(void) {
     int thisband;
     struct qso_t *qso;
 
-    if (nr_qsos < 10)
+    if (NR_QSOS < 10)
 	return (-1);
 
     thisband = atoi(band[bandinx]);
 
     /* look backwards in actual band for QSOs */
-    for (index = nr_qsos - 1; index >= 0; index--) {
+    for (index = NR_QSOS - 1; index >= 0; index--) {
 
 	qso = g_ptr_array_index(qso_array, index);
 	if (thisband == qso->band) {

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -91,7 +91,7 @@ void log_to_disk(int from_lan) {
 	char *logline = makelogline(qso);
 	qso->logline = logline; /* remember formatted line in qso entry */
 
-	store_qso(logline);
+	store_qso(logfile, logline);
         //TODO: create a copy of current_qso
 	g_ptr_array_add(qso_array, qso);
 
@@ -122,7 +122,7 @@ void log_to_disk(int from_lan) {
 
 	addcall2();
 
-	store_qso(lan_logline);
+	store_qso(logfile, lan_logline);
 	g_ptr_array_add(qso_array, qso);
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -348,7 +348,6 @@ char fldigi_url[50] = "http://localhost:7362/RPC2";
 /*----------------------------the parsed log lines-------------------------*/
 // array of qso's
 GPtrArray *qso_array;
-int nr_qsos = 0;
 
 /*------------------------------dupe array---------------------------------*/
 int nr_worked = 0;		/**< number of calls in worked[] */
@@ -1053,7 +1052,7 @@ int main(int argc, char *argv[]) {
 
     /* read the logfile and rebuild point and multiplier scoring */
     /* see also log_read_n_score() for non-interactive variant */
-    nr_qsos = readcalls(logfile, true);
+    readcalls(logfile, true);
     if (qtcdirection > 0) {
 	readqtccalls();
     }

--- a/src/note.c
+++ b/src/note.c
@@ -31,6 +31,7 @@
 #include "log_utils.h"
 #include "nicebox.h"		// Includes curses.h
 #include "scroll_log.h"
+#include "store_qso.h"
 
 
 void include_note(void) {
@@ -41,7 +42,6 @@ void include_note(void) {
     char buffer2[LOGLINELEN + 1] = "";
 
     int i;
-    FILE *fp;
 
     attron(A_STANDOUT);
     mvprintw(15, 1,
@@ -65,15 +65,7 @@ void include_note(void) {
 	       (LOGLINELEN - 1) - strlen(buffer2)); /* fill spaces */
 	buffer2[LOGLINELEN - 1] = '\0';
 
-	if ((fp = fopen(logfile, "a")) == NULL) {
-	    endwin();
-	    fprintf(stdout, "\nnote.c: Error opening log file.\n");
-	    exit(1);
-	}
-	fputs(buffer2, fp);
-	fputs("\n", fp);
-
-	fclose(fp);
+	store_qso(logfile, buffer2);
 
 	struct qso_t *qso = parse_qso(buffer2);
 	g_ptr_array_add(qso_array, qso);

--- a/src/note.c
+++ b/src/note.c
@@ -77,7 +77,6 @@ void include_note(void) {
 
 	struct qso_t *qso = parse_qso(buffer2);
 	g_ptr_array_add(qso_array, qso);
-	nr_qsos++;
 
 	scroll_log();
 	clear_display();

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -75,7 +75,6 @@ void fill_qtc_times(char *time);
 extern char lastcall[];
 extern int trxmode;
 extern int digikeyer;
-extern int nr_qsos;
 
 static int record_run = -1;		/* was recording already started? */
 
@@ -660,7 +659,7 @@ void qtc_main_panel(int direction) {
 			if (*qtccount > 0 && qtcreclist.confirmed == *qtccount) {
 			    if (qtcreclist.sentcfmall == 0) {
 				qtcreclist.sentcfmall = 1;
-				log_recv_qtc_to_disk(nr_qsos);
+				log_recv_qtc_to_disk(NR_QSOS);
 				if (record_run > -1) {
 				    stop_qtc_recording();
 				}
@@ -785,7 +784,7 @@ void qtc_main_panel(int direction) {
 	    case CTRL_S:
 		if (qtccurrdirection == SEND && *qtccount > 0
 			&& qtclist.totalsent == *qtccount) {
-		    log_sent_qtc_to_disk(nr_qsos);
+		    log_sent_qtc_to_disk(NR_QSOS);
 		    wattrset(qtcwin, LINE_INVERTED);
 		    mvwaddstr(qtcwin, 2, 11, "QTCs have been saved!");
 		    prevqtccall[0] = '\0';

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -84,7 +84,7 @@ void write_log_fm_cabr(struct qso_t *qso) {
     score_qso(qso);
     char *logline = makelogline(qso);	    /* format logline */
     qso->logline = logline;
-    store_qso(logline);
+    store_qso(logfile, logline);
     g_ptr_array_add(qso_array, qso);
 
     cleanup_qso();

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -88,7 +88,7 @@ void write_log_fm_cabr(struct qso_t *qso) {
     g_ptr_array_add(qso_array, qso);
 
     cleanup_qso();
-    qsoflags_for_qtc[nr_qsos - 1] = 0;
+    qsoflags_for_qtc[NR_QSOS - 1] = 0;
 }
 
 /* write a new line to the qtc log */
@@ -127,7 +127,7 @@ void write_qtclog_fm_cabr(char *qtcrcall, struct read_qtc_t  qtc_line) {
 	}
 
 	// look until not found and we're in list
-	while (found_call == 0 && qtc_curr_call_nr < nr_qsos) {
+	while (found_call == 0 && qtc_curr_call_nr < NR_QSOS) {
 	    strncpy(thiscall, QSOS(qtc_curr_call_nr) + 29, 14);
 	    g_strchomp(thiscall);
 	    strncpy(ttime, QSOS(qtc_curr_call_nr) + 17, 2);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -62,7 +62,7 @@ void do_backup(const char *logfile, bool interactive) {
 	    // rewrite log
 	    nr_qsos = 0;    // FIXME store_qso increments nr_qsos
 	    for (int i = 0 ; i < qso_array->len; i++) {
-		store_qso(QSOS(i));
+		store_qso(logfile, QSOS(i));
 	    }
 	    if (interactive) {
 		showstring("Log has been backed up as", backup);

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -60,8 +60,7 @@ void do_backup(const char *logfile, bool interactive) {
 	    char *backup = g_strdup_printf("%s_%s", prefix, logfile);
 	    rename(logfile, backup);
 	    // rewrite log
-	    nr_qsos = 0;    // FIXME store_qso increments nr_qsos
-	    for (int i = 0 ; i < qso_array->len; i++) {
+	    for (int i = 0 ; i < NR_QSOS; i++) {
 		store_qso(logfile, QSOS(i));
 	    }
 	    if (interactive) {

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -104,10 +104,10 @@ void get_next_serial(void) {
 void scroll_log(void) {
 
     for (int i = 5; i > 0; i--) {
-	if (nr_qsos < i) {
+	if (NR_QSOS < i) {
 	    g_strlcpy(logline_edit[5 - i], spaces(80), LINELEN + 1);
 	} else {
-	    g_strlcpy(logline_edit[5- i], QSOS(nr_qsos - i), LINELEN + 1);
+	    g_strlcpy(logline_edit[5- i], QSOS(NR_QSOS - i), LINELEN + 1);
 	}
     }
 

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -392,7 +392,7 @@ void filterLog(const char *call) {
 
     srch_index = 0;
 
-    for (int qso_index = 0; qso_index < nr_qsos; qso_index++) {
+    for (int qso_index = 0; qso_index < NR_QSOS; qso_index++) {
 
 	struct qso_t *qso = g_ptr_array_index(qso_array, qso_index);
 	if (qso->is_comment) {

--- a/src/store_qso.c
+++ b/src/store_qso.c
@@ -38,7 +38,6 @@ void store_qso(const char *file, char *loglineptr) {
 	endwin();
 	exit(1);
     }
-    nr_qsos++;
 
     fputs(loglineptr, fp);
     fputc('\n', fp);

--- a/src/store_qso.c
+++ b/src/store_qso.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "globalvars.h"		// Includes glib.h and tlf.h
 #include "tlf_curses.h"
@@ -35,6 +36,7 @@ void store_qso(const char *file, char *loglineptr) {
 
     if ((fp = fopen(file, "a"))  == NULL) {
 	fprintf(stdout,  "store_qso.c: Error opening file.\n");
+	sleep(1);
 	endwin();
 	exit(1);
     }

--- a/src/store_qso.c
+++ b/src/store_qso.c
@@ -30,10 +30,10 @@
 #include "tlf_curses.h"
 
 
-void store_qso(char *loglineptr) {
+void store_qso(const char *file, char *loglineptr) {
     FILE *fp;
 
-    if ((fp = fopen(logfile, "a"))  == NULL) {
+    if ((fp = fopen(file, "a"))  == NULL) {
 	fprintf(stdout,  "store_qso.c: Error opening file.\n");
 	endwin();
 	exit(1);

--- a/src/store_qso.h
+++ b/src/store_qso.h
@@ -21,6 +21,6 @@
 #ifndef STORE_QSO_H
 #define STORE_QSO_H
 
-void store_qso(char *loglineptr);
+void store_qso(const char *file, char *loglineptr);
 
 #endif /* STORE_QSO_H */

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -305,6 +305,7 @@ enum {
 #define LEN(array) (sizeof(array) / sizeof(array[0]))
 
 #define QSOS(n)    (((struct qso_t*)g_ptr_array_index(qso_array, n))->logline)
+#define NR_QSOS	   (qso_array->len)
 
 #endif /* TLF_H */
 

--- a/test/data.c
+++ b/test/data.c
@@ -327,7 +327,6 @@ int rigptt = 0;
 /*----------------------------the parsed log lines-------------------------*/
 // array of qso's
 GPtrArray *qso_array;
-int nr_qsos = 0;
 
 /*------------------------------dupe array---------------------------------*/
 int nr_worked = 0;		/*< number of calls in worked[] */

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -24,7 +24,7 @@ char section[8] = "";       // defined in getexchange.c
 int qsoflags_for_qtc[MAX_QSOS];
 
 void addcall(struct qso_t *qso) { }
-void store_qso(char *logline) { nr_qsos++; }
+void store_qso(const char *file, char *logline) { nr_qsos++; }
 void cleanup_qso() { }
 void make_qtc_logline(struct read_qtc_t qtc_line, char *fname) { }
 char *getgrid(char *comment) { return comment; }

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -24,7 +24,7 @@ char section[8] = "";       // defined in getexchange.c
 int qsoflags_for_qtc[MAX_QSOS];
 
 void addcall(struct qso_t *qso) { }
-void store_qso(const char *file, char *logline) { nr_qsos++; }
+void store_qso(const char *file, char *logline) { }
 void cleanup_qso() { }
 void make_qtc_logline(struct read_qtc_t qtc_line, char *fname) { }
 char *getgrid(char *comment) { return comment; }
@@ -94,7 +94,6 @@ int setup_default(void **state) {
     strcpy(exchange, "#");
 
     init_qso_array();
-    nr_qsos = 0;
 
     return 0;
 }

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -106,10 +106,10 @@ contest_config_t config_focm;
 #define QSO5 " 80CW  12-Jan-18 16:34 0009  UA9LM          599  599  17            UA9 17   3         "
 #define QSO6 " 80CW  12-Jan-18 16:36 0010  AA3BP          599  599  05            K   05   3         "
 
-/* helper to add string to pos n in qsos array, parse the string as qso
+/* helper to add string in qsos array, parse the string as qso
  * and add it to qso_array
  */
-void add_log(int n, char *string) {
+void add_log(char *string) {
     struct qso_t *qso;
     char *line;
 
@@ -117,19 +117,21 @@ void add_log(int n, char *string) {
     qso = parse_qso(line);
     g_free(line);
     g_ptr_array_add(qso_array, qso);
+
+    nr_qsos++;
 }
 
 static void write_qsos() {
     init_qso_array();
 
-    add_log(0, QSO1);
-    add_log(1, QSO2);
-    add_log(2, QSO3);
-    add_log(3, QSO4);
-    add_log(4, QSO5);
-    add_log(5, QSO6);
+    nr_qsos = 0;
 
-    nr_qsos = 6;
+    add_log(QSO1);
+    add_log(QSO2);
+    add_log(QSO3);
+    add_log(QSO4);
+    add_log(QSO5);
+    add_log(QSO6);
 }
 
 int setup_default(void **state) {
@@ -187,6 +189,7 @@ int teardown_default(void **state) {
     FREE_DYNAMIC_STRING(callmaster_filename);
     return 0;
 }
+
 
 //void test_callmaster_no_file(void **state) {
 //    remove_callmaster();
@@ -368,10 +371,8 @@ void test_displayPartials(void **state) {
 
 	char *line = g_strdup_printf(" 80CW  12-Jan-18 16:34 0009  UA9%cAA         599  599  17            UA9 17   3         ",
 		'A' + i);
-	add_log(6 + i, line);
+	add_log(line);
 	g_free(line);
-
-	nr_qsos++;
     }
 
     // callmaster has also some UAs

--- a/test/test_searchlog.c
+++ b/test/test_searchlog.c
@@ -117,14 +117,10 @@ void add_log(char *string) {
     qso = parse_qso(line);
     g_free(line);
     g_ptr_array_add(qso_array, qso);
-
-    nr_qsos++;
 }
 
 static void write_qsos() {
     init_qso_array();
-
-    nr_qsos = 0;
 
     add_log(QSO1);
     add_log(QSO2);


### PR DESCRIPTION
To complete the migration to 'qso_array' for in memory storing of log entries the commit drops the 'nr_qsos' variable and replaces its usage by the actual length of the array (see macro definition of 'NR_QSOS').

Some further minor changes are:

- Adapt test code to use of 'qso_array'
-  factor out writing a backup in 'readcalls()'
- add file of logfile as parameter for 'store_qso()' and
- reuse 'store_qso()' to write any notes into the logfile.