### PR TITLE
Update workflow for Node.js 16

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,7 +16,7 @@ jobs:
       AM_COLOR_TESTS: always
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Show OS info
       run: cat /etc/os-release
     - name: Install dependencies


### PR DESCRIPTION
Due to github moving to Node.js 16 some actions has to be updated. TLF workflow had just warning, but mine did actually fail with

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2

So switching to checkout v3.