### PR TITLE
Synchronize all calls to hamlib with a mutex.

### DIFF
--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -115,7 +115,9 @@ void gettxinfo(void) {
     /* CAT PTT wanted, available, inactive, and PTT On requested
      */
     if (rigptt == (CAT_PTT_USE | CAT_PTT_ON)) {
+	pthread_mutex_lock(&rig_lock);
 	retval = rig_set_ptt(my_rig, RIG_VFO_CURR, RIG_PTT_ON);
+	pthread_mutex_unlock(&rig_lock);
 
 	/* Set PTT active bit. */
 	rigptt |= CAT_PTT_ACTIVE;
@@ -127,7 +129,9 @@ void gettxinfo(void) {
     /* CAT PTT wanted, available, active and PTT Off requested
      */
     if (rigptt == (CAT_PTT_USE | CAT_PTT_ACTIVE | CAT_PTT_OFF)) {
+	pthread_mutex_lock(&rig_lock);
 	retval = rig_set_ptt(my_rig, RIG_VFO_CURR, RIG_PTT_OFF);
+	pthread_mutex_unlock(&rig_lock);
 
 	/* Clear PTT Off requested bit. */
 	rigptt &= ~CAT_PTT_OFF;
@@ -148,12 +152,22 @@ void gettxinfo(void) {
 	}
 	last_freq_time = now;
 
+	pthread_mutex_lock(&rig_lock);
 	retval = rig_get_vfo(my_rig, &vfo); /* initialize RIG_VFO_CURR */
+	pthread_mutex_unlock(&rig_lock);
+
 	if (retval == RIG_OK || retval == -RIG_ENIMPL || retval == -RIG_ENAVAIL) {
+	    pthread_mutex_lock(&rig_lock);
 	    retval = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);
+	    pthread_mutex_unlock(&rig_lock);
+
 	    if (trxmode == DIGIMODE && (digikeyer == GMFSK || digikeyer == FLDIGI)
 		    && retval == RIG_OK) {
+
+		pthread_mutex_lock(&rig_lock);
 		retvalmode = rig_get_mode(my_rig, RIG_VFO_CURR, &rigmode, &bwidth);
+		pthread_mutex_unlock(&rig_lock);
+
 		if (retvalmode != RIG_OK) {
 		    rigmode = RIG_MODE_NONE;
 		}
@@ -165,8 +179,10 @@ void gettxinfo(void) {
 	    if (rigmode == RIG_MODE_RTTY || rigmode == RIG_MODE_RTTYR) {
 		fldigi_shift_freq = fldigi_get_shift_freq();
 		if (fldigi_shift_freq != 0) {
+		    pthread_mutex_lock(&rig_lock);
 		    retval = rig_set_freq(my_rig, RIG_VFO_CURR,
 					  ((freq_t)rigfreq + (freq_t)fldigi_shift_freq));
+		    pthread_mutex_unlock(&rig_lock);
 		}
 	    }
 	}
@@ -209,7 +225,9 @@ void gettxinfo(void) {
 
     } else if (reqf == SETCWMODE) {
 
+	pthread_mutex_lock(&rig_lock);
 	retval = rig_set_mode(my_rig, RIG_VFO_CURR, RIG_MODE_CW, get_cw_bandwidth());
+	pthread_mutex_unlock(&rig_lock);
 
 	if (retval != RIG_OK) {
 	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
@@ -217,8 +235,10 @@ void gettxinfo(void) {
 
     } else if (reqf == SETSSBMODE) {
 
+	pthread_mutex_lock(&rig_lock);
 	retval = rig_set_mode(my_rig, RIG_VFO_CURR, get_ssb_mode(),
 			      TLF_DEFAULT_PASSBAND);
+	pthread_mutex_unlock(&rig_lock);
 
 	if (retval != RIG_OK) {
 	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
@@ -232,15 +252,19 @@ void gettxinfo(void) {
 	    else
 		new_mode = RIG_MODE_LSB;
 	}
+	pthread_mutex_lock(&rig_lock);
 	retval = rig_set_mode(my_rig, RIG_VFO_CURR, new_mode,
 			      TLF_DEFAULT_PASSBAND);
+	pthread_mutex_unlock(&rig_lock);
 
 	if (retval != RIG_OK) {
 	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
 	}
 
     } else if (reqf == RESETRIT) {
+	pthread_mutex_lock(&rig_lock);
 	retval = rig_set_rit(my_rig, RIG_VFO_CURR, 0);
+	pthread_mutex_unlock(&rig_lock);
 
 	if (retval != RIG_OK) {
 	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
@@ -249,7 +273,9 @@ void gettxinfo(void) {
     } else {
 	// set rig frequency (or carrier) to `reqf'
 	reqf -= fldigi_get_carrier();
+	pthread_mutex_lock(&rig_lock);
 	retval = rig_set_freq(my_rig, RIG_VFO_CURR, (freq_t) reqf);
+	pthread_mutex_unlock(&rig_lock);
 
 	if (retval != RIG_OK) {
 	    TLF_LOG_WARN("Problem with rig link: set frequency: %s", rigerror(retval));
@@ -290,7 +316,9 @@ static void handle_trx_bandswitch(const freq_t freq) {
 	return;     // no change was requested
     }
 
+    pthread_mutex_lock(&rig_lock);
     int retval = rig_set_mode(my_rig, RIG_VFO_CURR, mode, width);
+    pthread_mutex_unlock(&rig_lock);
 
     if (retval != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -104,6 +104,7 @@ extern int highqsonr;
 
 
 extern RIG *my_rig;
+extern pthread_mutex_t rig_lock;
 extern cqmode_t cqmode;
 extern int trxmode;
 extern int myrig_model;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -145,6 +145,8 @@ extern int cwstart;
 extern int early_started;
 extern int zonedisplay;
 extern int rigptt;
+extern bool rigsendmorse;
+extern bool rigstopmorse;
 extern int k_ptt;
 extern int k_pin14;
 extern int tune_seconds;

--- a/src/hamlib_keyer.c
+++ b/src/hamlib_keyer.c
@@ -23,20 +23,6 @@
 #include "globalvars.h"
 #include "hamlib_keyer.h"
 
-bool rig_has_send_morse() {
-   // SAFETY: should not be written after init
-   return (my_rig->caps->send_morse != NULL);
-}
-
-bool rig_has_stop_morse() {
-#if HAMLIB_VERSION >= 400
-    // SAFETY: should not be written after init
-    return (my_rig->caps->stop_morse != NULL);
-#else
-    return false;
-#endif
-}
-
 int hamlib_keyer_set_speed(int cwspeed) {
     value_t spd;
     spd.i = cwspeed;
@@ -71,7 +57,7 @@ int hamlib_keyer_send(char *cwmessage) {
 }
 
 int hamlib_keyer_stop() {
-    if (rig_has_stop_morse()) {
+    if (rigstopmorse) {
 	pthread_mutex_lock(&rig_lock);
 	int ret = rig_stop_morse(my_rig, RIG_VFO_CURR);
 	pthread_mutex_unlock(&rig_lock);

--- a/src/hamlib_keyer.h
+++ b/src/hamlib_keyer.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
-bool rig_has_send_morse();
-bool rig_has_stop_morse();
 int hamlib_keyer_set_speed(int cwspeed);
 int hamlib_keyer_get_speed( int *cwspeed);
 int hamlib_keyer_send(char *cwmessage);

--- a/src/main.c
+++ b/src/main.c
@@ -196,6 +196,8 @@ char synclogfile[120];
 char markerfile[120] = "";
 int xplanet = MARKER_NONE;
 int rigptt = 0;
+bool rigsendmorse;
+bool rigstopmorse;
 int tune_seconds;               /* tune up time in seconds for Alt-T */
 
 char message[25][80] = /**< Array of CW messages
@@ -848,13 +850,13 @@ static void keyer_init() {
 	    endwin();
 	    exit(EXIT_FAILURE);
 	}
-	if (!rig_has_send_morse()) {
+	if (!rigsendmorse) {
 	    showmsg("Rig does not support CW via Hamlib");
 	    sleep(1);
 	    endwin();
 	    exit(EXIT_FAILURE);
 	}
-	if (!rig_has_stop_morse()) {
+	if (!rigstopmorse) {
 #if HAMLIB_VERSION >= 400
 	    showmsg("Rig does not support stopping CW!!");
 #else

--- a/src/main.c
+++ b/src/main.c
@@ -329,6 +329,7 @@ bool bmautograb = false;
 /*-------------------------------------rigctl-------------------------------*/
 int myrig_model = 0;            /* unset */
 RIG *my_rig;			/* handle to rig (instance) */
+pthread_mutex_t rig_lock = PTHREAD_MUTEX_INITIALIZER;
 rmode_t rmode;			/* radio mode of operation */
 pbwidth_t width;
 vfo_t vfo;			/* vfo selection */

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -174,8 +174,10 @@ int init_tlf_rig(void) {
 
 void close_tlf_rig(RIG *my_rig) {
 
+    pthread_mutex_lock(&rig_lock);
     rig_close(my_rig);		/* close port */
     rig_cleanup(my_rig);	/* if you care about memory */
+    pthread_mutex_unlock(&rig_lock);
 
     printf("Rig port %s closed\n", rigportname);
 }
@@ -202,9 +204,13 @@ static int parse_rigconf() {
 	    }
 	    if (rigconf[i] == ',')
 		rigconf[i] = '\0';
+
+	    pthread_mutex_lock(&rig_lock);
 	    retcode =
 		rig_set_conf(my_rig, rig_token_lookup(my_rig, cnfparm),
 			     cnfval);
+	    pthread_mutex_unlock(&rig_lock);
+
 	    if (retcode != RIG_OK) {
 		showmsg("rig_set_conf: error  ");
 		return -1;
@@ -225,7 +231,9 @@ static void debug_tlf_rig() {
 
     sleep(10);
 
+    pthread_mutex_lock(&rig_lock);
     retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);
+    pthread_mutex_unlock(&rig_lock);
 
     if (retcode != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig get freq: %s", rigerror(retcode));
@@ -236,7 +244,9 @@ static void debug_tlf_rig() {
 
     const freq_t testfreq = 14000000;	// test set frequency
 
+    pthread_mutex_lock(&rig_lock);
     retcode = rig_set_freq(my_rig, RIG_VFO_CURR, testfreq);
+    pthread_mutex_unlock(&rig_lock);
 
     if (retcode != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig set freq: %s", rigerror(retcode));
@@ -244,7 +254,9 @@ static void debug_tlf_rig() {
 	showmsg("Rig set freq ok!");
     }
 
+    pthread_mutex_lock(&rig_lock);
     retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);	// read qrg
+    pthread_mutex_unlock(&rig_lock);
 
     if (retcode != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig get freq: %s", rigerror(retcode));

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -95,6 +95,13 @@ int init_tlf_rig(void) {
 
     caps = my_rig->caps;
 
+    rigsendmorse = my_rig->caps->send_morse != NULL;
+#if HAMLIB_VERSION >= 400
+    rigstopmorse = caps->stop_morse != NULL;
+#else
+    rigstopmorse = false;
+#endif
+
     /* If CAT PTT is wanted, test for CAT capability of rig backend. */
     if (rigptt & CAT_PTT_WANTED) {
 	if (caps->ptt_type == RIG_PTT_RIG) {


### PR DESCRIPTION
With HAMLIB_KEYER, hamlib calls are made from two different threads, they need to be synchronized.

This is for fixing #362, I have not been able to reproduce it after this patch.