### PR TITLE
Add keyword to disable rig mode setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ sudo apt install sox xplanet
 
 Once the dependencies are installed, the easiest way to get TLF's source is by
 downloading the latest tarball (version 1.4.1) from
-[here](http://download.savannah.gnu.org/releases/tlf/tlf-1.4.1.tar.gz), then
+[here](https://github.com/Tlf/tlf/releases/download/tlf-1.4.1/tlf-1.4.1.tar.gz), then
 navigating your Terminal to the directory where you unpacked it, and typing:
 
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ sudo apt install sox xplanet
 
 Once the dependencies are installed, the easiest way to get TLF's source is by
 downloading the latest tarball (version 1.4.1) from
-[here](https://github.com/Tlf/tlf/releases/download/tlf-1.4.1/tlf-1.4.1.tar.gz), then
+[here](http://download.savannah.gnu.org/releases/tlf/tlf-1.4.1.tar.gz), then
 navigating your Terminal to the directory where you unpacked it, and typing:
 
 ```

--- a/share/logcfg.dat
+++ b/share/logcfg.dat
@@ -45,15 +45,6 @@ CALL=NOCALL
 #
 #################################
 #                               #
-#  OPERATING MODE               #
-#                               #
-#################################
-# Can be set to CQ, S&P
-OPERATING_MODE=CQ
-#
-#
-#################################
-#                               #
 #  Time offset from UTC         #
 #                               #
 #################################
@@ -135,6 +126,8 @@ CWTONE=800
 #RIGPORT=/dev/ttyS0
 #RIGPORT=/dev/ttyUSB2
 #RIGPTT
+#
+#FOLLOW_MODE
 #
 #SSBMODE
 #

--- a/share/logcfg.dat
+++ b/share/logcfg.dat
@@ -45,6 +45,15 @@ CALL=NOCALL
 #
 #################################
 #                               #
+#  OPERATING MODE               #
+#                               #
+#################################
+# Can be set to CQ, S&P
+OPERATING_MODE=CQ
+#
+#
+#################################
+#                               #
 #  Time offset from UTC         #
 #                               #
 #################################
@@ -126,8 +135,6 @@ CWTONE=800
 #RIGPORT=/dev/ttyS0
 #RIGPORT=/dev/ttyUSB2
 #RIGPTT
-#
-#FOLLOW_MODE
 #
 #SSBMODE
 #

--- a/share/logcfg.dat
+++ b/share/logcfg.dat
@@ -129,6 +129,8 @@ CWTONE=800
 #           for ten tec OMNI VI #
 #################################
 #
+#FOLLOW_MODE
+#
 #RADIO_CONTROL
 #RIGMODEL=351
 #RIGSPEED=2400

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -148,12 +148,12 @@ int changepars(void) {
     noecho();
 
     for (k = 0; parameterstring[k]; k++)
-		parameterstring[k] = toupper(parameterstring[k]);
+	parameterstring[k] = toupper(parameterstring[k]);
 
     for (i = 0; i <= maxpar; i++) {
-		if (strncmp(parameterstring, parameters[i], 3) == 0) {
-			break;
-		}
+	if (strncmp(parameterstring, parameters[i], 3) == 0) {
+	    break;
+	}
     }
 
     switch (i) {

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -148,12 +148,12 @@ int changepars(void) {
     noecho();
 
     for (k = 0; parameterstring[k]; k++)
-	parameterstring[k] = toupper(parameterstring[k]);
+		parameterstring[k] = toupper(parameterstring[k]);
 
     for (i = 0; i <= maxpar; i++) {
-	if (strncmp(parameterstring, parameters[i], 3) == 0) {
-	    break;
-	}
+		if (strncmp(parameterstring, parameters[i], 3) == 0) {
+			break;
+		}
     }
 
     switch (i) {

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -203,9 +203,7 @@ void gettxinfo(void) {
 
 	if (bandinx != oldbandinx) {	// band change on trx
 	    oldbandinx = bandinx;
-		if (follow_mode) {
-			handle_trx_bandswitch((int) freq);
-		}
+	    handle_trx_bandswitch((int) freq);
 	}
 
 	/* read speed from rig */
@@ -299,32 +297,32 @@ static void handle_trx_bandswitch(const freq_t freq) {
 
     send_bandswitch(freq);
 
-	rmode_t mode = RIG_MODE_NONE;           // default: no change
-	pbwidth_t width = TLF_DEFAULT_PASSBAND; // passband width, in Hz
+    rmode_t mode = RIG_MODE_NONE;           // default: no change
+    pbwidth_t width = TLF_DEFAULT_PASSBAND; // passband width, in Hz
 
-	if (trxmode == SSBMODE) {
-		mode = get_ssb_mode();
-	} else if (trxmode == DIGIMODE) {
-		if ((rigmode & (RIG_MODE_LSB | RIG_MODE_USB | RIG_MODE_RTTY | RIG_MODE_RTTYR))
-			!= rigmode) {
-			mode = RIG_MODE_LSB;
-		}
-	} else {
-		mode = RIG_MODE_CW;
-		width = get_cw_bandwidth();
+    if (trxmode == SSBMODE) {
+	mode = get_ssb_mode();
+    } else if (trxmode == DIGIMODE) {
+	if ((rigmode & (RIG_MODE_LSB | RIG_MODE_USB | RIG_MODE_RTTY | RIG_MODE_RTTYR))
+		!= rigmode) {
+	    mode = RIG_MODE_LSB;
 	}
+    } else {
+	mode = RIG_MODE_CW;
+	width = get_cw_bandwidth();
+    }
 
-	if (mode == RIG_MODE_NONE) {
-		return;     // no change was requested
-	}
+    if (mode == RIG_MODE_NONE) {
+	return;     // no change was requested
+    }
 
     pthread_mutex_lock(&rig_lock);
     int retval = rig_set_mode(my_rig, RIG_VFO_CURR, mode, width);
     pthread_mutex_unlock(&rig_lock);
 
     if (retval != RIG_OK) {
-		TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
-	}
+	TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
+    }
 
 }
 

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -203,7 +203,9 @@ void gettxinfo(void) {
 
 	if (bandinx != oldbandinx) {	// band change on trx
 	    oldbandinx = bandinx;
-	    handle_trx_bandswitch((int) freq);
+	    if (follow_mode) {
+                handle_trx_bandswitch((int) freq);
+            }
 	}
 
 	/* read speed from rig */

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -203,7 +203,9 @@ void gettxinfo(void) {
 
 	if (bandinx != oldbandinx) {	// band change on trx
 	    oldbandinx = bandinx;
-	    handle_trx_bandswitch((int) freq);
+		if (follow_mode) {
+			handle_trx_bandswitch((int) freq);
+		}
 	}
 
 	/* read speed from rig */
@@ -297,32 +299,32 @@ static void handle_trx_bandswitch(const freq_t freq) {
 
     send_bandswitch(freq);
 
-    rmode_t mode = RIG_MODE_NONE;           // default: no change
-    pbwidth_t width = TLF_DEFAULT_PASSBAND; // passband width, in Hz
+	rmode_t mode = RIG_MODE_NONE;           // default: no change
+	pbwidth_t width = TLF_DEFAULT_PASSBAND; // passband width, in Hz
 
-    if (trxmode == SSBMODE) {
-	mode = get_ssb_mode();
-    } else if (trxmode == DIGIMODE) {
-	if ((rigmode & (RIG_MODE_LSB | RIG_MODE_USB | RIG_MODE_RTTY | RIG_MODE_RTTYR))
-		!= rigmode) {
-	    mode = RIG_MODE_LSB;
+	if (trxmode == SSBMODE) {
+		mode = get_ssb_mode();
+	} else if (trxmode == DIGIMODE) {
+		if ((rigmode & (RIG_MODE_LSB | RIG_MODE_USB | RIG_MODE_RTTY | RIG_MODE_RTTYR))
+			!= rigmode) {
+			mode = RIG_MODE_LSB;
+		}
+	} else {
+		mode = RIG_MODE_CW;
+		width = get_cw_bandwidth();
 	}
-    } else {
-	mode = RIG_MODE_CW;
-	width = get_cw_bandwidth();
-    }
 
-    if (mode == RIG_MODE_NONE) {
-	return;     // no change was requested
-    }
+	if (mode == RIG_MODE_NONE) {
+		return;     // no change was requested
+	}
 
     pthread_mutex_lock(&rig_lock);
     int retval = rig_set_mode(my_rig, RIG_VFO_CURR, mode, width);
     pthread_mutex_unlock(&rig_lock);
 
     if (retval != RIG_OK) {
-	TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
-    }
+		TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
+	}
 
 }
 

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -84,6 +84,7 @@ extern char logline_edit[5][LOGLINELEN + 1];
 
 extern char band[NBANDS][4];
 extern freq_t bandfrequency[NBANDS];
+extern bool follow_mode;
 
 extern struct tm *time_ptr;
 

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -84,7 +84,6 @@ extern char logline_edit[5][LOGLINELEN + 1];
 
 extern char band[NBANDS][4];
 extern freq_t bandfrequency[NBANDS];
-extern bool follow_mode;
 
 extern struct tm *time_ptr;
 

--- a/src/main.c
+++ b/src/main.c
@@ -171,7 +171,6 @@ char multsfile[80] = "";	/* name of file with a list of allowed
 char exchange_list[40] = "";
 int timeoffset = 0;
 int trxmode = CWMODE;
-bool follow_mode = false; /* Follow rig mode */
 rmode_t  rigmode = RIG_MODE_NONE;
 
 bool mixedmode = false;
@@ -183,7 +182,7 @@ int cluster = NOCLUSTER;	/* 0 = OFF, 1 = FOLLOW, 2  = spots  3 = all */
 bool clusterlog = false;	/* clusterlog on/off */
 bool searchflg = false;		/* display search  window */
 bool show_time = false;
-cqmode_t cqmode = CQ;
+cqmode_t cqmode;            /* can be CQ or S&P */
 bool demode = false;		/* send DE  before s&p call  */
 
 int announcefilter = FILTER_ANN; /*  filter cluster  announcements */
@@ -637,7 +636,7 @@ static void init_variables() {
     tune_seconds = 6;   /* tune up for 6 s */
     unique_call_multi = MULT_NONE;
     generic_mult = MULT_NONE;
-
+    cqmode = CQ;
     leading_zeros_serial = true;
     ctcomp = false;
     resend_call = RESEND_NOT_SET;

--- a/src/main.c
+++ b/src/main.c
@@ -172,6 +172,7 @@ char exchange_list[40] = "";
 int timeoffset = 0;
 int trxmode = CWMODE;
 rmode_t  rigmode = RIG_MODE_NONE;
+bool follow_mode = false; /* Follow rig mode */
 
 bool mixedmode = false;
 char sent_rst[4] = "599";

--- a/src/main.c
+++ b/src/main.c
@@ -171,6 +171,7 @@ char multsfile[80] = "";	/* name of file with a list of allowed
 char exchange_list[40] = "";
 int timeoffset = 0;
 int trxmode = CWMODE;
+bool follow_mode = false; /* Follow rig mode */
 rmode_t  rigmode = RIG_MODE_NONE;
 
 bool mixedmode = false;
@@ -182,7 +183,7 @@ int cluster = NOCLUSTER;	/* 0 = OFF, 1 = FOLLOW, 2  = spots  3 = all */
 bool clusterlog = false;	/* clusterlog on/off */
 bool searchflg = false;		/* display search  window */
 bool show_time = false;
-cqmode_t cqmode;            /* can be CQ or S&P */
+cqmode_t cqmode = CQ;
 bool demode = false;		/* send DE  before s&p call  */
 
 int announcefilter = FILTER_ANN; /*  filter cluster  announcements */
@@ -636,7 +637,7 @@ static void init_variables() {
     tune_seconds = 6;   /* tune up for 6 s */
     unique_call_multi = MULT_NONE;
     generic_mult = MULT_NONE;
-    cqmode = CQ;
+
     leading_zeros_serial = true;
     ctcomp = false;
     resend_call = RESEND_NOT_SET;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1235,6 +1235,7 @@ static config_t logcfg_configs[] = {
     {"SERIAL_EXCHANGE",	    CFG_CONTEST_BOOL(exchange_serial)},
     {"COUNTRY_MULT",	    CFG_BOOL(country_mult)},
     {"CQWW_M2",		    CFG_BOOL(cqwwm2)},
+    {"FOLLOW_MODE",         CFG_BOOL(follow_mode)},
     {"LAN_DEBUG",	    CFG_BOOL(landebug)},
     {"CALLUPDATE",	    CFG_BOOL(call_update)},
     {"TIME_MASTER",	    CFG_BOOL(time_master)},

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -32,7 +32,6 @@
 
 #include "audio.h"
 #include "bandmap.h"
-#include "bands.h"
 #include "cabrillo_utils.h"
 #include "change_rst.h"
 #include "cw_utils.h"
@@ -52,7 +51,6 @@
 #include "startmsg.h"
 #include "tlf_curses.h"
 #include "searchlog.h"
-#include "tlf.h"
 
 bool exist_in_country_list();
 
@@ -322,70 +320,6 @@ static int cfg_tlfcolor(const cfg_arg_t arg) {
     return rc;
 }
 
-// returns 0 on error
-static unsigned int parse_frequency(char *input) {
-    char *value = g_strdup(input);
-    str_toupper(value);     // normalize to upper case
-    /* must be digits and an optional K suffix */
-    if (!g_regex_match_simple("^\\s*[0-9]+K?\\s*$",
-			      value, (GRegexCompileFlags)0, (GRegexMatchFlags)0)) {
-	g_free(value);
-	return 0;
-    }
-
-    int freq = atoi(value);
-    if (strchr(value, 'K') != NULL) {
-	freq *= 1000;
-    }
-
-    g_free(value);
-    return freq;
-}
-
-static int cfg_band(const cfg_arg_t arg) {
-    gchar *index = g_match_info_fetch(match_info, 1);
-    int band = atoi(index);
-    int bi = bandnr2index(band);     // get band index
-    g_free(index);
-
-    if (bi == BANDINDEX_OOB) {
-	error_details = g_strdup("invalid band");
-	return PARSE_ERROR;
-    }
-
-    int rc = PARSE_OK;
-    char **fields = g_strsplit(parameter, ",", 4);
-    unsigned int values[4];
-    for (int i  = 0; i < 4 && rc == PARSE_OK; ++i) {
-	if (fields[i] == NULL) {
-	    error_details = g_strdup("too few arguments");
-	    rc = PARSE_WRONG_PARAMETER;
-	    break;
-	}
-	values[i] = parse_frequency(fields[i]);
-	if (values[i] == 0) {
-	    error_details = g_strdup_printf("invalid frequency %s", fields[i]);
-	    rc = PARSE_WRONG_PARAMETER;
-	}
-	// values may not be decreasing
-	else if (i > 0 && values[i] < values[i - 1]) {
-	    error_details = g_strdup_printf("wrong frequency %s", fields[i]);
-	    rc = PARSE_WRONG_PARAMETER;
-	}
-    }
-
-    if (rc == PARSE_OK) {
-	bandcorner[bi][0] = values[0];
-	cwcorner[bi] = values[1];
-	ssbcorner[bi] = values[2];
-	bandcorner[bi][1] = values[3];
-    }
-
-    g_strfreev(fields);
-
-    return rc;
-}
-
 static int cfg_call(const cfg_arg_t arg) {
     int rc = cfg_string((cfg_arg_t) {
 	.char_p = my.call, .size = sizeof(my.call),
@@ -413,24 +347,6 @@ static int cfg_contest(const cfg_arg_t arg) {
 	return rc;
     }
     setcontest(contest);
-    return PARSE_OK;
-}
-
-static int cfg_operating_mode(const cfg_arg_t arg) {
-    char *str = g_ascii_strup(parameter, -1);
-    g_strstrip(str);
-
-    if (strcmp(str, "CQ") == 0) {
-	    cqmode = CQ;
-    } else if (strcmp(str, "S&P") == 0) {
-        cqmode = S_P;
-    } else {
-        g_free(str);
-        error_details = g_strdup("must be CQ or S&P");
-        return PARSE_WRONG_PARAMETER;
-    }
-
-    g_free(str);
     return PARSE_OK;
 }
 
@@ -480,13 +396,12 @@ static int cfg_bandmap(const cfg_arg_t arg) {
     cluster = MAP;
 
     /* init bandmap filtering */
-    bm_config.allband = true;
-    bm_config.allmode = true;
-    bm_config.showdupes = true;
-    bm_config.skipdupes = false;
+    bm_config.allband = 1;
+    bm_config.allmode = 1;
+    bm_config.showdupes = 1;
+    bm_config.skipdupes = 0;
     bm_config.lifetime = 900;
-    bm_config.onlymults = false;
-    bm_config.show_out_of_band = false;
+    bm_config.onlymults = 0;
 
     /* Allow configuration of bandmap display if keyword
      * is followed by a '='
@@ -500,17 +415,15 @@ static int cfg_bandmap(const cfg_arg_t arg) {
 	    char *ptr = bm_fields[0];
 	    while (*ptr != '\0') {
 		switch (*ptr++) {
-		    case 'B': bm_config.allband = false;
+		    case 'B': bm_config.allband = 0;
 			break;
-		    case 'M': bm_config.allmode = false;
+		    case 'M': bm_config.allmode = 0;
 			break;
-		    case 'D': bm_config.showdupes = false;
+		    case 'D': bm_config.showdupes = 0;
 			break;
-		    case 'S': bm_config.skipdupes = true;
+		    case 'S': bm_config.skipdupes = 1;
 			break;
-		    case 'O': bm_config.onlymults = true;
-			break;
-		    case 'X': bm_config.show_out_of_band = true;
+		    case 'O': bm_config.onlymults = 1;
 			break;
 		    default:
 			break;
@@ -1295,7 +1208,6 @@ static config_t logcfg_configs[] = {
     {"QS_VKSPM",                CFG_MESSAGE(qtc_phsend_message, SP_TU_MSG) },
 
     {"TLFCOLOR([1-6])",  NEED_PARAM, cfg_tlfcolor},
-    {"BAND_([0-9]+)",  NEED_PARAM, cfg_band},
 
     {"LAN_PORT",        CFG_INT(lan_port, 1000, INT32_MAX)},
     {"TIME_OFFSET",     CFG_INT(timeoffset, -23, 23)},
@@ -1323,6 +1235,7 @@ static config_t logcfg_configs[] = {
     {"CLUSTER",         CFG_INT_CONST(cluster, CLUSTER)},
     {"SSBMODE",         CFG_INT_CONST(trxmode, SSBMODE)},
     {"RIGPTT",          CFG_INT_CONST(rigptt, CAT_PTT_WANTED)},
+    {"FOLLOW_MODE",     CFG_BOOL(follow_mode)},
 
     {"RIGCONF",         CFG_STRING_STATIC(rigconf, 80)},
     {"LOGFILE",         CFG_STRING_STATIC(logfile, 120)},
@@ -1389,7 +1302,6 @@ static config_t logcfg_configs[] = {
     {"CABRILLO-(.+)",       OPTIONAL_PARAM, cfg_cabrillo_field},
     {"RESEND_CALL",         NEED_PARAM, cfg_resend_call},
     {"GENERIC_MULT",        NEED_PARAM, cfg_generic_mult},
-    {"OPERATING_MODE",      NEED_PARAM, cfg_operating_mode},
 
     {NULL}  // end marker
 };

--- a/test/data.c
+++ b/test/data.c
@@ -413,8 +413,6 @@ char lan_logline[256];	    // defined in log_to_disk.c
 int resend_call;
 char sentcall[20] = "";     // storing the call what already sent
 
-bool follow_mode;
-
 #include <curses.h>
 NCURSES_EXPORT_VAR(WINDOW *) stdscr = NULL;
 int wattr_on(WINDOW *win, attr_t attrs, void *opts) {

--- a/test/data.c
+++ b/test/data.c
@@ -413,6 +413,8 @@ char lan_logline[256];	    // defined in log_to_disk.c
 int resend_call;
 char sentcall[20] = "";     // storing the call what already sent
 
+bool follow_mode;
+
 #include <curses.h>
 NCURSES_EXPORT_VAR(WINDOW *) stdscr = NULL;
 int wattr_on(WINDOW *win, attr_t attrs, void *opts) {

--- a/test/data.c
+++ b/test/data.c
@@ -412,6 +412,7 @@ char lan_logline[256];	    // defined in log_to_disk.c
 /* resend call option, can be 0 (do not use), 1 (partial), 2 (full) */
 int resend_call;
 char sentcall[20] = "";     // storing the call what already sent
+bool follow_mode;
 
 #include <curses.h>
 NCURSES_EXPORT_VAR(WINDOW *) stdscr = NULL;

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -189,6 +189,7 @@ int setup_default(void **state) {
     change_rst = false;
     fixedmult = 0.0;
     exclude_multilist_type = EXCLUDE_NONE;
+    follow_mode = true;
     rigptt = 0;
     minitest = 0;
     cqmode = CQ;
@@ -433,6 +434,7 @@ static bool_true_t bool_trues[] = {
     {"MIXED", &mixedmode},
     {"IGNOREDUPE", &ignoredupe},
     {"USE_CONTINENTLIST_ONLY", &continentlist_only},
+    {"FOLLOW_MODE", &follow_mode},
     {"RADIO_CONTROL", &trx_control},
     {"PORTABLE_MULT_2", &portable_x2},
     {"WYSIWYG_MULTIBAND", &wysiwyg_multi},
@@ -915,6 +917,12 @@ void test_ssbmode(void **state) {
     int rc = call_parse_logcfg("SSBMODE\n");
     assert_int_equal(rc, 0);
     assert_int_equal(trxmode, SSBMODE);
+}
+
+void test_follow_mode(void **state) {
+    int rc = call_parse_logcfg("FOLLOW_MODE\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_true(follow_mode);
 }
 
 void test_operating_mode(void **state) {

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -6,6 +6,7 @@
 #include <netinet/in.h>
 
 #include "../src/audio.h"
+#include "../src/bands.h"
 #include "../src/parse_logcfg.h"
 #include "../src/lancode.h"
 #include "../src/bandmap.h"
@@ -189,8 +190,8 @@ int setup_default(void **state) {
     fixedmult = 0.0;
     exclude_multilist_type = EXCLUDE_NONE;
     rigptt = 0;
-    follow_mode = true;
     minitest = 0;
+    cqmode = CQ;
 
     setcontest(QSO_MODE);
 
@@ -327,31 +328,31 @@ void test_keyer_device_too_long(void **state) {
 
 void test_vk_play_cmd(void **state) {
     int rc = call_parse_logcfg("VK_PLAY_COMMAND= sox -q $1 -d\n");
-    assert_int_equal(rc,0);
+    assert_int_equal(rc, 0);
     assert_string_equal(vk_play_cmd, "sox -q $1 -d");
 }
 
 void test_vk_record_cmd(void **state) {
     int rc = call_parse_logcfg("VK_RECORD_COMMAND= sox -r 8000 -q -d $1 &\n");
-    assert_int_equal(rc,0);
+    assert_int_equal(rc, 0);
     assert_string_equal(vk_record_cmd, "sox -r 8000 -q -d $1 &");
 }
 
 void test_soundlog_play_cmd(void **state) {
     int rc = call_parse_logcfg("SOUNDLOG_PLAY_COMMAND= sox -q $1 -d\n");
-    assert_int_equal(rc,0);
+    assert_int_equal(rc, 0);
     assert_string_equal(soundlog_play_cmd, "sox -q $1 -d");
 }
 
 void test_soundlog_record_cmd(void **state) {
     int rc = call_parse_logcfg("SOUNDLOG_RECORD_COMMAND= ./soundlog");
-    assert_int_equal(rc,0);
+    assert_int_equal(rc, 0);
     assert_string_equal(soundlog_record_cmd, "./soundlog");
 }
 
 void test_soundlog_directory(void **state) {
     int rc = call_parse_logcfg("SOUNDLOG_DIRECTORY= ~/soundlogs");
-    assert_int_equal(rc,0);
+    assert_int_equal(rc, 0);
     assert_string_equal(soundlog_dir, "~/soundlogs");
 }
 
@@ -397,7 +398,7 @@ void test_usepartials_wrong_arg(void **state) {
     int rc = call_parse_logcfg("USEPARTIALS=abc\n");
     assert_int_equal(rc, PARSE_ERROR);
     assert_string_equal(showmsg_spy,
-                       "Wrong parameter format for keyword 'USEPARTIALS'. See man page.\n");
+			"Wrong parameter format for keyword 'USEPARTIALS'. See man page.\n");
 
 }
 
@@ -433,7 +434,6 @@ static bool_true_t bool_trues[] = {
     {"IGNOREDUPE", &ignoredupe},
     {"USE_CONTINENTLIST_ONLY", &continentlist_only},
     {"RADIO_CONTROL", &trx_control},
-    {"FOLLOW_MODE", &follow_mode},
     {"PORTABLE_MULT_2", &portable_x2},
     {"WYSIWYG_MULTIBAND", &wysiwyg_multi},
     {"WYSIWYG_ONCE", &wysiwyg_once},
@@ -917,12 +917,11 @@ void test_ssbmode(void **state) {
     assert_int_equal(trxmode, SSBMODE);
 }
 
-void test_follow_mode(void **state) {
-    int rc = call_parse_logcfg("FOLLOW_MODE\n");
-    assert_int_equal(rc, PARSE_OK);
-    assert_true(follow_mode);
+void test_operating_mode(void **state) {
+    int rc = call_parse_logcfg("OPERATING_MODE=S&P\n");
+    assert_int_equal(rc, 0);
+    assert_int_equal(cqmode, S_P);
 }
-
 
 // TLFCOLOR1..6
 void test_tlfcolorn(void **state) {
@@ -986,7 +985,7 @@ void test_bandmap(void **state) {
     int rc = call_parse_logcfg("BANDMAP\n");
     assert_int_equal(rc, 0);
     assert_int_equal(cluster, MAP);
-    assert_int_equal(bm_config.showdupes, 1);
+    assert_true(bm_config.showdupes);
     assert_int_equal(bm_config.lifetime, 900);
 }
 
@@ -994,7 +993,7 @@ void test_bandmap_d100(void **state) {
     int rc = call_parse_logcfg("BANDMAP=D,100\n");
     assert_int_equal(rc, 0);
     assert_int_equal(cluster, MAP);
-    assert_int_equal(bm_config.showdupes, 0);
+    assert_false(bm_config.showdupes);
     assert_int_equal(bm_config.lifetime, 100);
 }
 

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -6,7 +6,6 @@
 #include <netinet/in.h>
 
 #include "../src/audio.h"
-#include "../src/bands.h"
 #include "../src/parse_logcfg.h"
 #include "../src/lancode.h"
 #include "../src/bandmap.h"
@@ -190,8 +189,8 @@ int setup_default(void **state) {
     fixedmult = 0.0;
     exclude_multilist_type = EXCLUDE_NONE;
     rigptt = 0;
+    follow_mode = true;
     minitest = 0;
-    cqmode = CQ;
 
     setcontest(QSO_MODE);
 
@@ -328,31 +327,31 @@ void test_keyer_device_too_long(void **state) {
 
 void test_vk_play_cmd(void **state) {
     int rc = call_parse_logcfg("VK_PLAY_COMMAND= sox -q $1 -d\n");
-    assert_int_equal(rc, 0);
+    assert_int_equal(rc,0);
     assert_string_equal(vk_play_cmd, "sox -q $1 -d");
 }
 
 void test_vk_record_cmd(void **state) {
     int rc = call_parse_logcfg("VK_RECORD_COMMAND= sox -r 8000 -q -d $1 &\n");
-    assert_int_equal(rc, 0);
+    assert_int_equal(rc,0);
     assert_string_equal(vk_record_cmd, "sox -r 8000 -q -d $1 &");
 }
 
 void test_soundlog_play_cmd(void **state) {
     int rc = call_parse_logcfg("SOUNDLOG_PLAY_COMMAND= sox -q $1 -d\n");
-    assert_int_equal(rc, 0);
+    assert_int_equal(rc,0);
     assert_string_equal(soundlog_play_cmd, "sox -q $1 -d");
 }
 
 void test_soundlog_record_cmd(void **state) {
     int rc = call_parse_logcfg("SOUNDLOG_RECORD_COMMAND= ./soundlog");
-    assert_int_equal(rc, 0);
+    assert_int_equal(rc,0);
     assert_string_equal(soundlog_record_cmd, "./soundlog");
 }
 
 void test_soundlog_directory(void **state) {
     int rc = call_parse_logcfg("SOUNDLOG_DIRECTORY= ~/soundlogs");
-    assert_int_equal(rc, 0);
+    assert_int_equal(rc,0);
     assert_string_equal(soundlog_dir, "~/soundlogs");
 }
 
@@ -398,7 +397,7 @@ void test_usepartials_wrong_arg(void **state) {
     int rc = call_parse_logcfg("USEPARTIALS=abc\n");
     assert_int_equal(rc, PARSE_ERROR);
     assert_string_equal(showmsg_spy,
-			"Wrong parameter format for keyword 'USEPARTIALS'. See man page.\n");
+                       "Wrong parameter format for keyword 'USEPARTIALS'. See man page.\n");
 
 }
 
@@ -434,6 +433,7 @@ static bool_true_t bool_trues[] = {
     {"IGNOREDUPE", &ignoredupe},
     {"USE_CONTINENTLIST_ONLY", &continentlist_only},
     {"RADIO_CONTROL", &trx_control},
+    {"FOLLOW_MODE", &follow_mode},
     {"PORTABLE_MULT_2", &portable_x2},
     {"WYSIWYG_MULTIBAND", &wysiwyg_multi},
     {"WYSIWYG_ONCE", &wysiwyg_once},
@@ -917,11 +917,12 @@ void test_ssbmode(void **state) {
     assert_int_equal(trxmode, SSBMODE);
 }
 
-void test_operating_mode(void **state) {
-    int rc = call_parse_logcfg("OPERATING_MODE=S&P\n");
-    assert_int_equal(rc, 0);
-    assert_int_equal(cqmode, S_P);
+void test_follow_mode(void **state) {
+    int rc = call_parse_logcfg("FOLLOW_MODE\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_true(follow_mode);
 }
+
 
 // TLFCOLOR1..6
 void test_tlfcolorn(void **state) {
@@ -985,7 +986,7 @@ void test_bandmap(void **state) {
     int rc = call_parse_logcfg("BANDMAP\n");
     assert_int_equal(rc, 0);
     assert_int_equal(cluster, MAP);
-    assert_true(bm_config.showdupes);
+    assert_int_equal(bm_config.showdupes, 1);
     assert_int_equal(bm_config.lifetime, 900);
 }
 
@@ -993,7 +994,7 @@ void test_bandmap_d100(void **state) {
     int rc = call_parse_logcfg("BANDMAP=D,100\n");
     assert_int_equal(rc, 0);
     assert_int_equal(cluster, MAP);
-    assert_false(bm_config.showdupes);
+    assert_int_equal(bm_config.showdupes, 0);
     assert_int_equal(bm_config.lifetime, 100);
 }
 

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1656,11 +1656,6 @@ The station callsign used in messages; also used to determine the station's
 country, zone and continent.
 .
 .TP
-\fBOPERATING_MODE\fR=\fICQ\fR|\fIS&P\fR
-Set operating mode for start up. Use \fICQ\fR for "run" and \fIS&P\fR for "search and pounce".
-The default mode is \fICQ\fR.
-.
-.TP
 \fBTIME_OFFSET\fR=\fI0\fR
 Used to shift the @PACKAGE_NAME@ time with respect to the computer clock.
 .
@@ -1738,27 +1733,6 @@ See the relevant Xplanet documentation.
 .
 .IP
 Use azimuthal projection and center the map on your QTH (station location).
-.
-.TP
-\fBBAND_\fINN\fR=\fIbottom,cw_end,ssb_start,top\fR
-Define band edges. \fINN\fR is the band designator (wavelength), allowed values are:
-160, 80, 60, 40, 30, 20, 17, 15, 12, 10.
-.
-.IP
-All 4 comma separated parameters are mandatory and
-shall be specified in integer Hz units with an optional
-\fIk\fR suffix.
-.IP
-Example specification for Region\ 1 40\ m band:
-.IP
-    \fBBAND_40\fR = \fI7000k, 7040k, 7050k, 7200k\fR
-.
-.IP
-Internal default band definitions are based on a superset of all Regions.
-For example, 40\ m ends by default at 7300\ kHz.
-In addition to configuring the legal limits
-\fBBAND_\fINN\fR can also be used to fine tune actual band configurations
-for a specific contest.
 .
 .SS Morse Code Keyer Commands
 .
@@ -2050,6 +2024,10 @@ available used to activate the radio's PTT for sending voice messages instead
 of the \fBcwdaemon\fR PTT.
 .
 .TP
+\fBFOLLOW_MODE\fR[=<\fION\fR|\fIOFF\fR>]
+Control if RIG should change modulation when band is changed
+.
+.TP
 \fBCWBANDWIDTH\fR=\fIwidth\fR
 Sets the CW bandwidth of your rig when changing bands.
 .
@@ -2106,8 +2084,6 @@ string parsed for:
 .RB ( Ctrl-G )
 .br
 	\(lqO\(rq - show only new multipliers
-.br
-	\(lqX\(rq - show also out-of-band spots when in all-band mode
 .br
 .RI < number >
 lifetime for new spots in seconds (number >=

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -2050,6 +2050,10 @@ available used to activate the radio's PTT for sending voice messages instead
 of the \fBcwdaemon\fR PTT.
 .
 .TP
+\fBFOLLOW_MODE\fR[=<\fION\fR|\fIOFF\fR>]
+Control if RIG should change modulation when band is changed
+.
+.TP
 \fBCWBANDWIDTH\fR=\fIwidth\fR
 Sets the CW bandwidth of your rig when changing bands.
 .

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1656,6 +1656,11 @@ The station callsign used in messages; also used to determine the station's
 country, zone and continent.
 .
 .TP
+\fBOPERATING_MODE\fR=\fICQ\fR|\fIS&P\fR
+Set operating mode for start up. Use \fICQ\fR for "run" and \fIS&P\fR for "search and pounce".
+The default mode is \fICQ\fR.
+.
+.TP
 \fBTIME_OFFSET\fR=\fI0\fR
 Used to shift the @PACKAGE_NAME@ time with respect to the computer clock.
 .
@@ -1733,6 +1738,27 @@ See the relevant Xplanet documentation.
 .
 .IP
 Use azimuthal projection and center the map on your QTH (station location).
+.
+.TP
+\fBBAND_\fINN\fR=\fIbottom,cw_end,ssb_start,top\fR
+Define band edges. \fINN\fR is the band designator (wavelength), allowed values are:
+160, 80, 60, 40, 30, 20, 17, 15, 12, 10.
+.
+.IP
+All 4 comma separated parameters are mandatory and
+shall be specified in integer Hz units with an optional
+\fIk\fR suffix.
+.IP
+Example specification for Region\ 1 40\ m band:
+.IP
+    \fBBAND_40\fR = \fI7000k, 7040k, 7050k, 7200k\fR
+.
+.IP
+Internal default band definitions are based on a superset of all Regions.
+For example, 40\ m ends by default at 7300\ kHz.
+In addition to configuring the legal limits
+\fBBAND_\fINN\fR can also be used to fine tune actual band configurations
+for a specific contest.
 .
 .SS Morse Code Keyer Commands
 .
@@ -2024,10 +2050,6 @@ available used to activate the radio's PTT for sending voice messages instead
 of the \fBcwdaemon\fR PTT.
 .
 .TP
-\fBFOLLOW_MODE\fR[=<\fION\fR|\fIOFF\fR>]
-Control if RIG should change modulation when band is changed
-.
-.TP
 \fBCWBANDWIDTH\fR=\fIwidth\fR
 Sets the CW bandwidth of your rig when changing bands.
 .
@@ -2084,6 +2106,8 @@ string parsed for:
 .RB ( Ctrl-G )
 .br
 	\(lqO\(rq - show only new multipliers
+.br
+	\(lqX\(rq - show also out-of-band spots when in all-band mode
 .br
 .RI < number >
 lifetime for new spots in seconds (number >=


### PR DESCRIPTION
Tested with FTdx3000, os: Elementary OS 7.
Test case: Rig setup for bands: 40,20,15m to SSB, for 80m for CW. FOLLOW_MODE enabled in logcfg.dat, tlf started on 80m with CW mode. Switching band on tlf will cause to switch modulation on rig to CW.
In case when FOLLOW_MODE is disabled, then changing bands will not cause switching mode on rig to CW, just new band which is visible in tlf.