### PR TITLE
Make bands configurable

### DIFF
--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -70,13 +70,13 @@ GPtrArray *spots;
 
 
 bm_config_t bm_config = {
-    1,	/* show all bands */
-    1,  /* show all mode */
-    1,  /* show dupes */
-    1,	/* skip dupes during grab */
-    900,/* default lifetime */
-    0,  /* DO NOT show ONLY multipliers */
-    false, /* do not show out-of-band spots */
+    .allband = true,    /* show all bands */
+    .allmode = true,    /* show all mode */
+    .showdupes = true,  /* show dupes */
+    .skipdupes = true,	/* skip dupes during grab */
+    .lifetime = 900,    /* default lifetime */
+    .onlymults = false, /* DO NOT show ONLY multipliers */
+    .show_out_of_band = false,  /* do not show out-of-band spots */
 };
 
 static bool bm_initialized = false;
@@ -158,7 +158,7 @@ void bmdata_read_file() {
 			case 2:		sscanf(token, "%hhd", &entry->mode);
 			    break;
 			case 3:	        // re-evaluate band index
-                                        entry->bandindex = freq2bandindex(entry->freq);
+			    entry->bandindex = freq2bandindex(entry->freq);
 			    break;
 			case 4:		sscanf(token, "%c", &entry->node);
 			    break;
@@ -586,10 +586,10 @@ char *format_spot(spot *data) {
 
 static char get_spot_marker(spot *data) {
     if (data->bandindex == BANDINDEX_OOB) {
-        return 'X';
+	return 'X';
     }
     if (bm_ismulti(data)) {
-        return 'M';
+	return 'M';
     }
 
     return ' ';
@@ -698,7 +698,7 @@ void filter_spots() {
 
     if (spots)
 	g_ptr_array_free(spots, TRUE);		/* free spot array */
-						/* allocate new one */
+    /* allocate new one */
     spots = g_ptr_array_new_full(128, (GDestroyNotify)free_spot);
 
 
@@ -722,10 +722,10 @@ void filter_spots() {
 	if (!multi && bm_config.onlymults)
 	    continue;
 
-        /* ignore out-of-band spots if configured so */
-        if (data->bandindex == BANDINDEX_OOB && !bm_config.show_out_of_band) {
-            continue;
-        }
+	/* ignore out-of-band spots if configured so */
+	if (data->bandindex == BANDINDEX_OOB && !bm_config.show_out_of_band) {
+	    continue;
+	}
 
 	/* if spot is allband or allmode is set or band or mode matches
 	 * than add to the filtered 'spot' array
@@ -919,19 +919,19 @@ void bm_menu() {
     c = toupper(key_get());
     switch (c) {
 	case 'B':
-	    bm_config.allband = 1 - bm_config.allband;
+	    bm_config.allband = !bm_config.allband;
 	    break;
 
 	case 'M':
-	    bm_config.allmode = 1 - bm_config.allmode;
+	    bm_config.allmode = !bm_config.allmode;
 	    break;
 
 	case 'D':
-	    bm_config.showdupes = 1 - bm_config.showdupes;
+	    bm_config.showdupes = !bm_config.showdupes;
 	    break;
 
 	case 'O':
-	    bm_config.onlymults = 1 - bm_config.onlymults;
+	    bm_config.onlymults = !bm_config.onlymults;
 	    break;
     }
     bandmap_show();		/* refresh display */

--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -31,7 +31,8 @@ typedef struct {
     short 	bandindex;
     char	node;
     unsigned int timeout;/* time (in seconds) left in bandmap */
-    char 	dupe;	/* only used internal in bm_show() */
+    char 	dupe;	/* only used internally in bm_show() */
+    bool 	mult;	/* only used internally in bm_show() */
     int 	cqzone;	/* CQ zone */
     int 	ctynr;	/* Country nr */
     char 	*pfx; /* prefix */

--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -48,6 +48,7 @@ typedef struct {
     short skipdupes;
     short lifetime;
     short onlymults;
+    bool show_out_of_band;
 } bm_config_t;
 
 extern bm_config_t bm_config;

--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -31,7 +31,7 @@ typedef struct {
     short 	bandindex;
     char	node;
     unsigned int timeout;/* time (in seconds) left in bandmap */
-    char 	dupe;	/* only used internally in bm_show() */
+    bool 	dupe;	/* only used internally in bm_show() */
     bool 	mult;	/* only used internally in bm_show() */
     int 	cqzone;	/* CQ zone */
     int 	ctynr;	/* Country nr */

--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -42,12 +42,12 @@ typedef struct {
 #define SPOT_OLD	(SPOT_NEW * 2)  / 3
 
 typedef struct {
-    short allband;
-    short allmode;
-    short showdupes;
-    short skipdupes;
+    bool allband;
+    bool allmode;
+    bool showdupes;
+    bool skipdupes;
     short lifetime;
-    short onlymults;
+    bool onlymults;
     bool show_out_of_band;
 } bm_config_t;
 

--- a/src/bands.c
+++ b/src/bands.c
@@ -28,7 +28,7 @@
 const static int bandnr[NBANDS] =
 { 160, 80, 60, 40, 30, 20, 17, 15, 12, 10, 0 };
 
-const unsigned int bandcorner[NBANDS][2] = {
+unsigned int bandcorner[NBANDS][2] = {
     { 1800000, 2000000 },	// band bottom, band top
     { 3500000, 4000000 },
     { 5250000, 5450000 },       // 5351500-5356500 worldwide
@@ -42,7 +42,7 @@ const unsigned int bandcorner[NBANDS][2] = {
     {        0,        0 }
 };
 
-const unsigned int cwcorner[NBANDS] = {
+unsigned int cwcorner[NBANDS] = {
     1838000,
     3580000,
     5354000,
@@ -56,7 +56,7 @@ const unsigned int cwcorner[NBANDS] = {
     0
 };
 
-const unsigned int ssbcorner[NBANDS] = {
+unsigned int ssbcorner[NBANDS] = {
     1840000,
     3600000,
     5354000,

--- a/src/bands.h
+++ b/src/bands.h
@@ -35,9 +35,9 @@
 #define BAND_DOWN    -1
 
 extern int inxes[NBANDS];  /**< conversion from BANDINDEX to BAND-mask */
-extern const unsigned int bandcorner[NBANDS][2];
-extern const unsigned int cwcorner[NBANDS];
-extern const unsigned int ssbcorner[NBANDS];
+extern unsigned int bandcorner[NBANDS][2];
+extern unsigned int cwcorner[NBANDS];
+extern unsigned int ssbcorner[NBANDS];
 
 /** \brief converts bandnumber to bandindex
  *

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -467,6 +467,7 @@ static int cfg_bandmap(const cfg_arg_t arg) {
     bm_config.skipdupes = 0;
     bm_config.lifetime = 900;
     bm_config.onlymults = 0;
+    bm_config.show_out_of_band = false;
 
     /* Allow configuration of bandmap display if keyword
      * is followed by a '='
@@ -489,6 +490,8 @@ static int cfg_bandmap(const cfg_arg_t arg) {
 		    case 'S': bm_config.skipdupes = 1;
 			break;
 		    case 'O': bm_config.onlymults = 1;
+			break;
+		    case 'X': bm_config.show_out_of_band = true;
 			break;
 		    default:
 			break;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -461,12 +461,12 @@ static int cfg_bandmap(const cfg_arg_t arg) {
     cluster = MAP;
 
     /* init bandmap filtering */
-    bm_config.allband = 1;
-    bm_config.allmode = 1;
-    bm_config.showdupes = 1;
-    bm_config.skipdupes = 0;
+    bm_config.allband = true;
+    bm_config.allmode = true;
+    bm_config.showdupes = true;
+    bm_config.skipdupes = false;
     bm_config.lifetime = 900;
-    bm_config.onlymults = 0;
+    bm_config.onlymults = false;
     bm_config.show_out_of_band = false;
 
     /* Allow configuration of bandmap display if keyword
@@ -481,15 +481,15 @@ static int cfg_bandmap(const cfg_arg_t arg) {
 	    char *ptr = bm_fields[0];
 	    while (*ptr != '\0') {
 		switch (*ptr++) {
-		    case 'B': bm_config.allband = 0;
+		    case 'B': bm_config.allband = false;
 			break;
-		    case 'M': bm_config.allmode = 0;
+		    case 'M': bm_config.allmode = false;
 			break;
-		    case 'D': bm_config.showdupes = 0;
+		    case 'D': bm_config.showdupes = false;
 			break;
-		    case 'S': bm_config.skipdupes = 1;
+		    case 'S': bm_config.skipdupes = true;
 			break;
-		    case 'O': bm_config.onlymults = 1;
+		    case 'O': bm_config.onlymults = true;
 			break;
 		    case 'X': bm_config.show_out_of_band = true;
 			break;

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -6,6 +6,7 @@
 #include <netinet/in.h>
 
 #include "../src/audio.h"
+#include "../src/bands.h"
 #include "../src/parse_logcfg.h"
 #include "../src/lancode.h"
 #include "../src/bandmap.h"
@@ -1472,4 +1473,13 @@ void test_digi_rig_mode_rttyr(void **state) {
     int rc = call_parse_logcfg("DIGI_RIG_MODE=RTTYR");
     assert_int_equal(rc, PARSE_OK);
     assert_int_equal(digi_mode, RIG_MODE_RTTYR);
+}
+
+void test_band40_ok(void **state) {
+    int rc = call_parse_logcfg("BAND_40=7000k,7040k,7050k,7200k");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(bandcorner[3][0], 7000*1000);
+    assert_int_equal(bandcorner[3][1], 7200*1000);
+    assert_int_equal(cwcorner[3], 7040*1000);
+    assert_int_equal(ssbcorner[3], 7050*1000);
 }

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -327,31 +327,31 @@ void test_keyer_device_too_long(void **state) {
 
 void test_vk_play_cmd(void **state) {
     int rc = call_parse_logcfg("VK_PLAY_COMMAND= sox -q $1 -d\n");
-    assert_int_equal(rc,0);
+    assert_int_equal(rc, 0);
     assert_string_equal(vk_play_cmd, "sox -q $1 -d");
 }
 
 void test_vk_record_cmd(void **state) {
     int rc = call_parse_logcfg("VK_RECORD_COMMAND= sox -r 8000 -q -d $1 &\n");
-    assert_int_equal(rc,0);
+    assert_int_equal(rc, 0);
     assert_string_equal(vk_record_cmd, "sox -r 8000 -q -d $1 &");
 }
 
 void test_soundlog_play_cmd(void **state) {
     int rc = call_parse_logcfg("SOUNDLOG_PLAY_COMMAND= sox -q $1 -d\n");
-    assert_int_equal(rc,0);
+    assert_int_equal(rc, 0);
     assert_string_equal(soundlog_play_cmd, "sox -q $1 -d");
 }
 
 void test_soundlog_record_cmd(void **state) {
     int rc = call_parse_logcfg("SOUNDLOG_RECORD_COMMAND= ./soundlog");
-    assert_int_equal(rc,0);
+    assert_int_equal(rc, 0);
     assert_string_equal(soundlog_record_cmd, "./soundlog");
 }
 
 void test_soundlog_directory(void **state) {
     int rc = call_parse_logcfg("SOUNDLOG_DIRECTORY= ~/soundlogs");
-    assert_int_equal(rc,0);
+    assert_int_equal(rc, 0);
     assert_string_equal(soundlog_dir, "~/soundlogs");
 }
 
@@ -397,7 +397,7 @@ void test_usepartials_wrong_arg(void **state) {
     int rc = call_parse_logcfg("USEPARTIALS=abc\n");
     assert_int_equal(rc, PARSE_ERROR);
     assert_string_equal(showmsg_spy,
-                       "Wrong parameter format for keyword 'USEPARTIALS'. See man page.\n");
+			"Wrong parameter format for keyword 'USEPARTIALS'. See man page.\n");
 
 }
 
@@ -978,7 +978,7 @@ void test_bandmap(void **state) {
     int rc = call_parse_logcfg("BANDMAP\n");
     assert_int_equal(rc, 0);
     assert_int_equal(cluster, MAP);
-    assert_int_equal(bm_config.showdupes, 1);
+    assert_true(bm_config.showdupes);
     assert_int_equal(bm_config.lifetime, 900);
 }
 
@@ -986,7 +986,7 @@ void test_bandmap_d100(void **state) {
     int rc = call_parse_logcfg("BANDMAP=D,100\n");
     assert_int_equal(rc, 0);
     assert_int_equal(cluster, MAP);
-    assert_int_equal(bm_config.showdupes, 0);
+    assert_false(bm_config.showdupes);
     assert_int_equal(bm_config.lifetime, 100);
 }
 
@@ -1478,8 +1478,8 @@ void test_digi_rig_mode_rttyr(void **state) {
 void test_band40_ok(void **state) {
     int rc = call_parse_logcfg("BAND_40=7000k,7040k,7050k,7200k");
     assert_int_equal(rc, PARSE_OK);
-    assert_int_equal(bandcorner[3][0], 7000*1000);
-    assert_int_equal(bandcorner[3][1], 7200*1000);
-    assert_int_equal(cwcorner[3], 7040*1000);
-    assert_int_equal(ssbcorner[3], 7050*1000);
+    assert_int_equal(bandcorner[3][0], 7000 * 1000);
+    assert_int_equal(bandcorner[3][1], 7200 * 1000);
+    assert_int_equal(cwcorner[3], 7040 * 1000);
+    assert_int_equal(ssbcorner[3], 7050 * 1000);
 }

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1734,6 +1734,27 @@ See the relevant Xplanet documentation.
 .IP
 Use azimuthal projection and center the map on your QTH (station location).
 .
+.TP
+\fBBAND_\fINN\fR=\fIbottom,cw_end,ssb_start,top\fR
+Define band edges. \fINN\fR is the band designator (wavelength), allowed values are:
+160, 80, 60, 40, 30, 20, 17, 15, 12, 10.
+.
+.IP
+All 4 comma separated parameters are mandatory and
+shall be specified in integer Hz units with an optional
+\fIk\fR suffix.
+.IP
+Example specification for Region\ 1 40\ m band:
+.IP
+    \fBBAND_40\fR = \fI7000k, 7040k, 7050k, 7200k\fR
+.
+.IP
+Internal default band definitions are based on a superset of all Regions.
+For example, 40\ m ends by default at 7300\ kHz.
+In addition to configuring the legal limits
+\fBBAND_\fINN\fR can also be used to fine tune actual band configurations
+for a specific contest.
+.
 .SS Morse Code Keyer Commands
 .
 .TP
@@ -2080,6 +2101,8 @@ string parsed for:
 .RB ( Ctrl-G )
 .br
 	\(lqO\(rq - show only new multipliers
+.br
+	\(lqX\(rq - show also out-of-band spots when in all-band mode
 .br
 .RI < number >
 lifetime for new spots in seconds (number >=


### PR DESCRIPTION
Aiming to resolve #387.

Bands can be specified using the `BAND_mmm` keywords, where `mmm` is the band's wavelength . The argument is a comma separated tuple of 4 frequencies: band bottom, CW corner, SSB corner, band top. Frequencies must be specified in Hz, with an optional **k** suffix.

An example for 40m according to Region 1 band plan (https://www.iaru-r1.org/on-the-air/band-plans/):
```
BAND_40 = 7000k, 7040k, 7050k, 7200k
```

Will update the man page and also add marking spots on bandmap.