### PR TITLE
Fix lock-up on home key in exchange field

### DIFF
--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -323,7 +323,7 @@ int getexchange(void) {
 	     * Fall through to KEY_LEFT stanza if ungetch() is successful.
 	     */
 	    case KEY_HOME: {
-		if (ungetch(x) != OK)
+		if (current_qso.comment[0] == '\0' || ungetch(x) != OK)
 		    break;
 	    }
 


### PR DESCRIPTION
Fixing lock-up when `Home` is pressed in the empty exchange field.

`Home` starts editing at the beginning of the field. If the field is empty then TLF locks up and while cluster info is updated it does not react to any keys. The only way to quit the program is to kill the process.

Steps to reproduce

- switch to exchange input, clear the field
- press `Home`
- further key presses have no effect

Why it happens:

1. field is empty, user presses `Home`
2. `x = key_poll()` delivers `Home`
3. in `case KEY_HOME:` the key is put back into keyboard buffer using `ungetch()`
4. fall through to `case KEY_LEFT:`, here `exchange_edit()` is -- correctly -- not called as input field is empty
5. goto 2

The same logic with `ungetch` is used in `callinput`, but there the empty field case is handled.