### PR TITLE
Hand over correct parameter for scoring

### DIFF
--- a/src/focm.c
+++ b/src/focm.c
@@ -48,8 +48,8 @@ int cntry;
 int cont;
 
 
-int score_foc() {
-    return foc_score(current_qso.call);
+int score_foc(struct qso_t *qso) {
+    return foc_score(qso->call);
 }
 
 /** FOC contest configuration */


### PR DESCRIPTION
Second part of fixes.

Scoring functions need a 'struct qso_t *' as parameter and should evaluate based on that data.