### PR TITLE
Fix frequency input logic

### DIFF
--- a/src/callinput.c
+++ b/src/callinput.c
@@ -1059,10 +1059,14 @@ bool valid_call_char(int ch) {
  * Check if string contains only digits
  * \param str    the string to check
  * \return true  if only digits inside
- *         false at least one none digit
+ *         false contains at least one non-digit or it's an empty string
  */
 bool plain_number(char *str) {
     int i;
+
+    if (strlen(str) == 0) {
+        return false;
+    }
 
     for (i = 0; i < strlen(str); i++) {
 	if (!isdigit(str[i])) {

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -1065,7 +1065,7 @@ bool plain_number(char *str) {
     int i;
 
     if (strlen(str) == 0) {
-        return false;
+	return false;
     }
 
     for (i = 0; i < strlen(str); i++) {

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -1250,11 +1250,10 @@ void handle_bandswitch(int direction) {
     mvaddstr(12, 0, band[bandinx]);
 
     if (trx_control) {
-	freq = bandfrequency[bandinx]; // TODO: is this needed?
 	set_outfreq(bandfrequency[bandinx]);
     }
 
-    send_bandswitch(bandinx);
+    send_bandswitch(bandfrequency[bandinx]);
 }
 
 /** handle TRX memory operation and update screen

--- a/src/callinput.h
+++ b/src/callinput.h
@@ -28,5 +28,6 @@
 int callinput(void);
 void send_bandswitch(freq_t freq);
 bool valid_call_char(int ch);
+bool plain_number(char *str);
 
 #endif /* CALLINPUT_H */

--- a/src/sendqrg.h
+++ b/src/sendqrg.h
@@ -40,6 +40,6 @@ bool rig_has_stop_morse();
 int init_tlf_rig(void);
 void close_tlf_rig(RIG *my_rig);
 
-int sendqrg(void);
+bool sendqrg(void);
 
 #endif /* end of include guard: SENDQRG_H */


### PR DESCRIPTION
Changing frequency by entering it in the call input field is a handy feature, but it has some rough edges.

1. if an out-of-band frequency (all digits) is entered then it is treated erroneously as a callsign
![image](https://github.com/Tlf/tlf/assets/15141948/122b53ea-657d-46c0-bd2a-7530b4326650)

2. similarly, when there is no rig control then all numeric values are taken for a callsign
![image](https://github.com/Tlf/tlf/assets/15141948/6aa648e6-9490-4cee-87dd-23f7133dbf7f)


Reworked `sendqrg()` to use `plain_number()` to check if input is a number. Originally `atof()` was used to parse it, presumably to support fractional kHz values. As dot is used to configure bandmap this part of the feature was broken anyway, so I replaced it with a simple `atoi()`.
In `logit.c` moved the clearing in case of freq up to the check itself and thus reduced the indenting of the code actually doing relevant stuff.