### PR TITLE
Rename rig_lock to rig_mutex to avoid clash with hamlib

### DIFF
--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -115,9 +115,9 @@ void gettxinfo(void) {
     /* CAT PTT wanted, available, inactive, and PTT On requested
      */
     if (rigptt == (CAT_PTT_USE | CAT_PTT_ON)) {
-	pthread_mutex_lock(&rig_mutex);
+	pthread_mutex_lock(&tlf_rig_mutex);
 	retval = rig_set_ptt(my_rig, RIG_VFO_CURR, RIG_PTT_ON);
-	pthread_mutex_unlock(&rig_mutex);
+	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	/* Set PTT active bit. */
 	rigptt |= CAT_PTT_ACTIVE;
@@ -129,9 +129,9 @@ void gettxinfo(void) {
     /* CAT PTT wanted, available, active and PTT Off requested
      */
     if (rigptt == (CAT_PTT_USE | CAT_PTT_ACTIVE | CAT_PTT_OFF)) {
-	pthread_mutex_lock(&rig_mutex);
+	pthread_mutex_lock(&tlf_rig_mutex);
 	retval = rig_set_ptt(my_rig, RIG_VFO_CURR, RIG_PTT_OFF);
-	pthread_mutex_unlock(&rig_mutex);
+	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	/* Clear PTT Off requested bit. */
 	rigptt &= ~CAT_PTT_OFF;
@@ -152,21 +152,21 @@ void gettxinfo(void) {
 	}
 	last_freq_time = now;
 
-	pthread_mutex_lock(&rig_mutex);
+	pthread_mutex_lock(&tlf_rig_mutex);
 	retval = rig_get_vfo(my_rig, &vfo); /* initialize RIG_VFO_CURR */
-	pthread_mutex_unlock(&rig_mutex);
+	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval == RIG_OK || retval == -RIG_ENIMPL || retval == -RIG_ENAVAIL) {
-	    pthread_mutex_lock(&rig_mutex);
+	    pthread_mutex_lock(&tlf_rig_mutex);
 	    retval = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);
-	    pthread_mutex_unlock(&rig_mutex);
+	    pthread_mutex_unlock(&tlf_rig_mutex);
 
 	    if (trxmode == DIGIMODE && (digikeyer == GMFSK || digikeyer == FLDIGI)
 		    && retval == RIG_OK) {
 
-		pthread_mutex_lock(&rig_mutex);
+		pthread_mutex_lock(&tlf_rig_mutex);
 		retvalmode = rig_get_mode(my_rig, RIG_VFO_CURR, &rigmode, &bwidth);
-		pthread_mutex_unlock(&rig_mutex);
+		pthread_mutex_unlock(&tlf_rig_mutex);
 
 		if (retvalmode != RIG_OK) {
 		    rigmode = RIG_MODE_NONE;
@@ -179,10 +179,10 @@ void gettxinfo(void) {
 	    if (rigmode == RIG_MODE_RTTY || rigmode == RIG_MODE_RTTYR) {
 		fldigi_shift_freq = fldigi_get_shift_freq();
 		if (fldigi_shift_freq != 0) {
-		    pthread_mutex_lock(&rig_mutex);
+		    pthread_mutex_lock(&tlf_rig_mutex);
 		    retval = rig_set_freq(my_rig, RIG_VFO_CURR,
 					  ((freq_t)rigfreq + (freq_t)fldigi_shift_freq));
-		    pthread_mutex_unlock(&rig_mutex);
+		    pthread_mutex_unlock(&tlf_rig_mutex);
 		}
 	    }
 	}
@@ -225,9 +225,9 @@ void gettxinfo(void) {
 
     } else if (reqf == SETCWMODE) {
 
-	pthread_mutex_lock(&rig_mutex);
+	pthread_mutex_lock(&tlf_rig_mutex);
 	retval = rig_set_mode(my_rig, RIG_VFO_CURR, RIG_MODE_CW, get_cw_bandwidth());
-	pthread_mutex_unlock(&rig_mutex);
+	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval != RIG_OK) {
 	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
@@ -235,10 +235,10 @@ void gettxinfo(void) {
 
     } else if (reqf == SETSSBMODE) {
 
-	pthread_mutex_lock(&rig_mutex);
+	pthread_mutex_lock(&tlf_rig_mutex);
 	retval = rig_set_mode(my_rig, RIG_VFO_CURR, get_ssb_mode(),
 			      TLF_DEFAULT_PASSBAND);
-	pthread_mutex_unlock(&rig_mutex);
+	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval != RIG_OK) {
 	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
@@ -252,19 +252,19 @@ void gettxinfo(void) {
 	    else
 		new_mode = RIG_MODE_LSB;
 	}
-	pthread_mutex_lock(&rig_mutex);
+	pthread_mutex_lock(&tlf_rig_mutex);
 	retval = rig_set_mode(my_rig, RIG_VFO_CURR, new_mode,
 			      TLF_DEFAULT_PASSBAND);
-	pthread_mutex_unlock(&rig_mutex);
+	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval != RIG_OK) {
 	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
 	}
 
     } else if (reqf == RESETRIT) {
-	pthread_mutex_lock(&rig_mutex);
+	pthread_mutex_lock(&tlf_rig_mutex);
 	retval = rig_set_rit(my_rig, RIG_VFO_CURR, 0);
-	pthread_mutex_unlock(&rig_mutex);
+	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval != RIG_OK) {
 	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
@@ -273,9 +273,9 @@ void gettxinfo(void) {
     } else {
 	// set rig frequency (or carrier) to `reqf'
 	reqf -= fldigi_get_carrier();
-	pthread_mutex_lock(&rig_mutex);
+	pthread_mutex_lock(&tlf_rig_mutex);
 	retval = rig_set_freq(my_rig, RIG_VFO_CURR, (freq_t) reqf);
-	pthread_mutex_unlock(&rig_mutex);
+	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval != RIG_OK) {
 	    TLF_LOG_WARN("Problem with rig link: set frequency: %s", rigerror(retval));
@@ -316,9 +316,9 @@ static void handle_trx_bandswitch(const freq_t freq) {
 	return;     // no change was requested
     }
 
-    pthread_mutex_lock(&rig_mutex);
+    pthread_mutex_lock(&tlf_rig_mutex);
     int retval = rig_set_mode(my_rig, RIG_VFO_CURR, mode, width);
-    pthread_mutex_unlock(&rig_mutex);
+    pthread_mutex_unlock(&tlf_rig_mutex);
 
     if (retval != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -104,7 +104,7 @@ extern int highqsonr;
 
 
 extern RIG *my_rig;
-extern pthread_mutex_t rig_mutex;
+extern pthread_mutex_t tlf_rig_mutex;
 extern cqmode_t cqmode;
 extern int trxmode;
 extern int myrig_model;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -104,7 +104,7 @@ extern int highqsonr;
 
 
 extern RIG *my_rig;
-extern pthread_mutex_t rig_lock;
+extern pthread_mutex_t rig_mutex;
 extern cqmode_t cqmode;
 extern int trxmode;
 extern int myrig_model;

--- a/src/hamlib_keyer.c
+++ b/src/hamlib_keyer.c
@@ -28,9 +28,9 @@ int hamlib_keyer_set_speed(int cwspeed) {
     value_t spd;
     spd.i = cwspeed;
 
-    pthread_mutex_lock(&rig_mutex);
+    pthread_mutex_lock(&tlf_rig_mutex);
     int ret = rig_set_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, spd);
-    pthread_mutex_unlock(&rig_mutex);
+    pthread_mutex_unlock(&tlf_rig_mutex);
 
     return ret;
 }
@@ -40,9 +40,9 @@ int hamlib_keyer_get_speed(int *cwspeed) {
 
     assert(cwspeed != NULL);
 
-    pthread_mutex_lock(&rig_mutex);
+    pthread_mutex_lock(&tlf_rig_mutex);
     int ret = rig_get_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, &value);
-    pthread_mutex_unlock(&rig_mutex);
+    pthread_mutex_unlock(&tlf_rig_mutex);
 
     if (ret == RIG_OK)
 	*cwspeed = value.i;
@@ -50,9 +50,9 @@ int hamlib_keyer_get_speed(int *cwspeed) {
 }
 
 int hamlib_keyer_send(char *cwmessage) {
-    pthread_mutex_lock(&rig_mutex);
+    pthread_mutex_lock(&tlf_rig_mutex);
     int ret = rig_send_morse(my_rig, RIG_VFO_CURR, cwmessage);
-    pthread_mutex_unlock(&rig_mutex);
+    pthread_mutex_unlock(&tlf_rig_mutex);
 
     return ret;
 }
@@ -60,9 +60,9 @@ int hamlib_keyer_send(char *cwmessage) {
 int hamlib_keyer_stop() {
 #if HAMLIB_VERSION >= 400
     if (rig_has_stop_morse()) {
-	pthread_mutex_lock(&rig_mutex);
+	pthread_mutex_lock(&tlf_rig_mutex);
 	int ret = rig_stop_morse(my_rig, RIG_VFO_CURR);
-	pthread_mutex_unlock(&rig_mutex);
+	pthread_mutex_unlock(&tlf_rig_mutex);
 	return ret;
     }
 #endif

--- a/src/hamlib_keyer.c
+++ b/src/hamlib_keyer.c
@@ -28,9 +28,9 @@ int hamlib_keyer_set_speed(int cwspeed) {
     value_t spd;
     spd.i = cwspeed;
 
-    pthread_mutex_lock(&rig_lock);
+    pthread_mutex_lock(&rig_mutex);
     int ret = rig_set_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, spd);
-    pthread_mutex_unlock(&rig_lock);
+    pthread_mutex_unlock(&rig_mutex);
 
     return ret;
 }
@@ -40,9 +40,9 @@ int hamlib_keyer_get_speed(int *cwspeed) {
 
     assert(cwspeed != NULL);
 
-    pthread_mutex_lock(&rig_lock);
+    pthread_mutex_lock(&rig_mutex);
     int ret = rig_get_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, &value);
-    pthread_mutex_unlock(&rig_lock);
+    pthread_mutex_unlock(&rig_mutex);
 
     if (ret == RIG_OK)
 	*cwspeed = value.i;
@@ -50,9 +50,9 @@ int hamlib_keyer_get_speed(int *cwspeed) {
 }
 
 int hamlib_keyer_send(char *cwmessage) {
-    pthread_mutex_lock(&rig_lock);
+    pthread_mutex_lock(&rig_mutex);
     int ret = rig_send_morse(my_rig, RIG_VFO_CURR, cwmessage);
-    pthread_mutex_unlock(&rig_lock);
+    pthread_mutex_unlock(&rig_mutex);
 
     return ret;
 }
@@ -60,9 +60,9 @@ int hamlib_keyer_send(char *cwmessage) {
 int hamlib_keyer_stop() {
 #if HAMLIB_VERSION >= 400
     if (rig_has_stop_morse()) {
-	pthread_mutex_lock(&rig_lock);
+	pthread_mutex_lock(&rig_mutex);
 	int ret = rig_stop_morse(my_rig, RIG_VFO_CURR);
-	pthread_mutex_unlock(&rig_lock);
+	pthread_mutex_unlock(&rig_mutex);
 	return ret;
     }
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -331,7 +331,7 @@ bool bmautograb = false;
 /*-------------------------------------rigctl-------------------------------*/
 int myrig_model = 0;            /* unset */
 RIG *my_rig;			/* handle to rig (instance) */
-pthread_mutex_t rig_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t tlf_rig_mutex = PTHREAD_MUTEX_INITIALIZER;
 rmode_t rmode;			/* radio mode of operation */
 pbwidth_t width;
 vfo_t vfo;			/* vfo selection */

--- a/src/main.c
+++ b/src/main.c
@@ -331,7 +331,7 @@ bool bmautograb = false;
 /*-------------------------------------rigctl-------------------------------*/
 int myrig_model = 0;            /* unset */
 RIG *my_rig;			/* handle to rig (instance) */
-pthread_mutex_t rig_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t rig_mutex = PTHREAD_MUTEX_INITIALIZER;
 rmode_t rmode;			/* radio mode of operation */
 pbwidth_t width;
 vfo_t vfo;			/* vfo selection */

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -197,10 +197,10 @@ int init_tlf_rig(void) {
 
 void close_tlf_rig(RIG *my_rig) {
 
-    pthread_mutex_lock(&rig_mutex);
+    pthread_mutex_lock(&tlf_rig_mutex);
     rig_close(my_rig);		/* close port */
     rig_cleanup(my_rig);	/* if you care about memory */
-    pthread_mutex_unlock(&rig_mutex);
+    pthread_mutex_unlock(&tlf_rig_mutex);
 
     printf("Rig port %s closed\n", rigportname);
 }
@@ -228,11 +228,11 @@ static int parse_rigconf() {
 	    if (rigconf[i] == ',')
 		rigconf[i] = '\0';
 
-	    pthread_mutex_lock(&rig_mutex);
+	    pthread_mutex_lock(&tlf_rig_mutex);
 	    retcode =
 		rig_set_conf(my_rig, rig_token_lookup(my_rig, cnfparm),
 			     cnfval);
-	    pthread_mutex_unlock(&rig_mutex);
+	    pthread_mutex_unlock(&tlf_rig_mutex);
 
 	    if (retcode != RIG_OK) {
 		showmsg("rig_set_conf: error  ");
@@ -254,9 +254,9 @@ static void debug_tlf_rig() {
 
     sleep(10);
 
-    pthread_mutex_lock(&rig_mutex);
+    pthread_mutex_lock(&tlf_rig_mutex);
     retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);
-    pthread_mutex_unlock(&rig_mutex);
+    pthread_mutex_unlock(&tlf_rig_mutex);
 
     if (retcode != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig get freq: %s", rigerror(retcode));
@@ -267,9 +267,9 @@ static void debug_tlf_rig() {
 
     const freq_t testfreq = 14000000;	// test set frequency
 
-    pthread_mutex_lock(&rig_mutex);
+    pthread_mutex_lock(&tlf_rig_mutex);
     retcode = rig_set_freq(my_rig, RIG_VFO_CURR, testfreq);
-    pthread_mutex_unlock(&rig_mutex);
+    pthread_mutex_unlock(&tlf_rig_mutex);
 
     if (retcode != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig set freq: %s", rigerror(retcode));
@@ -277,9 +277,9 @@ static void debug_tlf_rig() {
 	showmsg("Rig set freq ok!");
     }
 
-    pthread_mutex_lock(&rig_mutex);
+    pthread_mutex_lock(&tlf_rig_mutex);
     retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);	// read qrg
-    pthread_mutex_unlock(&rig_mutex);
+    pthread_mutex_unlock(&tlf_rig_mutex);
 
     if (retcode != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig get freq: %s", rigerror(retcode));

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -197,10 +197,10 @@ int init_tlf_rig(void) {
 
 void close_tlf_rig(RIG *my_rig) {
 
-    pthread_mutex_lock(&rig_lock);
+    pthread_mutex_lock(&rig_mutex);
     rig_close(my_rig);		/* close port */
     rig_cleanup(my_rig);	/* if you care about memory */
-    pthread_mutex_unlock(&rig_lock);
+    pthread_mutex_unlock(&rig_mutex);
 
     printf("Rig port %s closed\n", rigportname);
 }
@@ -228,11 +228,11 @@ static int parse_rigconf() {
 	    if (rigconf[i] == ',')
 		rigconf[i] = '\0';
 
-	    pthread_mutex_lock(&rig_lock);
+	    pthread_mutex_lock(&rig_mutex);
 	    retcode =
 		rig_set_conf(my_rig, rig_token_lookup(my_rig, cnfparm),
 			     cnfval);
-	    pthread_mutex_unlock(&rig_lock);
+	    pthread_mutex_unlock(&rig_mutex);
 
 	    if (retcode != RIG_OK) {
 		showmsg("rig_set_conf: error  ");
@@ -254,9 +254,9 @@ static void debug_tlf_rig() {
 
     sleep(10);
 
-    pthread_mutex_lock(&rig_lock);
+    pthread_mutex_lock(&rig_mutex);
     retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);
-    pthread_mutex_unlock(&rig_lock);
+    pthread_mutex_unlock(&rig_mutex);
 
     if (retcode != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig get freq: %s", rigerror(retcode));
@@ -267,9 +267,9 @@ static void debug_tlf_rig() {
 
     const freq_t testfreq = 14000000;	// test set frequency
 
-    pthread_mutex_lock(&rig_lock);
+    pthread_mutex_lock(&rig_mutex);
     retcode = rig_set_freq(my_rig, RIG_VFO_CURR, testfreq);
-    pthread_mutex_unlock(&rig_lock);
+    pthread_mutex_unlock(&rig_mutex);
 
     if (retcode != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig set freq: %s", rigerror(retcode));
@@ -277,9 +277,9 @@ static void debug_tlf_rig() {
 	showmsg("Rig set freq ok!");
     }
 
-    pthread_mutex_lock(&rig_lock);
+    pthread_mutex_lock(&rig_mutex);
     retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);	// read qrg
-    pthread_mutex_unlock(&rig_lock);
+    pthread_mutex_unlock(&rig_mutex);
 
     if (retcode != RIG_OK) {
 	TLF_LOG_WARN("Problem with rig get freq: %s", rigerror(retcode));


### PR DESCRIPTION
Fixes #394: mutex `rig_lock` renamed to `rig_mutex` to avoid the clash.
Other mutexes are also called this way, so it also aligns the naming with the rest of the code.