### PR TITLE
Fix 2-character prefix search

### DIFF
--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -149,6 +149,7 @@ int find_best_match(const char *call) {
 	w = two_char_prefix_index[key];
 	if (w >= 0) {
 	    bool ok = true;
+	    // for an exact entry require the whole call to match
 	    if (prefix_by_index(w)->exact) {
 		ok = (strcmp(prefix_by_index(w)->pfx, call) == 0);
 	    }

--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -146,8 +146,15 @@ int find_best_match(const char *call) {
     /* first check if it has a unique 2-char prefix */
     if (strlen(call) >= 2) {
 	int key = prefix_hash_key(call);
-	if (two_char_prefix_index[key] >= 0) {
-	    return two_char_prefix_index[key];
+	w = two_char_prefix_index[key];
+	if (w >= 0) {
+	    bool ok = true;
+	    if (prefix_by_index(w)->exact) {
+		ok = (strcmp(prefix_by_index(w)->pfx, call) == 0);
+	    }
+	    if (ok) {
+		return w;
+	    }
 	}
     }
 

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -144,6 +144,7 @@ void test_best_match(void **state) {
     assert_string_equal(best_prefix("EA8XYZ"), "EA8");
     assert_string_equal(best_prefix("W3A"), "W");
     assert_string_equal(best_prefix("KL7ND"), "KL");
+    assert_string_equal(best_prefix("G8AAA"), "G");
 }
 
 void test_location_known(void **state) {


### PR DESCRIPTION
In September 2018 cty.dat (https://www.country-files.com/cty-2810-04-september-2018/) added G8ERJ to US
```
G8ERJ, N8CL and N8RA are all United States, K in CQ zone 5, ITU zone 8
```

This causes all G8 calls considered as US calls. There was a missing logic to handle exact matches correctly.

First added a test for it.