### PR TITLE
Improve keyer: unify key handling and add graceful closing of keyer window

### DIFF
--- a/src/callinput.c
+++ b/src/callinput.c
@@ -495,17 +495,6 @@ int callinput(void) {
 		break;
 	    }
 
-	    // Alt-0 to Alt-9 (M-0...M-9), send CW/Digimode messages 15-24.
-	    case 176 ... 185: {
-		if (*current_qso.call == '\0') {
-		    send_standard_message_prev_qso(x - 162); // alt-0 to alt-9
-		} else {
-		    send_standard_message(x - 162); /* alt-0 to alt-9 */
-		}
-
-		break;
-	    }
-
 	    // F12, activate autocq timing and message.
 	    case KEY_F(12): {
 		x = auto_cq();

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -52,6 +52,7 @@
 #include "gettxinfo.h"
 #include "grabspot.h"
 #include "ignore_unused.h"
+#include "keyer.h"
 #include "keystroke_names.h"
 #include "lancode.h"
 #include "muf.h"
@@ -88,37 +89,6 @@ bool plain_number(char *str);
 void handle_bandswitch(int direction);
 void handle_memory_operation(memory_op_t op);
 
-
-void tune() {
-    int count;
-    int count2;
-    gchar *buff;
-
-    count2 = tune_seconds;
-    while (count2 > 0) {
-	if (count2 >= 10) {
-	    count = 10;
-	} else {
-	    count = count2;
-	}
-	count2 -= count;
-	buff = g_strdup_printf("%d", count);
-	netkeyer(K_TUNE, buff);	// cw on
-	g_free(buff);
-
-	count = count * 4;    // sleeping 1/4 second units between keypress-checks
-	while (count > 0) {
-	    usleep(250000);
-	    if (key_poll() != -1) {	// any key pressed ?
-		count2 = 0;    // destroy outer loop as well
-		break;
-	    }
-	    count--;
-	}
-    }
-
-    netkeyer(K_ABORT, "");	// cw abort
-}
 
 
 /** callsign input loop

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -113,21 +113,22 @@ void add_to_keyer_terminal(char *buffer) {
 
 void show_header_line() {
     char *mode = "";
-    switch (cqmode) {
-	case CQ:
-	    mode = (simulator ? "Sim" : "Log");
-	    break;
-	case S_P:
-	    mode = "S&P";
-	    break;
-	case AUTO_CQ:
-	    mode = "AUTO_CQ";
-	    break;
-	case KEYBOARD:
-	    mode = "Keyboard";
-	    break;
-	default:
-	    ;   // should not happen
+    if (keyboard_mode) {
+	mode = "Keyboard";
+    } else {
+	switch (cqmode) {
+	    case CQ:
+		mode = (simulator ? "Sim" : "Log");
+		break;
+	    case S_P:
+		mode = "S&P";
+		break;
+	    case AUTO_CQ:
+		mode = "AUTO_CQ";
+		break;
+	    default:
+		;   // should not happen
+	}
     }
 
     attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -395,7 +395,7 @@ int fldigi_send_text(char *line) {
 	}
     }
 
-    if (cqmode != KEYBOARD) {   // normal mode, override flags
+    if (!keyboard_mode) {   // normal mode, override flags
 	start_tx = true;
 	switch_to_rx = true;
 	rc = cancel_tx();

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -164,6 +164,8 @@ int getexchange(void) {
 	    x = key_poll();
 	}
 
+        x = handle_common_key(x);
+
 	switch (x) {
 
 	    case CTRL_Q: {	// Ctl-q (^Q)--Open QTC panel for receiving or sending QTCs
@@ -293,32 +295,6 @@ int getexchange(void) {
 		break;
 	    }
 
-	    case KEY_F(1): {
-		if (trxmode == CWMODE || trxmode == DIGIMODE) {
-		    sendmessage(my.call);		/* F1 */
-		} else
-		    vk_play_file(ph_message[5]);	// call
-
-		break;
-	    }
-
-	    case KEY_F(2) ... KEY_F(11): {
-		/* F2...F11 - F1 = 1...10 */
-		if (*current_qso.call == '\0') {
-		    send_standard_message_prev_qso(x - KEY_F(1));
-		} else {
-		    send_standard_message(x - KEY_F(1));
-		}
-
-		break;
-	    }
-
-	    case 176 ... 185: {	/* Alt-0 to Alt-9 */
-		send_standard_message(x - 162);	/* Messages 15-24 */
-
-		break;
-	    }
-
 	    /* <Home>--edit exchange field, position cursor to left end of field.
 	     * Fall through to KEY_LEFT stanza if ungetch() is successful.
 	     */
