### PR TITLE
Fix obsoleted autoconf macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,11 +13,14 @@ dnl Clean compilation output makes compiler warnings more visible
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # Checks for programs.
-AC_PROG_CC_C99
+# (autoconf 2.70 obsoletes AC_PROG_CC_C99, it's now done by AC_PROG_CC)
+m4_version_prereq([2.70],[AC_PROG_CC],[AC_PROG_CC_C99])
+if test x"$ac_cv_prog_cc_c99" = x"no"; then
+	AC_MSG_FAILURE([*** C99 support is mandatory])
+fi
 AC_PROG_INSTALL
 
 # Checks for header files.
-AC_HEADER_STDC
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h \
 	sys/ioctl.h sys/socket.h sys/time.h syslog.h termios.h])
 


### PR DESCRIPTION
The version of autoconf used in current Debian (bookworm) and Ubuntu (22) distros deprecate a number of macros (see https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.70/html_node/Obsolete-Macros.html#Obsolete-Macros). In our case this affects `AC_PROG_CC_C99` and `AC_HEADER_STDC`.

This leads to warnings during configuration phase.
```
Run autoreconf -i && ./configure --datadir=$PWD/datadir && make -j2
configure.ac:16: warning: The macro `AC_PROG_CC_C99' is obsolete.
configure.ac:16: You should run autoupdate.
./lib/autoconf/c.m4:1659: AC_PROG_CC_C99 is expanded from...
configure.ac:16: the top level
configure.ac:20: warning: The macro `AC_HEADER_STDC' is obsolete.
configure.ac:20: You should run autoupdate.
./lib/autoconf/headers.m4:704: AC_HEADER_STDC is expanded from...
configure.ac:20: the top level
```

`AC_PROG_CC_C99` can be replaced by a plain `AC_PROG_CC` , whereas `AC_HEADER_STDC` can be safely removed.
