### PR TITLE
Resend macros draft

### DIFF
--- a/src/background_process.c
+++ b/src/background_process.c
@@ -217,7 +217,7 @@ void *background_process(void *ptr) {
 
 			if ((qsonum <= n) && (n > 0)) {
 			    qsonum = highqsonr + 1;
-			    qsonr_to_str(qsonrstr, qsonum);
+			    qsonr_to_str(current_qso_values.qsonrstr, qsonum);
 			}
 			lan_message[0] = '\0';
 

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -176,8 +176,8 @@ void clear_display(void) {
     format_time(time_buf, sizeof(time_buf), DATE_TIME_FORMAT);
     update_line(time_buf);
 
-    qsonr_to_str(qsonrstr, qsonum);
-    mvaddstr(12, 23, qsonrstr);
+    qsonr_to_str(current_qso_values.qsonrstr, qsonum);
+    mvaddstr(12, 23, current_qso_values.qsonrstr);
 
     if (no_rst) {
 	mvaddstr(12, 44, "   ");

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -94,8 +94,8 @@ int getexchange(void) {
     instring[1] = '\0';
 
     if (lan_active && contest->exchange_serial) {
-	strncpy(lastqsonr, qsonrstr, 5);
-	send_lan_message(INCQSONUM, qsonrstr);
+	strncpy(lastqsonr, current_qso_values.qsonrstr, 5);
+	send_lan_message(INCQSONUM, current_qso_values.qsonrstr);
     }
 
     if (contest->recall_mult)

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -94,7 +94,7 @@ int getexchange(void) {
     instring[1] = '\0';
 
     if (lan_active && contest->exchange_serial) {
-	strncpy(lastqsonr, current_qso_values.qsonrstr, 5);
+	strncpy(last_qso_values.qsonrstr, current_qso_values.qsonrstr, 5);
 	send_lan_message(INCQSONUM, current_qso_values.qsonrstr);
     }
 

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -102,6 +102,7 @@ extern int lan_mutex;
 extern bool lan_active;
 extern int highqsonr;
 
+extern struct qso_values_t last_qso_values;
 extern struct qso_values_t current_qso_values;
 
 extern RIG *my_rig;
@@ -110,7 +111,6 @@ extern int trxmode;
 extern int myrig_model;
 extern rmode_t rigmode;
 extern freq_t freq;
-extern char lastqsonr[];
 extern bool cqwwm2;
 extern char lastcall[];
 extern char recvd_rst[];

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -102,6 +102,7 @@ extern int lan_mutex;
 extern bool lan_active;
 extern int highqsonr;
 
+extern struct qso_values_t current_qso_values;
 
 extern RIG *my_rig;
 extern cqmode_t cqmode;

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -153,7 +153,7 @@ void log_to_disk(int from_lan) {
 
     attron(COLOR_PAIR(C_WINDOW));
 
-    mvaddstr(12, 23, qsonrstr);
+    mvaddstr(12, 23, current_qso_values.qsonrstr);
 
     if (no_rst) {
 	mvaddstr(12, 44, "   ");

--- a/src/main.c
+++ b/src/main.c
@@ -269,7 +269,11 @@ int early_started = 0;			/**< 1 if sending call started early,
 					   strlen(hiscall)>cwstart or 'space' */
 char lastcall[20];
 char lastqsonr[5];
-char qsonrstr[5] = "0001";
+struct qso_values_t current_qso_values = {
+	.qsonrstr = "0001"
+};
+
+//char qsonrstr[5] = "0001";
 char band[NBANDS][4] =
 { "160", " 80", " 60", " 40", " 30", " 20", " 17", " 15", " 12", " 10", "???" };
 char proposed_exchange[80];

--- a/src/main.c
+++ b/src/main.c
@@ -268,10 +268,11 @@ int sending_call = 0;
 int early_started = 0;			/**< 1 if sending call started early,
 					   strlen(hiscall)>cwstart or 'space' */
 char lastcall[20];
-char lastqsonr[5];
 struct qso_values_t current_qso_values = {
 	.qsonrstr = "0001"
 };
+
+struct qso_values_t last_qso_values;
 
 //char qsonrstr[5] = "0001";
 char band[NBANDS][4] =

--- a/src/note.c
+++ b/src/note.c
@@ -55,7 +55,7 @@ void include_note(void) {
     noecho();
 
     if (lan_active) {
-	sprintf(buffer2, "; Node %c, %d : ", thisnode, atoi(qsonrstr) - 1);
+	sprintf(buffer2, "; Node %c, %d : ", thisnode, atoi(current_qso_values.qsonrstr) - 1);
     } else
 	sprintf(buffer2, "; ");
 

--- a/src/readcabrillo.c
+++ b/src/readcabrillo.c
@@ -471,7 +471,7 @@ int readcabrillo(int mode) {
 	}
     }
 
-    strcpy(t_qsonrstr, qsonrstr);
+    strcpy(t_qsonrstr, current_qso_values.qsonrstr);
     t_qsonum = qsonum;
     t_bandinx = bandinx;
 
@@ -481,7 +481,7 @@ int readcabrillo(int mode) {
 	cab_qso_to_tlf(logline, cabdesc);
     }
 
-    strcpy(qsonrstr, t_qsonrstr);
+    strcpy(current_qso_values.qsonrstr, t_qsonrstr);
     qsonum = t_qsonum;
     bandinx = t_bandinx;
 

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -47,29 +47,29 @@ void get_next_serial(void) {
     mm = qsonum - 1;
 
     if (!log_is_comment(logline4)) {
-	memcpy(qsonrstr, logline4 + 23, 4);
-	qsonrstr[4] = '\0';
-	mm = atoi(qsonrstr);
+	memcpy(current_qso_values.qsonrstr, logline4 + 23, 4);
+	current_qso_values.qsonrstr[4] = '\0';
+	mm = atoi(current_qso_values.qsonrstr);
     }
     if (!log_is_comment(logline3)) {
 	if (atoi(logline3 + 23) > mm) {
-	    memcpy(qsonrstr, logline3 + 23, 4);
-	    qsonrstr[4] = '\0';
-	    mm = atoi(qsonrstr);
+	    memcpy(current_qso_values.qsonrstr, logline3 + 23, 4);
+	    current_qso_values.qsonrstr[4] = '\0';
+	    mm = atoi(current_qso_values.qsonrstr);
 	}
     }
     if (!log_is_comment(logline2)) {
 	if (atoi(logline2 + 23) > mm) {
-	    memcpy(qsonrstr, logline2 + 23, 4);
-	    qsonrstr[4] = '\0';
-	    mm = atoi(qsonrstr);
+	    memcpy(current_qso_values.qsonrstr, logline2 + 23, 4);
+	    current_qso_values.qsonrstr[4] = '\0';
+	    mm = atoi(current_qso_values.qsonrstr);
 	}
     }
     if (!log_is_comment(logline1)) {
 	if (atoi(logline1 + 23) > mm) {
-	    memcpy(qsonrstr, logline1 + 23, 4);
-	    qsonrstr[4] = '\0';
-	    mm = atoi(qsonrstr);
+	    memcpy(current_qso_values.qsonrstr, logline1 + 23, 4);
+	    current_qso_values.qsonrstr[4] = '\0';
+	    mm = atoi(current_qso_values.qsonrstr);
 	}
     }
 
@@ -77,25 +77,25 @@ void get_next_serial(void) {
 
 	if (lan_mutex == 2) {	/* last stored message is from lan */
 
-	    if (atoi(qsonrstr) <= highqsonr) {
+	    if (atoi(current_qso_values.qsonrstr) <= highqsonr) {
 		qsonum = highqsonr;
 	    }
 	} else {
-	    qsonum = atoi(qsonrstr);
+	    qsonum = atoi(current_qso_values.qsonrstr);
 	    if (qsonum < highqsonr)
 		qsonum = highqsonr;
 	    if (highqsonr < qsonum)
 		highqsonr = qsonum;
 	}
     } else
-	qsonum = atoi(qsonrstr);
+	qsonum = atoi(current_qso_values.qsonrstr);
 
     if (!log_is_comment(logline4))
 	qsonum++;
     else
 	qsonum = mm + 1;
 
-    qsonr_to_str(qsonrstr, qsonum);
+    qsonr_to_str(current_qso_values.qsonrstr, qsonum);
 }
 
 #define LINELEN 80

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -188,7 +188,7 @@ void update_qso_values() {
     }
 }
 
-void ExpandMacro(void) {
+void ExpandMacro(struct qso_values_t * qso_values) {
 
     int i;
     static char qsonroutput[5] = "";
@@ -200,9 +200,9 @@ void ExpandMacro(void) {
 
     if (NULL != strstr(buffer, "@")) {
         replace_1(buffer, BUFSIZE, "@",
-                current_qso_values.hiscall_first_occurence);
+                qso_values->hiscall_first_occurence);
         replace_all(buffer, BUFSIZE, "@",
-                current_qso_values.hiscall_next_occurence);
+                qso_values->hiscall_next_occurence);
     }
 
 
@@ -218,12 +218,12 @@ void ExpandMacro(void) {
 	int leading_zeros = 0;
 	bool lead = true;
 	for (i = 0; i <= 4; i++) {
-	    if (lead && current_qso_values.qsonrstr[i] == '0') {
+	    if (lead && qso_values->qsonrstr[i] == '0') {
 		++leading_zeros;
 	    } else {
 		lead = false;
 	    }
-	    qsonroutput[i] = short_number(current_qso_values.qsonrstr[i]);
+	    qsonroutput[i] = short_number(qso_values->qsonrstr[i]);
 	}
 	qsonroutput[4] = '\0';
 
@@ -235,7 +235,7 @@ void ExpandMacro(void) {
 		    qsonroutput + leading_zeros);   /* serial nr */
 
 	if (lan_active && contest->exchange_serial) {
-            send_lan_message(INCQSONUM, current_qso_values.qsonrstr);
+            send_lan_message(INCQSONUM, qso_values->qsonrstr);
 	}
     }
 
@@ -255,7 +255,7 @@ void sendbuf(void) {
 	    (trxmode == DIGIMODE && digikeyer != NO_KEYER)) {
 
         prepare_current_qso_values();
-	ExpandMacro();
+	ExpandMacro(&current_qso_values);
         update_qso_values();
 
 	if (!simulator) {

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -220,7 +220,7 @@ void ExpandMacro(void) {
 		    qsonroutput + leading_zeros);   /* serial nr */
 
 	if (lan_active && contest->exchange_serial) {
-	    strncpy(lastqsonr, current_qso_values.qsonrstr, 5);
+	    strncpy(last_qso_values.qsonrstr, current_qso_values.qsonrstr, 5);
 	    send_lan_message(INCQSONUM, current_qso_values.qsonrstr);
 	}
     }

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -178,6 +178,14 @@ void prepare_current_qso_values() {
     current_qso_values.hiscall_next_occurence = current_qso.call;
 }
 
+void update_qso_values() {
+    if (NULL != strstr(buffer, "#")) {
+	if (lan_active && contest->exchange_serial) {
+	    strncpy(last_qso_values.qsonrstr, current_qso_values.qsonrstr, 5);
+        }
+    }
+}
+
 void ExpandMacro(void) {
 
     int i;
@@ -226,8 +234,8 @@ void ExpandMacro(void) {
 		    qsonroutput + leading_zeros);   /* serial nr */
 
 	if (lan_active && contest->exchange_serial) {
-	    strncpy(last_qso_values.qsonrstr, current_qso_values.qsonrstr, 5);
-	    send_lan_message(INCQSONUM, current_qso_values.qsonrstr);
+            update_qso_values();
+            send_lan_message(INCQSONUM, current_qso_values.qsonrstr);
 	}
     }
 

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -165,6 +165,19 @@ void replace_all(char *buf, int size, const char *what, const char *rep) {
     replace_n(buf, size, what, rep, 999);
 }
 
+void prepare_current_qso_values() {
+    char *p = current_qso.call + strlen(hiscall_sent);
+    if (strlen(hiscall_sent) != 0) {
+        hiscall_sent[0] = '\0';
+        early_started = 0;
+    }
+    if (cqmode == CQ && resend_call != RESEND_NOT_SET) {
+        strcpy(sentcall, current_qso.call);
+    }
+    current_qso_values.hiscall_first_occurence = p;
+    current_qso_values.hiscall_next_occurence = current_qso.call;
+}
+
 void ExpandMacro(void) {
 
     int i;
@@ -176,18 +189,11 @@ void ExpandMacro(void) {
 
 
     if (NULL != strstr(buffer, "@")) {
-	char *p = current_qso.call + strlen(hiscall_sent);
-	if (strlen(hiscall_sent) != 0) {
-	    hiscall_sent[0] = '\0';
-	    early_started = 0;
-//                              sending_call = 0;
-	}
-	if (cqmode == CQ && resend_call != RESEND_NOT_SET) {
-	    strcpy(sentcall, current_qso.call);
-	}
-	replace_1(buffer, BUFSIZE, "@", p);   /* his call, 1st occurrence */
-	replace_all(buffer, BUFSIZE, "@",
-		    current_qso.call);   /* his call, further occurrences */
+        prepare_current_qso_values();
+        replace_1(buffer, BUFSIZE, "@",
+                current_qso_values.hiscall_first_occurence);
+        replace_all(buffer, BUFSIZE, "@",
+                current_qso_values.hiscall_next_occurence);
     }
 
 

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -203,12 +203,12 @@ void ExpandMacro(void) {
 	int leading_zeros = 0;
 	bool lead = true;
 	for (i = 0; i <= 4; i++) {
-	    if (lead && qsonrstr[i] == '0') {
+	    if (lead && current_qso_values.qsonrstr[i] == '0') {
 		++leading_zeros;
 	    } else {
 		lead = false;
 	    }
-	    qsonroutput[i] = short_number(qsonrstr[i]);
+	    qsonroutput[i] = short_number(current_qso_values.qsonrstr[i]);
 	}
 	qsonroutput[4] = '\0';
 
@@ -220,8 +220,8 @@ void ExpandMacro(void) {
 		    qsonroutput + leading_zeros);   /* serial nr */
 
 	if (lan_active && contest->exchange_serial) {
-	    strncpy(lastqsonr, qsonrstr, 5);
-	    send_lan_message(INCQSONUM, qsonrstr);
+	    strncpy(lastqsonr, current_qso_values.qsonrstr, 5);
+	    send_lan_message(INCQSONUM, current_qso_values.qsonrstr);
 	}
     }
 

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -174,7 +174,7 @@ void time_update(void) {
 	mvaddstr(11, 0, logline4);
 	mvaddstr(13, 0, spaces(67));
 	attron(COLOR_PAIR(C_WINDOW));
-	mvaddstr(12, 23, qsonrstr);
+	mvaddstr(12, 23, current_qso_values.qsonrstr);
 	printcall();
 
 	showscore();	/* update  score  window every 2 seconds */

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -220,7 +220,7 @@ struct qso_t {
     char *section;              // transient field
 };
 
-struct qso_macro_t {
+struct qso_values_t {
     char sent_rst[4];
     char rcvd_rst[4];
     char qsonrstr[5];

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -224,8 +224,8 @@ struct qso_values_t {
     char sent_rst[4];
     char rcvd_rst[4];
     char qsonrstr[5];
-    char hiscall_first_occurence[20];
-    char hiscall_next_occurence[20];
+    char* hiscall_first_occurence;
+    char* hiscall_next_occurence;
 };
 
 void refreshp();

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -224,7 +224,8 @@ struct qso_values_t {
     char sent_rst[4];
     char rcvd_rst[4];
     char qsonrstr[5];
-    char hiscall[20];
+    char hiscall_first_occurence[20];
+    char hiscall_next_occurence[20];
 };
 
 void refreshp();

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -220,6 +220,12 @@ struct qso_t {
     char *section;              // transient field
 };
 
+struct qso_macro_t {
+    char sent_rst[4];
+    char rcvd_rst[4];
+    char qsonrstr[5];
+    char hiscall[20];
+};
 
 void refreshp();
 

--- a/test/data.c
+++ b/test/data.c
@@ -238,7 +238,9 @@ int sending_call = 0;
 int early_started = 0;			/**< 1 if sending call started early,
 					   strlen(hiscall)>cwstart or 'space' */
 char lastcall[20];
-char qsonrstr[5] = "0001";
+struct qso_values_t current_qso_values = {
+	.qsonrstr = "0001"
+};
 char band[NBANDS][4] =
 { "160", " 80", " 60", " 40", " 30", " 20", " 17", " 15", " 12", " 10", "???" };
 char proposed_exchange[80];

--- a/test/test_sendbuf.c
+++ b/test/test_sendbuf.c
@@ -94,7 +94,7 @@ int setup_default(void **state) {
     strcpy(current_qso.call, "lz1ab");
     strcpy(sent_rst, "579");
     shortqsonr = LONGCW;
-    strcpy(qsonrstr, "0309");
+    strcpy(current_qso_values.qsonrstr, "0309");
     current_qso.comment = g_malloc0(COMMENT_SIZE);
     strcpy(current_qso.comment, "Alex");
     *message[SP_CALL_MSG] = '\0';
@@ -189,25 +189,25 @@ void test_expandQsoNrshort(void **state) {
 
 void test_expandQsoNr_leadingzeros(void **state) {
     noleadingzeros = false;
-    strcpy(qsonrstr, "0007");
+    strcpy(current_qso_values.qsonrstr, "0007");
     check_ExpandMacro("nr #", "nr 007");
-    strcpy(qsonrstr, "0073");
+    strcpy(current_qso_values.qsonrstr, "0073");
     check_ExpandMacro("nr #", "nr 073");
-    strcpy(qsonrstr, "0123");
+    strcpy(current_qso_values.qsonrstr, "0123");
     check_ExpandMacro("nr #", "nr 123");
-    strcpy(qsonrstr, "4711");
+    strcpy(current_qso_values.qsonrstr, "4711");
     check_ExpandMacro("nr #", "nr 4711");
 }
 
 void test_expandQsoNr_noleadingzeros(void **state) {
     noleadingzeros = true;
-    strcpy(qsonrstr, "0007");
+    strcpy(current_qso_values.qsonrstr, "0007");
     check_ExpandMacro("nr #", "nr 7");
-    strcpy(qsonrstr, "0073");
+    strcpy(current_qso_values.qsonrstr, "0073");
     check_ExpandMacro("nr #", "nr 73");
-    strcpy(qsonrstr, "0123");
+    strcpy(current_qso_values.qsonrstr, "0123");
     check_ExpandMacro("nr #", "nr 123");
-    strcpy(qsonrstr, "4711");
+    strcpy(current_qso_values.qsonrstr, "4711");
     check_ExpandMacro("nr #", "nr 4711");
 }
 


### PR DESCRIPTION
@dl1jbe @zcsahok I'm working on a fix for https://github.com/Tlf/tlf/issues/332.
The work is in progress, but I thought maybe you could take an early look and say if you approve the overall direction.
Basically I want to make sendbuf accept qso_values_t type. It's going to use those values to expand macros in the buffer.
Depending on the situation we will be passing current_qso_values or last_qso_values into the sendbuf function.
If callsign field is empty we will be passing last_qso_values otherwise we will be passing current_qso_values.

What do you think?