### PR TITLE
Fix critical Clang warnings

### DIFF
--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -23,7 +23,6 @@
 
 #include <stdbool.h>
 #include <hamlib/rig.h>
-#include "tlf.h"
 
 typedef struct {
     char 	*call;

--- a/src/muf.c
+++ b/src/muf.c
@@ -198,8 +198,7 @@ int t;
 double xn, xs, ls, h, ff, x, yn_, k, lm, u, a;
 
 
-static double power(man, ex)
-double man, ex;
+static double power(double man, double ex)
 {
     return exp(ex * log(man));
 }

--- a/src/qtcwin.c
+++ b/src/qtcwin.c
@@ -54,11 +54,11 @@
 
 
 void init_qtc_panel();
-void draw_qtc_panel();
+void draw_qtc_panel(int direction);
 void start_qtc_recording();
 void stop_qtc_recording();
 void clear_help_block();
-void show_help_msg();
+void show_help_msg(int msgidx);
 void showfield(int fidx);
 void modify_field(int pressed);
 void delete_from_field(int dir);

--- a/src/setcontest.h
+++ b/src/setcontest.h
@@ -21,6 +21,7 @@
 #ifndef SETCONTEST_H
 #define SETCONTEST_H
 
+#include "bandmap.h"
 #include "globalvars.h"
 
 #define CONTEST_IS(cid) (contest->id == cid)
@@ -28,7 +29,7 @@
 
 extern contest_config_t config_qso;
 
-bool general_ismulti();
+bool general_ismulti(spot *data);
 contest_config_t *lookup_contest(char *name);
 void list_contests();
 void setcontest(char *name);

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -25,6 +25,7 @@
 #include <time.h>
 
 #include "hamlib/rig.h"
+#include "bandmap.h"
 #include "dxcc.h"
 
 enum {
@@ -265,7 +266,7 @@ typedef struct {
 	    int (*fn)(struct qso_t *);
 	};
     }			points;
-    bool (*is_multi)();
+    bool (*is_multi)(spot *data);
 
 } contest_config_t;
 


### PR DESCRIPTION
Coming Clang-16 converts some former warnings into strict errors. The patch provides fixes for the following Clang-16 settings:

# clang-16 defaults
-Werror=implicit-function-declaration
-Werror=implicit-int
-Werror=incompatible-function-pointer-types


