### PR TITLE
Fix edit_last

### DIFF
--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -188,7 +188,7 @@ void edit_last(void) {
 
     stop_background_process();  // note: this freezes nr_qsos, as network is paused
 
-    const int topline = MAX(NR_LINES - NR_QSOS, 0);
+    const int topline = (NR_LINES > NR_QSOS ? NR_LINES - NR_QSOS : 0);
 
     // set current end of exchange field
     fields[FIELD_INDEX_EXCHANGE].end = fields[FIELD_INDEX_EXCHANGE].start + contest->exchange_width - 1;


### PR DESCRIPTION
Evaluation of `topline` got broken with the switch to `qso_array->len` (#351). `len` is unsigned that promotes `NR_LINES` to unsigned too and the expression in MAX evaluates as unsigned giving wrong result.

The issue is somewhat complex: MAX is a macro defined roughly as `a > b ? a : b`.  What happens is that `a > b` (in our case `NR_LINES - NR_QSOS > 0`) is evaluated as unsigned, giving always true (lhs being unsigned). But the final value (`a`) is evaluated as signed due to the assignment to `int` and results in a negative value.

To reproduce the issue log more that 5 QSOs and press cursor up repeatedly. Log view won't be launched as it should when going past the topmost QSO.