### PR TITLE
Fixed LOGFILE casing in pacc_pa rules

### DIFF
--- a/rules/pacc_pa
+++ b/rules/pacc_pa
@@ -1,7 +1,7 @@
 # PACC contest for stations inside PA0 #
 ########################################
 CONTEST=pacc_pa
-logfile=pacc.log
+LOGFILE=pacc.log
 CONTEST_MODE
 CABRILLO=UNIVERSAL
 #


### PR DESCRIPTION
The LOGFILE keyword needs to be in uppercase, or else the program will not start correctly.