### PR TITLE
Audit KSQP mults lists

### DIFF
--- a/rules/ksqp/ksqp.py
+++ b/rules/ksqp/ksqp.py
@@ -1,27 +1,33 @@
 """
 KSQP contest
-https://ksqsoparty.org/rules/KSQPRules2022.pdf?1
+https://ksqsoparty.org/rules/KSQPRules2023.pdf
+https://ksqsoparty.org/rules/KSQPRules2022.pdf
 """
 
-states = ['CA', 'AL', 'AK', 'AZ', 'AR', 'CO', 'CT', 'DE', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA',
-'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ',
-'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT',
-'VA', 'WA', 'WV', 'WI', 'WY', 'DC',
+states = [
+'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
+'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
+'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NC', 'ND', 'NE', 'NH',
+'NJ', 'NM', 'NV', 'NY', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
+'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY',
 # Canada
-'NB', 'NL', 'NS', 'PE', 'QC', 'ON', 'MB', 'SK', 'AB', 'BC', 'NT', 'NU', 'YT',
+'AB', 'BC', 'MB', 'NB', 'NL', 'NS', 'NT', 'NU', 'ON', 'PE',
+'QC', 'SK', 'YT',
 # Other countries
 'DX']
 
 counties = [
-'ALL', 'AND', 'ATC', 'BAR', 'BRT', 'BOU', 'BRO', 'BUT', 'CHS', 'CHT', 'CHE', 'CHY',
-'CLK', 'CLY', 'CLO', 'COF', 'COM', 'COW', 'CRA', 'DEC', 'DIC', 'DON', 'DOU', 'EDW',
-'ELK', 'ELL', 'ELS', 'FIN', 'FOR', 'FRA', 'GEA', 'GOV', 'GRM', 'GRT', 'GRY', 'GLY',
-'GRE', 'HAM', 'HPR', 'HVY', 'HAS', 'HOG', 'JAC', 'JEF', 'JEW', 'JOH', 'KEA', 'KIN',
-'KIO', 'LAB', 'LAN', 'LEA', 'LCN', 'LIN', 'LOG', 'LYO', 'MRN', 'MSH', 'MCP', 'MEA',
-'MIA', 'MIT', 'MGY', 'MOR', 'MTN', 'NEM', 'NEO', 'NES', 'NOR', 'OSA', 'OSB', 'OTT',
-'PAW', 'PHI', 'POT', 'PRA', 'RAW', 'REN', 'REP', 'RIC', 'RIL', 'ROO', 'RUS', 'RSL',
-'SAL', 'SCO', 'SED', 'SEW', 'SHA', 'SHE', 'SMN', 'SMI', 'STA', 'STN', 'STE', 'SUM',
-'THO', 'TRE', 'WAB', 'WAL', 'WAS', 'WIC', 'WIL', 'WOO', 'WYA']
+'ALL', 'AND', 'ATC', 'BAR', 'BRT', 'BOU', 'BRO', 'BUT', 'CHS', 'CHT',
+'CHE', 'CHY', 'CLK', 'CLY', 'CLO', 'COF', 'COM', 'COW', 'CRA', 'DEC',
+'DIC', 'DON', 'DOU', 'EDW', 'ELK', 'ELL', 'ELS', 'FIN', 'FOR', 'FRA',
+'GEA', 'GOV', 'GRM', 'GRT', 'GRY', 'GLY', 'GRE', 'HAM', 'HPR', 'HVY',
+'HAS', 'HOG', 'JAC', 'JEF', 'JEW', 'JOH', 'KEA', 'KIN', 'KIO', 'LAB',
+'LAN', 'LEA', 'LCN', 'LIN', 'LOG', 'LYO', 'MRN', 'MSH', 'MCP', 'MEA',
+'MIA', 'MIT', 'MGY', 'MOR', 'MTN', 'NEM', 'NEO', 'NES', 'NOR', 'OSA',
+'OSB', 'OTT', 'PAW', 'PHI', 'POT', 'PRA', 'RAW', 'REN', 'REP', 'RIC',
+'RIL', 'ROO', 'RUS', 'RSL', 'SAL', 'SCO', 'SED', 'SEW', 'SHA', 'SHE',
+'SMN', 'SMI', 'STA', 'STN', 'STE', 'SUM', 'THO', 'TRE', 'WAB', 'WAL',
+'WAS', 'WIC', 'WIL', 'WOO', 'WYA']
 
 rule_mode = ""
 


### PR DESCRIPTION
Remove 'DC' for states mults list as it is not a mult for this event.

Break lines of all mult lists at ten entities per line for ease of counting.

Add link to KSQP 2023 rules.