@@ -342,39 +318,6 @@ int getexchange(void) {
 		break;
 	    }
 
-	    case KEY_PPAGE: {	/* Page-Up--change MY RST */
-		if (change_rst) {
-		    rst_recv_up();
-
-		    if (!no_rst)
-			mvaddstr(12, 49, recvd_rst);
-
-		} else {	/* speed up */
-		    speedup();
-
-		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-		    mvprintw(0, 14, "%2u", GetCWSpeed());
-		}
-		break;
-
-	    }
-	    case KEY_NPAGE: {	/* Page-Down--change MY RST */
-		if (change_rst) {
-
-		    rst_recv_down();
-
-		    if (!no_rst)
-			mvaddstr(12, 49, recvd_rst);
-
-		} else {	/* speed down */
-		    speeddown();
-
-		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
-		    mvprintw(0, 14, "%2u", GetCWSpeed());
-		}
-		break;
-
-	    }
 	    case ',':		// Keyboard Morse
 	    case CTRL_K: {	// Ctrl-K
 		move(5, 0);

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -164,7 +164,7 @@ int getexchange(void) {
 	    x = key_poll();
 	}
 
-        x = handle_common_key(x);
+	x = handle_common_key(x);
 
 	switch (x) {
 

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -164,17 +164,17 @@ int handle_common_key(int key) {
 	    break;
 	}
 
-        // Alt-0 to Alt-9 (M-0...M-9), send CW/Digimode messages 15-24.
-        case 128+'0' ... 128+'9': {
-            int index = key - (128+'0') + CQ_TU_MSG + 1;
-            if (*current_qso.call == '\0') {
-                send_standard_message_prev_qso(index);
-            } else {
-                send_standard_message(index);
-            }
+	// Alt-0 to Alt-9 (M-0...M-9), send CW/Digimode messages 15-24.
+	case 128+'0' ... 128+'9': {
+	    int index = key - (128 + '0') + CQ_TU_MSG + 1;
+	    if (*current_qso.call == '\0') {
+		send_standard_message_prev_qso(index);
+	    } else {
+		send_standard_message(index);
+	    }
 
-            break;
-        }
+	    break;
+	}
 
 	// <Page-Down>, change RST if call field not empty, else decrease CW speed.
 	case KEY_NPAGE: {

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <unistd.h>
 
 #include "clear_display.h"
 #include "globalvars.h"
@@ -41,6 +42,11 @@
 #include "tlf_panel.h"
 #include "ui_utils.h"
 #include "write_keyer.h"
+#include "audio.h"
+#include "change_rst.h"
+#include "cw_utils.h"
+#include "sendspcall.h"
+#include "cqww_simulator.h"
 
 /* size and position of keyer window */
 #define KEYER_LINE_WIDTH 60
@@ -52,16 +58,162 @@
 
 void mfj1278_control(int x);
 
+// handle common keys
+// F1..F11, Alt-0..9, _ (underscore), PgUp, PgDn, Alt-W, Alt-T
+// returns 0 if key was handled
+int handle_common_key(int key) {
+    bool handled = true;
+    switch (key) {
+	// F1, send CQ or S&P call message. (???)
+	case KEY_F(1): {
+	    if (trxmode == CWMODE || trxmode == DIGIMODE) {
+		//FIXME when called from getexchange then just send my.call
+		if (cqmode == S_P) {
+		    sendspcall();
+		} else {
+		    send_standard_message(0);	/* CQ */
+		}
+
+		set_simulator_state(CALL);
+
+	    } else {
+		if (cqmode == S_P)
+		    vk_play_file(ph_message[5]);	/* S&P */
+		else
+		    vk_play_file(ph_message[0]);
+	    }
+	    break;
+	}
+
+	// F2-F11, send messages 2 through 11.
+	case KEY_F(2) ... KEY_F(11): {
+	    // F2...F11 - F1 = 1...10
+	    if (*current_qso.call == '\0') {
+		send_standard_message_prev_qso(key - KEY_F(1));
+	    } else {
+		send_standard_message(key - KEY_F(1));
+	    }
+
+	    break;
+	}
+
+	// Underscore, confirm last exchange.
+	case '_': {
+	    if (S_P == cqmode) {
+		send_standard_message_prev_qso(SP_TU_MSG);
+	    } else {
+		send_standard_message_prev_qso(2);
+	    }
+
+	    break;
+	}
+
+	// <Page-Up>, change RST if call field not empty, else increase CW speed.
+	case KEY_PPAGE: {
+	    if (change_rst && (strlen(current_qso.call) != 0)) {	// change RST
+
+		rst_sent_up();
+
+		if (!no_rst)
+		    mvaddstr(12, 44, sent_rst);
+		mvaddstr(12, 29, current_qso.call);
+
+	    } else {	// change cw speed
+		speedup();
+
+		attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+		mvprintw(0, 14, "%2u", GetCWSpeed());
+	    }
+
+	    break;
+	}
+
+	// <Page-Down>, change RST if call field not empty, else decrease CW speed.
+	case KEY_NPAGE: {
+	    if (change_rst && (strlen(current_qso.call) != 0)) {
+
+		rst_sent_down();
+
+		if (!no_rst)
+		    mvaddstr(12, 44, sent_rst);
+		mvaddstr(12, 29, current_qso.call);
+
+	    } else {
+
+		speeddown();
+
+		attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+		mvprintw(0, 14, "%2u", GetCWSpeed());
+	    }
+	    break;
+	}
+
+	// Alt-W (M-W), set Morse weight.
+	case ALT_W: {
+	    char weightbuf[5] = "";
+	    char *end;
+
+	    mvaddstr(12, 29, "Wght: -50..50");
+
+	    nicebox(1, 1, 2, 12, "CW");
+	    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
+	    mvprintw(2, 2, "Speed:   %2u ", GetCWSpeed());
+	    mvprintw(3, 2, "Weight: %3d ", weight);
+	    refreshp();
+
+	    usleep(800000);
+	    mvaddstr(3, 10, spaces(3));
+
+	    echo();
+	    mvgetnstr(3, 10, weightbuf, 3);
+	    noecho();
+
+	    g_strchomp(weightbuf);
+
+	    int tmp = strtol(weightbuf, &end, 10);
+
+	    if (weightbuf[0] != '\0' && *end == '\0') {
+		/* successful conversion */
+		if (tmp >= -50 && tmp <= 50) {
+		    weight = tmp;
+		    netkeyer(K_WEIGHT, weightbuf);
+		}
+	    }
+	    clear_display();
+
+	    break;
+	}
+
+	// Alt-T (M-T), tune xcvr via cwdaemon.
+	case ALT_T: {
+	    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+	    mvaddstr(0, 2, "Tune     ");
+	    move(12, 29);
+	    refreshp();
+
+	    tune(); //FIXME defined in callinput.c
+
+	    show_header_line();
+	    refreshp();
+
+	    break;
+	}
+
+	default:
+	    handled = false;
+    }
+
+    return handled ? 0 : key;
+}
+
 void keyer(void) {
 
     static WINDOW *win = NULL;
     static PANEL *panel = NULL;
 
     int x = 0, j = 0;
-    int cury, curx;
     char keyerstring[KEYER_LINE_WIDTH + 1] = "";
     int keyerstringpos = 0;
-    char weightbuf[15];
     const char txcontrolstring[2] = { CTRL_T, '\0' };	// ^t
     const char rxcontrolstring[2] = { CTRL_R, '\0' };	// ^r
     const char crcontrolstring[2] = { RETURN, '\0' };	// cr
@@ -151,6 +303,8 @@ void keyer(void) {
 	    }
 	}
 
+	x = handle_common_key(x);
+
 	x = toupper(x);
 
 	if ((x >= ' ' && x <= 'Z') || x == LINEFEED) { /* ~printable or LF */
@@ -172,7 +326,7 @@ void keyer(void) {
 	    keyerstring[keyerstringpos] = '\0';
 
 	} else {
-
+	    // special keys
 	    switch (x) {
 		case '|': { // new line
 		    if (cwkeyer == MFJ1278_KEYER ||
@@ -203,65 +357,12 @@ void keyer(void) {
 		    }
 		    break;
 		}
+
 		case '\\': {
 		    if (cwkeyer == MFJ1278_KEYER ||
 			    digikeyer == MFJ1278_KEYER) {
 			sendmessage(ctl_c_controlstring);
 		    }
-		    break;
-		}
-
-		case ALT_W: {	// Alt-W, set weight
-		    mvaddstr(1, 0, "Weight=   ");
-		    refreshp();
-		    move(1, 7);
-		    echo();
-		    getnstr(weightbuf, 2);
-		    noecho();
-
-		    weight = atoi(weightbuf);
-		    netkeyer(K_WEIGHT, weightbuf);
-		    break;
-		}
-
-		// <Page-Up>, increase CW speed.
-		case KEY_PPAGE: {
-		    speedup();
-		    show_header_line();
-		    break;
-		}
-
-		// <Page-Down>, decrease CW speed.
-		case KEY_NPAGE: {
-		    speeddown();
-		    show_header_line();
-		    break;
-		}
-
-		case KEY_F(1): {
-		    getyx(stdscr, cury, curx);
-		    move(5, 0);
-		    send_keyer_message(0);	/* F1 */
-		    move(cury, curx);
-		    break;
-		}
-		case KEY_F(2) ... KEY_F(11): {
-		    if (*current_qso.call == '\0') {
-			send_standard_message_prev_qso(x - KEY_F(1));
-		    } else {
-			send_standard_message(x - KEY_F(1));
-		    }
-		    break;
-		}
-
-		// Underscore, confirm last exchange.
-		case '_': {
-		    if (S_P == cqmode) {
-			send_standard_message_prev_qso(SP_TU_MSG);
-		    } else {
-			send_standard_message_prev_qso(2);
-		    }
-
 		    break;
 		}
 

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -100,21 +100,20 @@ static void tune() {
 int handle_common_key(int key) {
     bool handled = true;
     switch (key) {
-	// F1, send CQ or S&P call message. (???)
+	// F1, send CQ or S&P call message.
 	case KEY_F(1): {
 	    if (trxmode == CWMODE || trxmode == DIGIMODE) {
-		//FIXME when called from getexchange then just send my.call
 		if (cqmode == S_P) {
 		    sendspcall();
 		} else {
-		    send_standard_message(0);	/* CQ */
+		    send_standard_message(0);       /* CQ */
 		}
 
 		set_simulator_state(CALL);
 
 	    } else {
 		if (cqmode == S_P)
-		    vk_play_file(ph_message[5]);	/* S&P */
+		    vk_play_file(ph_message[5]);    /* S&P */
 		else
 		    vk_play_file(ph_message[0]);
 	    }
@@ -240,7 +239,7 @@ int handle_common_key(int key) {
 	    move(12, 29);
 	    refreshp();
 
-	    tune(); //FIXME defined in callinput.c
+	    tune();
 
 	    show_header_line();
 	    refreshp();

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -119,8 +119,8 @@ void keyer(void) {
 	    x = ' ';
 	}
 
-	// <Escape>, Ctrl-K (^K), Alt-k (M-k)
-	if (x == ESCAPE || x == CTRL_K || x == ALT_K) {
+	// <Escape>, Ctrl-K (^K), Alt-k (M-k), ` (Grave Accent)
+	if (x == ESCAPE || x == CTRL_K || x == ALT_K || x == '`') {
 	    if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {
 		/* switch back to rx */
 		keyer_append(rxcontrolstring);

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -159,6 +159,7 @@ int handle_common_key(int key) {
 	    attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 	    mvprintw(2, 2, "Speed:   %2u ", GetCWSpeed());
 	    mvprintw(3, 2, "Weight: %3d ", weight);
+	    move(3, 10);
 	    refreshp();
 
 	    usleep(800000);

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -128,6 +128,19 @@ int handle_common_key(int key) {
 	    break;
 	}
 
+        // Alt-0 to Alt-9 (M-0...M-9), send CW/Digimode messages 15-24.
+        case 128+'0' ... 128+'9': {
+            int index = key - (128+'0') + CQ_TU_MSG + 1;
+            if (*current_qso.call == '\0') {
+                send_standard_message_prev_qso(index);
+            } else {
+                send_standard_message(index);
+            }
+
+            break;
+        }
+
+
 	// <Page-Down>, change RST if call field not empty, else decrease CW speed.
 	case KEY_NPAGE: {
 	    if (change_rst && (strlen(current_qso.call) != 0)) {

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -325,6 +325,11 @@ void keyer(void) {
 	    }
 	}
 
+	// Cursor down: close keyer window (same as Ctrl-K)
+	if (x == KEY_DOWN) {
+	    x = CTRL_K;
+	}
+
 	// <Escape>, Ctrl-K (^K), Alt-k (M-k), ` (Grave Accent)
 	if (x == ESCAPE || x == CTRL_K || x == ALT_K || x == '`') {
 	    if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -72,8 +72,7 @@ void keyer(void) {
 	return; /* no keyer present */
     }
 
-    const cqmode_t cqmode_save = cqmode;
-    cqmode = KEYBOARD;
+    keyboard_mode = true;
     show_header_line();
 
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
@@ -277,7 +276,7 @@ void keyer(void) {
     }
     hide_panel(panel);
 
-    cqmode = cqmode_save;
+    keyboard_mode = false;
 
     clear_display();
 }

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -315,9 +315,14 @@ void keyer(void) {
 	    x = ' ';
 	}
 
-	// Send space instead of newline or return.
+	// Newline or return:
+	//  - in CW mode close keyer window (same as Ctrl-K)
+	//  - else send space instead
 	if (x == '\n' || x == KEY_ENTER) {
 	    x = ' ';
+	    if (trxmode == CWMODE) {
+		x = CTRL_K;
+	    }
 	}
 
 	// <Escape>, Ctrl-K (^K), Alt-k (M-k), ` (Grave Accent)

--- a/src/keyer.h
+++ b/src/keyer.h
@@ -21,6 +21,8 @@
 #ifndef KEYER_H
 #define KEYER_H
 
+int handle_common_key(int key);
+
 void keyer(void);
 
 #endif /* end of include guard: KEYER_H */

--- a/src/main.c
+++ b/src/main.c
@@ -183,6 +183,7 @@ bool clusterlog = false;	/* clusterlog on/off */
 bool searchflg = false;		/* display search  window */
 bool show_time = false;
 cqmode_t cqmode;            /* can be CQ or S&P */
+bool keyboard_mode;
 bool demode = false;		/* send DE  before s&p call  */
 
 int announcefilter = FILTER_ANN; /*  filter cluster  announcements */
@@ -647,6 +648,7 @@ static void init_variables() {
     unique_call_multi = MULT_NONE;
     generic_mult = MULT_NONE;
     cqmode = CQ;
+    keyboard_mode = false;
     leading_zeros_serial = true;
     ctcomp = false;
     resend_call = RESEND_NOT_SET;

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -57,10 +57,10 @@ typedef enum {
     CQ,         // Run
     S_P,        // Search and Pounce
     AUTO_CQ,    // temporary, used in autocq.c
-    KEYBOARD,   // temporary, used in keyer.c
     NONE        // used in trx_memory to signal empty memory
 } cqmode_t;
 
+extern bool keyboard_mode;
 
 #define FILTER_ALL 0 	/*  filter announcements */
 #define FILTER_ANN 1

--- a/test/test_getexchange.c
+++ b/test/test_getexchange.c
@@ -40,6 +40,7 @@ void sendmessage(const char *msg) {}
 void send_standard_message(int msg) {}
 void send_standard_message_prev_qso(int msg) {}
 void add_local_spot(void) {}
+int handle_common_key(int key) { return 0; }
 void keyer(void) {}
 void qtc_main_panel(int direction) {}
 void rst_recv_up() {}

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -59,6 +59,7 @@ int recall_exchange() { return -1; }
 void refresh_comment() {}
 void time_update() {}
 void show_rtty() {}
+int handle_common_key(int key) { return 0; }
 void keyer() {}
 void send_standard_message(int msg) {}
 void send_standard_message_prev_qso(int msg) {}

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1077,11 +1077,14 @@ Activate keyboard mode.
 All message and keying control keys work the same way as in log input mode.
 To close the keyer window without stopping the ongoing transmission
 press either
-.BR Ctrl-K ,
-.BR Alt-K ,
+.BR Ctrl\-K ,
+.BR Alt\-K ,
 .B `
-(Grave Accent) or
-.BR \[da]\  (Down-Arrow).
+(Grave Accent),
+.BR \[da]\  (Down-Arrow)
+or
+.BR Enter
+(in CW mode only).
 .B Escape
 closes the window and also stops keying.
 .

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1073,7 +1073,17 @@ Insert note in log.
 .BR ,\  (comma)
 .TQ
 .B  Ctrl-K
-Activate Morse Keyboard.
+Activate keyboard mode.
+All message and keying control keys work the same way as in log input mode.
+To close the keyer window without stopping the ongoing transmission
+press either
+.BR Ctrl-K ,
+.BR Alt-K ,
+.B `
+(Grave Accent) or
+.BR \[da]\  (Down-Arrow).
+.B Escape
+closes the window and also stops keying.
 .
 .TP
 .BR \(dq\  "(Double quotation)"
@@ -1196,10 +1206,6 @@ direction.
 .
 It can be toggled with
 .BR Ctrl-V .
-.
-.TP
-.B Ctrl-K
-Keyboard (CW and RTTY).
 .
 .TP
 .B Ctrl-L
@@ -1327,7 +1333,8 @@ Show the frequencies of other local station(s).
 .
 .TP
 .B Alt-K
-Keyboard (CW and RTTY).
+Keyboard mode, same as
+.RB Ctrl-K .
 .
 .TP
 .B Alt-M


### PR DESCRIPTION
(this is still work in progress, comments are welcome)

My motivation was twofold:

1) provide a single-key alternative to close keyer window without stopping keying. This allows faster typing of additional messages. No need to press Ctrl-K for a graceful exit. The new closing key is ` (grave accent or back tick) that is located below Esc on the US keyboard.
![image](https://github.com/Tlf/tlf/assets/15141948/bff8e4ba-a1f1-4480-a3b6-ff6b24bf76e0)


2) allow use of all F-key, Alt-key messages, plus keyer related other keys (speed up/down, weight, tuning) uniformly in all input fields: call input, exchange input and keyer window. This allows also removing code duplication.

"Keyboard" mode had to defined as an additional extension to CQ/S&P (as opposed to an standalone state), as some keys behave differently if one was in CQ or S&P mode.

tune() was moved to keyer() as the common handling is located there.

There is one issue: the `SEND_DE` (=F1 sends "DE <mycall>" in S&P mode) seems to affect call input field only. In exchange input field the plain "<mycall>" is sent. Not sure if this was deliberate or was simply forgotten.
With the common handling it's technically much easier to send in both cases "DE <mycall>".
If the user still wants to send their bare callsign it is always possible using F6.
My suggestion is take this change of `SEND_DE` handling as a bug fix.
