### PR TITLE
Adding His Majesty King of Spain CW/SSB contest

### DIFF
--- a/rules/eakingofspain/eakingofspain
+++ b/rules/eakingofspain/eakingofspain
@@ -1,0 +1,77 @@
+#
+# ruleset for EA King of spain contest CW and SSB
+#
+# based on https://concursos.ure.es/en/s-m-el-rey-de-espana-cw/bases/
+#
+# verified with https://concursos.ure.es/en/s-m-el-rey-de-espana-ssb/bases/
+#
+# needs eakingofspan.py plugin for multiplier calculation
+#
+CONTEST=eakingofspain
+LOGFILE=eakingofspain.log
+CONTEST_MODE
+
+CABRILLO=UNIVERSAL
+CABRILLO-CONTEST = EA-MAJESTAD-CW
+CABRILLO-CATEGORY-MODE = CW
+#CABRILLO-CONTEST = EA-MAJESTAD-SSB                                             
+#CABRILLO-CATEGORY-MODE = SSB                                                   
+CABRILLO-CATEGORY-BAND = (ALL, 160M, 80M, 40M, 15M, 10M)
+CABRILLO-CATEGORY-POWER = (HIGH, LOW, QRP)
+
+# scoring for DX station
+
+MY_COUNTRY_POINTS=1
+MY_CONTINENT_POINTS=1
+DX_POINTS=1
+COUNTRY_LIST_POINTS=3
+COUNTRYLIST=EA,EA6,EA8,EA9
+GENERIC_MULT=BAND
+
+#
+##################################
+#                                #
+#  Messages F1= to F12=          #
+#  Message CQ_TU_MSG=            #
+#  Message S&P_TU_MSG=           #
+#                                #
+#  % = call                      #
+#  @ = hiscall                   #
+#  # = serial                    #
+#  [ = RST                       #
+#  + = increase cw speed         #
+#  - = decrease cw speed         #
+#                                #
+##################################
+#
+F1=CQ EA TEST % %
+F2=@ DE %
+F3=@ 5NN #
+F4=TU 
+F5= @
+F6=%
+F7=@ SRI QSO B4 GL
+F8=AGN
+F9= ?
+F10= QRZ?
+F11= PSE K
+F12=TEST % %
+#
+CQ_TU_MSG=TU % 
+S&P_TU_MSG=TU UR 5NN #
+#
+#ALT_0=
+#ALT_1=
+#ALT_2=
+#ALT_3=
+#ALT_4=
+#ALT_5=
+#ALT_6=
+#ALT_7=
+#ALT_8=
+#ALT_9=
+#
+#SEND_DE
+#
+####### END #####################
+

--- a/rules/eakingofspain/eakingofspain.py
+++ b/rules/eakingofspain/eakingofspain.py
@@ -1,0 +1,34 @@
+"""
+https://concursos.ure.es/en/s-m-el-rey-de-espana-cw/bases/
+
+Multipliers: The Multipliers, on each band, are the same for both EA and DX stations and are as follows:
+
+– The EADX-100 entities.
+
+– The Spanish provinces (52).
+
+– Special station His Majesty The King of Spain (EF0F) will pass the abbreviation (SMR)
+
+"""
+
+EA_DXCCS = ['EA', 'EA6', 'EA8', 'EA9']
+EA_PROVINCES = ['AV', 'BU', 'C', 'LE', 'LO', 'LU', 'O', 'OU', 'P', 'PO', 'S',
+    'SA', 'SG', 'SO', 'VA', 'ZA', 'BI', 'HU', 'NA', 'SS', 'TE', 'VI', 'Z',
+    'B', 'GI', 'L', 'T', 'BA', 'CC', 'CR', 'CU', 'GU', 'M', 'TO', 'A', 'AB',
+    'CS', 'MU', 'V', 'IB', 'AL', 'CA', 'CO', 'GR', 'H', 'J', 'MA', 'SE', 'GC',
+    'TF', 'CE', 'ML', 'SMR']
+
+def check_exchange(qso):
+    dxcc = tlf.get_dxcc(qso.call)
+
+    if dxcc.main_prefix in EA_DXCCS:
+        exchange = qso.exchange.strip()
+        if exchange in EA_PROVINCES:
+            mult = f'{dxcc.main_prefix}/{exchange}'
+        else:
+            mult = ''   # invalid county
+    else:
+        mult = dxcc.main_prefix
+
+    return {'mult1_value': mult}
+


### PR DESCRIPTION
I created this plugin and ruleset to make tlf work for the His Majesty King of Spain CW contest.
Verification with the rules of the His Majesty King of Spain SSB contest show they should work there.

This code has been tested in the contest. The resulting scoring has not yet been verified with the scoring by the URE, which I hope to do in a number of weeks when they publish the first results.
