### PR TITLE
Ignore control directives in initial exchange file

### DIFF
--- a/src/initial_exchange.c
+++ b/src/initial_exchange.c
@@ -79,6 +79,11 @@ struct ie_list *make_ie_list(char *file) {
 	    continue;
 	}
 
+	/* skip control directives like !!Order!!,... */
+	if (inputbuffer[0] == '!') {
+	    continue;
+	}
+
 	if (strlen(inputbuffer) > 80) {
 	    /* line to long */
 	    char msg[80];

--- a/test/data/ie_ok.txt
+++ b/test/data/ie_ok.txt
@@ -1,5 +1,5 @@
 
-#!!Order!!, Call, Exch1
+!!Order!!, Call, Exch1
 #
 2E0BBB ,51N00W
  2E0AAA, 51N3W


### PR DESCRIPTION
In order to be able to use N1MM initial exchange files as-is just ignore the control directives.

Example N1MM call history file (https://n1mmwp.hamdocs.com/mmfiles/cqwwcw-lastone-txt/)
``` 
!!Order!!, Call, Exch1, UserText, 
# CQWWCW
# CQWWSSB
# Last Edit,2022-11-25
# No need to be on CHF if your QTH/Zone have not changed.
# Send new info/corr. DIRECT  to ve2fk@arrl.net
# Thanks K3CT SQ7FPD
# Special callsign ANNOUNCED end of the list.
# Updated from log of VE2FK
2E0AQQ,14,
2E0CNL,14,
2E0FAQ,14,
```

Documentation: https://n1mmwp.hamdocs.com/setup/call-history/
