### PR TITLE
test/test_addpfx.c: Fix declaration of pfxmultab

### DIFF
--- a/test/test_addpfx.c
+++ b/test/test_addpfx.c
@@ -6,7 +6,7 @@
 // OBJECT ../src/addpfx.o
 // OBJECT ../src/bands.o
 
-extern int pfxmultab;
+extern bool pfxmultab;
 
 int find_worked_pfx(char *prefix);
 


### PR DESCRIPTION
This was causing test failures on Debian's s390x architecture.

Since the last release was so long ago, I uploaded a git snapshot to Debian. On big-endian s390x, one test was actually failing. (On other architectures this is a just a compiler warning.)