### PR TITLE
Update workflow to use Node.js 20

### DIFF
--- a/.github/workflows/ci-build-ubuntu-20.yml
+++ b/.github/workflows/ci-build-ubuntu-20.yml
@@ -16,7 +16,7 @@ jobs:
       AM_COLOR_TESTS: always
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Show OS info
       run: cat /etc/os-release
     - name: Install dependencies

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,7 +16,7 @@ jobs:
       AM_COLOR_TESTS: always
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Show OS info
       run: cat /etc/os-release
     - name: Install dependencies


### PR DESCRIPTION
A quick one to fix the warning

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3.

See also https://stackoverflow.com/questions/77897660/github-actions-node-js-16-actions-are-deprecated-warning
