### PR TITLE
Initialize noleadingzeros in init_variables()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -141,8 +141,8 @@ bool serial_section_mult = false;
 bool serial_or_section = false;	/* exchange is serial OR section, like HA-DX */
 bool serial_grid4_mult = false;
 bool qso_once = false;
-bool noleadingzeros = false;
-bool ctcomp = false;
+bool noleadingzeros;
+bool ctcomp;
 bool nob4 = false;		// allow auto b4
 bool ignoredupe = false;
 int dupe = 0;
@@ -627,6 +627,7 @@ static void init_variables() {
     unique_call_multi = MULT_NONE;
     generic_mult = MULT_NONE;
 
+    noleadingzeros = false;
     ctcomp = false;
     resend_call = RESEND_NOT_SET;
 


### PR DESCRIPTION
Was late for #350, so here's my minor fix.
Ideally all global variables shall be initialized in `init_variables()` in order to be able to reload configuration from a defined state (see #233). As this is a low prio issue and there are a lot of globals it's done only on ad-hoc basis whenever a relevant code part is changed. I added this now for `noleadingzeros`.