### PR TITLE
Fix pkill man page

### DIFF
--- a/scripts/play_vk
+++ b/scripts/play_vk
@@ -27,7 +27,7 @@ trap 'kill -s KILL $PID' TERM INT
 # mute mic
 #amixer -c 0 set Mic mute -q
 
-# play file on the default sound device in background, so signals can be catch
+# play file on the default sound device in background, so signals can be catched
 # by the 'trap' instruction above
 
 # SoX play utility syntax

--- a/scripts/play_vk
+++ b/scripts/play_vk
@@ -27,7 +27,7 @@ trap 'kill -s KILL $PID' TERM INT
 # mute mic
 #amixer -c 0 set Mic mute -q
 
-# play file on the default sound device in background, so signals can be catched
+# play file on the default sound device in background, so signals can be caught
 # by the 'trap' instruction above
 
 # SoX play utility syntax

--- a/scripts/soundlog
+++ b/scripts/soundlog
@@ -8,7 +8,7 @@ trap 'kill -s INT $PID' TERM USR1
 while [ -f $HOME/.VRlock ]
 do
 		# store recorded files in actual directory
-		filename=`eval date +%d%H%M`".au"
+		filename=$(eval date +%d%H%M)".au"
 		if test -f $filename
 		then
 			sleep 10

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -606,7 +606,7 @@ shown):
 .
 .P
 .EX
-/usr/bin/pkill \-f rec
+/usr/bin/pkill \-x rec
 .EE
 .
 .P


### PR DESCRIPTION
Cleans up the ambiguous -f parameter from the pkill example in man page. Additionally replace backticks by $() as suggested by N0NB. 

Replaces PR #426.