### PR TITLE
Fix ARRL Sweepstakes

### DIFF
--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -222,7 +222,6 @@ extern char exchange_list[40];
 extern char rttyoutput[];
 extern char spot_ptr[MAX_SPOTS][82];
 extern char lastmsg[];
-extern char exchange[40];
 #ifdef HAVE_LIBXMLRPC
 extern char fldigi_url[50];
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -186,7 +186,6 @@ bool demode = false;		/* send DE  before s&p call  */
 
 int announcefilter = FILTER_ANN; /*  filter cluster  announcements */
 bool showscore_flag = false;	/* show  score window */
-char exchange[40];
 int defer_store = 0;
 mystation_t my;			/* all info about me */
 

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -219,7 +219,6 @@ contest_config_t config_arrldx_dx = {
 contest_config_t config_arrl_ss = {
     .id = ARRL_SS,
     .name = "ARRL_SS",
-    .exchange_serial = true,
     .points = {
 	.type = FIXED,
 	.point = 2,

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -43,6 +43,8 @@
 #include "sendbuf.h"
 #include "bands.h"
 
+char exchange[40];      // format of sent exchange
+
 struct linedata_t *get_next_record(FILE *fp);
 struct linedata_t *get_next_qtc_record(FILE *fp, int qtcdirection);
 void free_linedata(struct linedata_t *ptr);
@@ -453,9 +455,6 @@ void prepare_line(struct linedata_t *qso, struct cabrillo_desc *desc,
 }
 
 static void set_exchange_format() {
-    if (strlen(exchange) > 0) {
-	return;                 // it was set explicitly, use it
-    }
     if (contest->exchange_serial) {
 	strcpy(exchange, "#");  // contest is using serial number
 	return;

--- a/test/data.c
+++ b/test/data.c
@@ -150,7 +150,6 @@ bool demode = false;		/* send DE  before s&p call  */
 int announcefilter = FILTER_ANN; /*  filter cluster  announcements */
 bool showscore_flag = false;	/* show  score window */
 int change_rst = 0;
-char exchange[40];
 int defer_store = 0;
 mystation_t my;
 char logfile[120] = "general.log";

--- a/test/test_adif.c
+++ b/test/test_adif.c
@@ -86,6 +86,7 @@ int setup_default(void **state) {
 void test_keep_old_format(void **state) {
     char buffer[181];
 
+    extern char exchange[40];      // defined in writecabrillo.c
     strcpy(exchange, "14");
 
     struct linedata_t *qso;

--- a/test/test_cabrillo.c
+++ b/test/test_cabrillo.c
@@ -91,6 +91,7 @@ char formatfile[] = TOP_SRCDIR "/share/cabrillo.fmt" ;
 
 int setup_default(void **state) {
     strcpy(my.call, "A1BCD");
+    extern char exchange[40];      // defined in writecabrillo.c
     strcpy(exchange, "#");
 
     init_qso_array();

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -3008,7 +3008,10 @@ Exchange is a continent (NA, SA, EU, AS, AF, OC).
 .
 .TP
 .B SERIAL_EXCHANGE
-Exchange is a serial number (formats exchange field).
+Exchange is a serial number (formats received exchange
+and configures Cabrillo exchange).
+Set this only if \fIboth\fR sent and received exchanges
+are plain serial numbers.
 .
 .TP
 .B MYQRA


### PR DESCRIPTION
Fixing the issue reported by @N0NB: it was not possible to configure the sent exchange for Cabrillo as TLF was insisting on using the serial number.

Caused by the internal definition of SS setting `exchange_serial = true`.

The meaning of the rarely used `exchange_serial` flag probably has drifted over time from "exchange contains (or begins with?) a serial number" to "both sent and received exchanges are plain serial numbers". Updated man page to reflect this.

Also moved the globally defined, but only locally used flag to writecabrillo.c. Didn't make it static for testing sake.