### PR TITLE
Apply astyle

### DIFF
--- a/.github/workflows/ci-build-ubuntu-20.yml
+++ b/.github/workflows/ci-build-ubuntu-20.yml
@@ -22,9 +22,13 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt-get install -y libhamlib-dev libxmlrpc-core-c3-dev libcmocka-dev python3-pexpect
+        sudo apt-get install -y libhamlib-dev libxmlrpc-core-c3-dev libcmocka-dev python3-pexpect astyle
     - name: Set up datadir
       run: mkdir datadir && ln -s $PWD/share datadir/tlf
+    - name: Check source formatting
+      run: |
+        F=$(astyle --dry-run --formatted --options=tools/astylerc src/*.[ch])
+        if [ ! -z "$F" ] ; then sed -e 's/^F/To be f/' <<< $F; exit 1; fi
     - name: Autoreconf and basic make
       run: |
         autoreconf -i && ./configure --datadir=$PWD/datadir && make -j2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,9 +22,13 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt-get install -y libhamlib-dev libxmlrpc-core-c3-dev libcmocka-dev python3-pexpect python3-dev
+        sudo apt-get install -y libhamlib-dev libxmlrpc-core-c3-dev libcmocka-dev python3-pexpect python3-dev astyle
     - name: Set up datadir
       run: mkdir datadir && ln -s $PWD/share datadir/tlf
+    - name: Check source formatting
+      run: |
+        F=$(astyle --dry-run --formatted --options=tools/astylerc src/*.[ch])
+        if [ ! -z "$F" ] ; then sed -e 's/^F/To be f/' <<< $F; exit 1; fi
     - name: Autoreconf and basic make
       run: |
         autoreconf -i && ./configure --datadir=$PWD/datadir && make -j2

--- a/src/addspot.c
+++ b/src/addspot.c
@@ -102,7 +102,7 @@ void add_local_spot(void) {
 static struct qso_t *find_last_qso() {
     int i = NR_QSOS;
     while (i > 0) {
-	struct qso_t *last_qso = g_ptr_array_index(qso_array, i-1);
+	struct qso_t *last_qso = g_ptr_array_index(qso_array, i - 1);
 	if (!last_qso->is_comment) {
 	    return last_qso;
 	}
@@ -154,7 +154,7 @@ static gchar *prepare_spot(void) {
     freq_t spot_freq;
     if (get_spot_data(&spot_call, &spot_freq)) {
 	spot_line = g_strdup_printf("DX %.1f %s ", spot_freq / 1000.,
-		spot_call);
+				    spot_call);
 	g_free(spot_call);
     } else {
 	beep();
@@ -206,7 +206,7 @@ static bool complete_spot(gchar **line) {
 	wmove(stdscr, LINES - 1, strlen(buffer) + 2);
     }
 
-    g_free (*line);
+    g_free(*line);
     *line = g_strdup(buffer);
 
     return c != ESCAPE;
@@ -225,5 +225,5 @@ void add_cluster_spot(void) {
 	    g_free(line);
 	}
     }
-    g_free (spot_line);
+    g_free(spot_line);
 }

--- a/src/audio.c
+++ b/src/audio.c
@@ -67,19 +67,19 @@ static void sr_start(void);
 void sr_stop();
 
 void sound_setup_default(void) {
-    if (vk_record_cmd) g_free (vk_record_cmd);
+    if (vk_record_cmd) g_free(vk_record_cmd);
     vk_record_cmd = g_strdup("rec -r 8000 $1 -q");
 
-    if (vk_play_cmd) g_free (vk_play_cmd);
+    if (vk_play_cmd) g_free(vk_play_cmd);
     vk_play_cmd = g_strdup("play_vk $1");
 
-    if (soundlog_record_cmd) g_free (soundlog_record_cmd);
+    if (soundlog_record_cmd) g_free(soundlog_record_cmd);
     soundlog_record_cmd = g_strdup("soundlog");
 
-    if (soundlog_play_cmd) g_free (soundlog_play_cmd);
+    if (soundlog_play_cmd) g_free(soundlog_play_cmd);
     soundlog_play_cmd = g_strdup("play -q $1 2> /dev/null");
 
-    if (soundlog_dir) g_free (soundlog_dir);
+    if (soundlog_dir) g_free(soundlog_dir);
     soundlog_dir = g_strdup("./soundlogs");
 }
 
@@ -91,7 +91,7 @@ void sound_setup_default(void) {
  */
 bool is_sr_running() {
     char *lockfile = g_strconcat(g_get_home_dir(), G_DIR_SEPARATOR_S,
-		".VRlock", NULL);
+				 ".VRlock", NULL);
     bool exists = (access(lockfile, F_OK) == 0);
     g_free(lockfile);
     return exists;
@@ -110,7 +110,7 @@ static void recordmenue(void) {
     mvaddstr(6, 20, "F1 ... F12, S, C: Record Messages");
 
     mvprintw(9, 20, "1; %s contest recorder",
-	    is_sr_running() ? "Stop" : "Start");
+	     is_sr_running() ? "Stop" : "Start");
 
     mvaddstr(10, 20, "2: List and Play contest file");
     mvaddstr(12, 20, "ESC: Exit sound recorder function");
@@ -273,10 +273,10 @@ static char *expand_directory(const char *dir) {
 }
 
 /* strip audio file suffix */
-static char* strip_suffix(char * filename) {
+static char *strip_suffix(char *filename) {
     GRegex *regex = g_regex_new("\\.au$", 0, 0, NULL);
-    char *stripped_name = g_regex_replace(regex, filename, -1 , 0,
-	    "", 0, NULL);
+    char *stripped_name = g_regex_replace(regex, filename, -1, 0,
+					  "", 0, NULL);
     g_regex_unref(regex);
     return stripped_name;
 }
@@ -312,7 +312,7 @@ static int sr_listfiles() {
 	g_free(printname);
 
 	i += 10;
-    	if (i > 60) {
+	if (i > 60) {
 	    i = 10;
 	    j++;
 	}
@@ -340,8 +340,8 @@ static void sr_start(void) {
     IGNORE(system("echo " " > ~/.VRlock"));
 
     char *command = g_strconcat("mkdir -p ", soundlog_dir, "; ",
-	    "cd ", soundlog_dir, "; ",
-	    soundlog_record_cmd, " >/dev/null 2>/dev/null &", NULL);
+				"cd ", soundlog_dir, "; ",
+				soundlog_record_cmd, " >/dev/null 2>/dev/null &", NULL);
 
     IGNORE(system(command));
     g_free(command);
@@ -360,15 +360,15 @@ void sr_stop() {
 static char *prepare_playback_command(char *filename) {
     char *file = g_strconcat(filename, ".au", NULL);
 
-    GRegex *regex = g_regex_new("\\$1", 0, 0 , NULL);
+    GRegex *regex = g_regex_new("\\$1", 0, 0, NULL);
     char *play_command = g_regex_replace(regex, soundlog_play_cmd, -1, 0,
-	    file, 0, NULL);
-	g_regex_unref(regex);
+					 file, 0, NULL);
+    g_regex_unref(regex);
     g_free(file);
 
     char *full_command = g_strconcat("cd ", soundlog_dir, "; ",
-		play_command, NULL);
-    g_free (play_command);
+				     play_command, NULL);
+    g_free(play_command);
 
     return full_command;
 }
@@ -384,14 +384,14 @@ static void vk_do_record(int message_nr) {
     move(17, 20);
     refreshp();
 
-    GRegex *regex = g_regex_new("\\$1", 0, 0 , NULL);
+    GRegex *regex = g_regex_new("\\$1", 0, 0, NULL);
     char *command = g_regex_replace(regex, vk_record_cmd, -1, 0,
-	    ph_message[message_nr], 0, NULL);
+				    ph_message[message_nr], 0, NULL);
     g_regex_unref(regex);
 
     /* let the command run in background so we can stop recording by
      * <esc> key later */
-    char *reccommand = g_strconcat( command, " &", NULL);
+    char *reccommand = g_strconcat(command, " &", NULL);
 
     IGNORE(system(reccommand));
     g_free(command);
@@ -413,11 +413,11 @@ void *play_thread(void *ptr) {
 
     pthread_detach(pthread_self());
 
-    vk_running=true;
+    vk_running = true;
 
     GRegex *regex = g_regex_new("\\$1", 0, 0, NULL);
     char *playcommand = g_regex_replace(regex, vk_play_cmd, -1, 0,
-	    audiofile, 0, NULL);
+					audiofile, 0, NULL);
     g_regex_unref(regex);
     g_free(ptr);
 
@@ -441,7 +441,7 @@ void *play_thread(void *ptr) {
 	netkeyer(K_PTT, "0");	// ptt off
     }
 
-    vk_running= false;
+    vk_running = false;
 
     return NULL;
 }
@@ -467,8 +467,8 @@ void vk_play_file(char *audiofile) {
 
     /* play sound in separate thread so it can be killed from the main one */
     if (pthread_create(&vk_thread, NULL, play_thread, (void *)file) != 0) {
-	    g_free(file);
-	    TLF_LOG_INFO("could not start sound thread!");
+	g_free(file);
+	TLF_LOG_INFO("could not start sound thread!");
     }
 }
 
@@ -480,7 +480,7 @@ void vk_stop() {
 
 /* check if playing VK message is finished */
 bool is_vk_finished() {
-	return (vk_running == false);
+    return (vk_running == false);
 }
 
 

--- a/src/audio.h
+++ b/src/audio.h
@@ -27,11 +27,11 @@
 
 #include <stdbool.h>
 
-extern char* vk_record_cmd;
-extern char* vk_play_cmd;
-extern char* soundlog_record_cmd;
-extern char* soundlog_play_cmd;
-extern char* soundlog_dir;
+extern char *vk_record_cmd;
+extern char *vk_play_cmd;
+extern char *soundlog_record_cmd;
+extern char *soundlog_play_cmd;
+extern char *soundlog_dir;
 
 void sound_setup_default(void);
 void record(void);

--- a/src/checklogfile.c
+++ b/src/checklogfile.c
@@ -287,8 +287,8 @@ void checklogfile(void) {
 			    fputs(inputbuffer, outfile);
 			}
 		    }
-                    if (inputbuffer != NULL)
-                        free(inputbuffer);
+		    if (inputbuffer != NULL)
+			free(inputbuffer);
 		    fclose(infile);
 		    fclose(outfile);
 		}

--- a/src/cw_utils.c
+++ b/src/cw_utils.c
@@ -23,9 +23,12 @@
 
 #include <glib.h>
 
+// *INDENT-OFF*
+
 #define CW_SPEEDS	"06121416182022242628303234363840424446485060"
 			/*< speed string with 2 chars each (in WPM) */
 
+// *INDENT-ON*
 
 char speedstr[50] = CW_SPEEDS;
 int speed = 10;

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -833,8 +833,8 @@ void checkexchange(struct qso_t *qso, bool interactive) {
     qso->mult1_value[0] = 0;
 
     if (plugin_has_check_exchange()) {
-        plugin_check_exchange(qso);
-        return;
+	plugin_check_exchange(qso);
+	return;
     }
 
     // ----------------------------cqww------------------------------

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -212,7 +212,8 @@ void gettxinfo(void) {
 	    retval = hamlib_keyer_get_speed(&rig_cwspeed);
 
 	    if (retval == RIG_OK) {
-		if (GetCWSpeed() != rig_cwspeed) { // FIXME: doesn't work if rig speed is between the values from CW_SPEEDS
+		if (GetCWSpeed() !=
+			rig_cwspeed) { // FIXME: doesn't work if rig speed is between the values from CW_SPEEDS
 		    SetCWSpeed(rig_cwspeed);
 
 		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -10,6 +10,8 @@
 
 extern const char *argp_program_version;
 
+// *INDENT-OFF*
+
 extern mystation_t my;			// all about my station
 extern char whichcontest[];
 extern contest_config_t *contest;	// contest configuration
@@ -39,6 +41,8 @@ extern int countries[MAX_DATALINES];	// for every country, a bitfield
 					// been worked
 
 extern int bandinx;			// band we're currently working on
+
+// *INDENT-ON*
 
 extern struct ie_list *main_ie_list;
 

--- a/src/hamlib_keyer.h
+++ b/src/hamlib_keyer.h
@@ -18,6 +18,6 @@
  */
 
 int hamlib_keyer_set_speed(int cwspeed);
-int hamlib_keyer_get_speed( int *cwspeed);
+int hamlib_keyer_get_speed(int *cwspeed);
 int hamlib_keyer_send(char *cwmessage);
 int hamlib_keyer_stop();

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -83,7 +83,8 @@ void log_to_disk(int from_lan) {
 
 	restart_band_timer();
 
-	struct qso_t *qso = collect_qso_data(); //TODO: move this after store_qso() call below
+	struct qso_t *qso =
+	    collect_qso_data(); //TODO: move this after store_qso() call below
 	addcall(qso);		/* add call to dupe list */
 
 	score_qso(qso);
@@ -91,7 +92,7 @@ void log_to_disk(int from_lan) {
 	qso->logline = logline; /* remember formatted line in qso entry */
 
 	store_qso(logfile, logline);
-        //TODO: create a copy of current_qso
+	//TODO: create a copy of current_qso
 	g_ptr_array_add(qso_array, qso);
 
 	// send qso to other nodes......

--- a/src/log_utils.h
+++ b/src/log_utils.h
@@ -29,7 +29,7 @@ bool log_is_comment(const char *buffer);
 int log_get_band(const char *logline);
 int log_get_mode(const char *logline);
 int log_get_points(const char *logline);
-struct qso_t *parse_qso(char * buffer);
+struct qso_t *parse_qso(char *buffer);
 void free_qso(struct qso_t *ptr);
 void free_qso_array();
 void init_qso_array();

--- a/src/main.c
+++ b/src/main.c
@@ -231,7 +231,7 @@ char *digi_message[sizeof(message) / sizeof(message[0])];
 char ph_message[14][80] = /**< Array of file names for voice keyer messages
 			   * See description of message[]
 			   */
-    { "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
+{ "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
 
 // QTC receive window Fx messages
 char qtc_recv_msgs[12][80] = {
@@ -438,7 +438,7 @@ static const char program_description[] =
 #ifdef HAVE_PYTHON
     " python-plugin"
 #endif
-;
+    ;
 static const struct argp_option options[] = {
     {
 	"config",   'f', "FILE", 0,
@@ -983,7 +983,7 @@ static void tlf_cleanup() {
     if (is_sr_running()) {
 	int c;
 	puts("ATTENTION: Sound recorder is still running!");
-	puts("           Do you want to stop it (y/n)?" );
+	puts("           Do you want to stop it (y/n)?");
 	c = getchar();
 	if (toupper(c) == 'Y') {
 	    sr_stop();

--- a/src/main.c
+++ b/src/main.c
@@ -233,21 +233,29 @@ char ph_message[14][80] = /**< Array of file names for voice keyer messages
 			   */
     { "", "", "", "", "", "", "", "", "", "", "", "", "", "" };
 
+// QTC receive window Fx messages
 char qtc_recv_msgs[12][80] = {
     "QTC?", "QRV", "R", "", "TIME?", "CALL?",
-    "NR?", "AGN", "", "QSL ALL", "", ""};	// QTC receive windows Fx messages
+    "NR?", "AGN", "", "QSL ALL", "", ""
+};
 
+// QTC send window Fx messages
 char qtc_send_msgs[12][80] = {
     "QRV?", "QTC sr/nr", "", "", "TIME", "CALL",
-    "NR", "", "", "", "", ""};		    	// QTC send window Fx messages
+    "NR", "", "", "", "", ""
+};
 
+// voice keyer file names for receiving QTCs
 char qtc_phrecv_message[14][80] = {
     "", "", "", "", "", "",
-    "", "", "", "", "", "" };			// voice keyer file names when receives QTCs
+    "", "", "", "", "", ""
+};
 
+// voice keyer file names for sending QTCs
 char qtc_phsend_message[14][80] = {
     "", "", "", "", "", "",
-    "", "", "", "", "", "" };			// voice keyer file names when send QTCs
+    "", "", "", "", "", ""
+};
 
 bool qtcrec_record = false;
 char qtcrec_record_command[2][50] = {"rec -q 8000", "-q &"};

--- a/src/makelogline.c
+++ b/src/makelogline.c
@@ -146,7 +146,7 @@ void prepare_fixed_part(char *logline, struct qso_t *qso) {
 //	    strcat(logline, lastqsonr);
 //	    lastqsonr[0] = '\0';
 //	} else
-	    strcat(logline, buf);
+	strcat(logline, buf);
     }
 
     if (lan_active && cqwwm2) {
@@ -235,7 +235,7 @@ void prepare_specific_part(char *logline, struct qso_t *qso) {
     FILL_TO(77);
 
     if (!iscontest) {
-        return;         // not a contest, we are done
+	return;         // not a contest, we are done
     }
 
     logline[68] = '\0'; /* cut back to make room for mults */

--- a/src/muf.c
+++ b/src/muf.c
@@ -198,8 +198,7 @@ int t;
 double xn, xs, ls, h, ff, x, yn_, k, lm, u, a;
 
 
-static double power(double man, double ex)
-{
+static double power(double man, double ex) {
     return exp(ex * log(man));
 }
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -713,12 +713,12 @@ static int cfg_countrylist(const cfg_arg_t arg) {
 	fclose(fp);
 
     } else {	/* not a file */
-        char *colon = strchr(buffer, ':');
-        if (colon != NULL) {
-            country_list_raw = colon + 1;   // skip optional contest name
-        } else {
-            country_list_raw = buffer;
-        }
+	char *colon = strchr(buffer, ':');
+	if (colon != NULL) {
+	    country_list_raw = colon + 1;   // skip optional contest name
+	} else {
+	    country_list_raw = buffer;
+	}
     }
 
     if (country_list_raw == NULL) {
@@ -758,8 +758,8 @@ static int cfg_countrylist(const cfg_arg_t arg) {
     getpx(my.call);
     mult_side = exist_in_country_list();
     setcontest(whichcontest);
-    if(buffer != NULL)
-        free(buffer);
+    if (buffer != NULL)
+	free(buffer);
 
     return PARSE_OK;
 }
@@ -851,7 +851,7 @@ static int cfg_continentlist(const cfg_arg_t arg) {
 
     setcontest(whichcontest);
     if (buffer != NULL)
-        free(buffer);
+	free(buffer);
     return PARSE_OK;
 }
 

--- a/src/qtcvars.h
+++ b/src/qtcvars.h
@@ -79,6 +79,8 @@ typedef struct {
     int attr;		// meta attr: 0 => not nopied, 1 => copied
 } t_qtc_ry_line;
 
+// *INDENT-OFF*
+
 extern int next_qtc_qso;		// the next non-sent QSO, which can
 					// be send next as QTC
 extern int qsoflags_for_qtc[MAX_QSOS];	// array of flag to log lines of QSOs
@@ -114,4 +116,7 @@ extern char qtc_cap_calls[40];
 extern bool qtc_auto_filltime;		// set QTC auto filltime; when DX sent first
 					// QTC line, the first two digits will be copied to others
 extern bool qtc_recv_lazy;		// ignore check of received QTC lines
+
+// *INDENT-ON*
+
 #endif /* end of include guard: QTCVARS_H */

--- a/src/readcalls.c
+++ b/src/readcalls.c
@@ -197,7 +197,7 @@ int readcalls(const char *logfile, bool interactive) {
 
     fclose(fp);
     if (inputbuffer != NULL)
-        free(inputbuffer);
+	free(inputbuffer);
 
     if (log_changed) {
 	bool ok = false;

--- a/src/scroll_log.c
+++ b/src/scroll_log.c
@@ -107,7 +107,7 @@ void scroll_log(void) {
 	if (NR_QSOS < i) {
 	    g_strlcpy(logline_edit[5 - i], spaces(80), LINELEN + 1);
 	} else {
-	    g_strlcpy(logline_edit[5- i], QSOS(NR_QSOS - i), LINELEN + 1);
+	    g_strlcpy(logline_edit[5 - i], QSOS(NR_QSOS - i), LINELEN + 1);
 	}
     }
 

--- a/src/searchcallarray.c
+++ b/src/searchcallarray.c
@@ -134,7 +134,7 @@ bool is_dupe(char *call, int bandindex, int mode) {
 void update_worked(int station, struct qso_t *qso) {
     if (strlen(qso->comment) > 0) {
 	g_strlcpy(worked[station].exchange, qso->comment,
-		sizeof(worked[0].exchange));
+		  sizeof(worked[0].exchange));
 	g_strchomp(worked[station].exchange);
     }
     worked[station].qsotime[qso->mode][qso->bandindex] = qso->timestamp;

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -242,11 +242,11 @@ struct qso_t *get_previous_qso() {
     };
 
     // TODO:lan for networked mode it will be incorrect. Previous qso may not be the last one in the log.
-    for(int i=NR_QSOS-1; i >= 0; i--) {
-        struct qso_t *out_qso = g_ptr_array_index(qso_array, i);
-        if(!out_qso->is_comment) {
-            return out_qso;
-        }
+    for (int i = NR_QSOS - 1; i >= 0; i--) {
+	struct qso_t *out_qso = g_ptr_array_index(qso_array, i);
+	if (!out_qso->is_comment) {
+	    return out_qso;
+	}
     }
     return &empty_qso;
 }

--- a/src/sendqrg.h
+++ b/src/sendqrg.h
@@ -25,13 +25,13 @@
 #include <stdbool.h>
 
 #ifdef HAMLIB_FILPATHLEN
-  #define TLFFILPATHLEN HAMLIB_FILPATHLEN
+#define TLFFILPATHLEN HAMLIB_FILPATHLEN
 #else
-  #ifdef FILPATHLEN
-  #define TLFFILPATHLEN FILPATHLEN
-  #else
-  #error "(HAMLIB_)FILPATHLEN macro not found"
-  #endif
+#ifdef FILPATHLEN
+#define TLFFILPATHLEN FILPATHLEN
+#else
+#error "(HAMLIB_)FILPATHLEN macro not found"
+#endif
 #endif
 
 bool rig_has_send_morse();

--- a/src/startmsg.h
+++ b/src/startmsg.h
@@ -26,7 +26,8 @@ void clearmsg(void);
 void clearmsg_wait(void);
 void showmsg(char *message);	// output text
 void shownr(char *message, int nr); // output text + number
-void showstring(const char *message1, const char *message2);  // output 2 strings
+void showstring(const char *message1,
+		const char *message2);  // output 2 strings
 
 
 #endif /* end of include guard: STARTMSG_H */

--- a/src/writecabrillo.c
+++ b/src/writecabrillo.c
@@ -219,7 +219,7 @@ struct linedata_t *get_next_qtc_record(FILE *fp, int qtcdirection) {
     }
 
     if (buffer != NULL)
-        free(buffer);
+	free(buffer);
     return ptr;
 }
 


### PR DESCRIPTION
Follow-up from #398 - consistently applying astyle to all source files. (src/*.[ch])

Some specially formatted comments are protected using INDENT-OFF/ON.

Trailing comments in main.c moved before the definition they to.