### PR TITLE
Provide a fallback for M_PI and M_PI_2

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,7 +58,7 @@ noinst_HEADERS = \
 	keyer.h keystroke_names.h \
 	lancode.h last10.h listmessages.h log_utils.h \
 	log_to_disk.h logit.h logview.h \
-	makelogline.h messagechange.h muf.h \
+	makelogline.h math_utils.h messagechange.h muf.h \
 	nicebox.h note.h netkeyer.h\
 	paccdx.h parse_logcfg.h printcall.h \
 	paccdx.h parse_logcfg.h plugin.h printcall.h \

--- a/src/math_utils.h
+++ b/src/math_utils.h
@@ -26,7 +26,7 @@
 #include <math.h>
 #endif
 
-/* provide a fallback for M_PI as C standard does not guarantee the definition
+/* provide a fallback for M_PI_2 as C standard does not guarantee the definition
 of these constant */
 #ifndef M_PI_2
 # define M_PI_2         1.57079632679489661923  /* pi/2 */

--- a/src/math_utils.h
+++ b/src/math_utils.h
@@ -1,0 +1,37 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2023	Thomas Beierlein <dl1jbe@darc.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+
+#ifndef MATH_UTILS_H
+#define MATH_UTILS_H
+
+/* Make sure math.h is included before the following definitions */
+#ifndef MATH_H
+#include <math.h>
+#endif
+
+/* provide a fallback for M_PI as C standard does not guarantee the definition
+of these constant */
+#ifndef M_PI_2
+# define M_PI_2         1.57079632679489661923  /* pi/2 */
+#endif
+
+#define RADIAN  (90.0 / M_PI_2)
+
+#endif

--- a/src/muf.c
+++ b/src/muf.c
@@ -32,6 +32,13 @@
 #include "tlf_panel.h"
 #include "ui_utils.h"
 
+#ifndef M_PI_2
+	# define M_PI_2         1.57079632679489661923  /* pi/2 */
+#endif
+
+#ifndef M_PI
+	# define M_PI           3.14159265358979323846  /* pi */
+#endif
 
 // message splitters:
 // line[0] - original line, content can be modified in-place

--- a/src/muf.c
+++ b/src/muf.c
@@ -33,11 +33,11 @@
 #include "ui_utils.h"
 
 #ifndef M_PI_2
-	# define M_PI_2         1.57079632679489661923  /* pi/2 */
+# define M_PI_2         1.57079632679489661923  /* pi/2 */
 #endif
 
 #ifndef M_PI
-	# define M_PI           3.14159265358979323846  /* pi */
+# define M_PI           3.14159265358979323846  /* pi */
 #endif
 
 // message splitters:

--- a/src/muf.c
+++ b/src/muf.c
@@ -27,18 +27,11 @@
 #include "get_time.h"
 #include "globalvars.h"
 #include "getwwv.h"
+#include "math_utils.h"
 #include "sunup.h"
 #include "qrb.h"
 #include "tlf_panel.h"
 #include "ui_utils.h"
-
-#ifndef M_PI_2
-# define M_PI_2         1.57079632679489661923  /* pi/2 */
-#endif
-
-#ifndef M_PI
-# define M_PI           3.14159265358979323846  /* pi */
-#endif
 
 // message splitters:
 // line[0] - original line, content can be modified in-place
@@ -190,7 +183,6 @@ September 26, 1986.
 *********************************************************************/
 
 #define ARC_IN_KM 111.2         // same as in Hamlib's locator.c
-#define RADIAN  (180.0 / M_PI)
 
 int month;
 

--- a/src/sunup.c
+++ b/src/sunup.c
@@ -22,13 +22,7 @@
 #include <time.h>
 
 #include "get_time.h"
-
-#ifndef M_PI
-# define M_PI           3.14159265358979323846  /* pi */
-#endif
-
-#define RADIAN  (180.0 / M_PI)
-
+#include "math_utils.h"
 
 /** Compute sun up and down at given latitude
  *

--- a/src/sunup.c
+++ b/src/sunup.c
@@ -24,7 +24,7 @@
 #include "get_time.h"
 
 #ifndef M_PI
-	# define M_PI           3.14159265358979323846  /* pi */
+# define M_PI           3.14159265358979323846  /* pi */
 #endif
 
 #define RADIAN  (180.0 / M_PI)

--- a/src/sunup.c
+++ b/src/sunup.c
@@ -23,6 +23,10 @@
 
 #include "get_time.h"
 
+#ifndef M_PI
+	# define M_PI           3.14159265358979323846  /* pi */
+#endif
+
 #define RADIAN  (180.0 / M_PI)
 
 


### PR DESCRIPTION
As C standards does not define M_PI or M_PI_2 provide a fallback. Some LIBC implementations (e.g. MUSL) miss these definitions.
