### PR TITLE
Fix mult info when on a WARC band

### DIFF
--- a/src/showscore.c
+++ b/src/showscore.c
@@ -52,7 +52,7 @@ static const int bi_normal[6] = {
     BANDINDEX_20,  BANDINDEX_15, BANDINDEX_10
 };
 static const int bi_warc[6] = {
-    BANDINDEX_160, BANDINDEX_80, BANDINDEX_40,
+    BANDINDEX_160, BANDINDEX_80, BANDINDEX_60,
     BANDINDEX_30,  BANDINDEX_17, BANDINDEX_12
 };
 

--- a/src/showscore.c
+++ b/src/showscore.c
@@ -41,17 +41,17 @@
 
 
 /* list of columns to display score for each band */
-static int band_cols[6] =
+static const int band_cols[6] =
 { 50, 55, 60, 65, 70, 75 };
 
 /* list of BANDINDEX entries to show in each column
  * first  - for normal contest bands
  * second - if in warc band */
-static int bi_normal[6] = {
+static const int bi_normal[6] = {
     BANDINDEX_160, BANDINDEX_80, BANDINDEX_40,
     BANDINDEX_20,  BANDINDEX_15, BANDINDEX_10
 };
-static int bi_warc[6] = {
+static const int bi_warc[6] = {
     BANDINDEX_160, BANDINDEX_80, BANDINDEX_40,
     BANDINDEX_30,  BANDINDEX_17, BANDINDEX_12
 };
@@ -90,7 +90,7 @@ void show_summary(int points, int multi) {
  *
  * \param bi  list of band indices to use
  */
-void display_header(int *bi) {
+static void display_header(const int *bi) {
     int i;
 
     /* prepare header line */
@@ -232,14 +232,12 @@ void showscore(void) {
     }
 
     /* show header with active band and number of QSOs */
-    if (!IsWarcIndex(bandinx)) {
-
-	display_header(bi_normal);
-
-    } else {
-
-	display_header(bi_warc);
+    const int *bi_array = bi_normal;
+    if (IsWarcIndex(bandinx)) {
+	bi_array = bi_warc;
     }
+
+    display_header(bi_array);
 
     /* show mults per band, if applicable */
     if (wysiwyg_multi
@@ -251,66 +249,66 @@ void showscore(void) {
 
 	mvaddstr(3, START_COL, "Mult ");
 	for (i = 0; i < 6; i++) {
-	    printfield(3, band_cols[i], multscore[bi_normal[i]]);
+	    printfield(3, band_cols[i], multscore[bi_array[i]]);
 	}
 
     } else if (itumult || wazmult) {
 
 	mvaddstr(3, START_COL, "Mult ");
 	for (i = 0; i < 6; i++) {
-	    printfield(3, band_cols[i], zonescore[bi_normal[i]]);
+	    printfield(3, band_cols[i], zonescore[bi_array[i]]);
 	}
 
     } else if (pfxmultab) {
 
 	mvaddstr(3, START_COL, "Mult ");
 	for (i = 0; i < 6; i++) {
-	    printfield(3, band_cols[i], GetNrOfPfx_OnBand(bi_normal[i]));
+	    printfield(3, band_cols[i], GetNrOfPfx_OnBand(bi_array[i]));
 	}
 
     } else if (dx_arrlsections) {
 
 	mvaddstr(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
-	    printfield(3, band_cols[i], countryscore[bi_normal[i]]);
+	    printfield(3, band_cols[i], countryscore[bi_array[i]]);
 	}
 
 	mvaddstr(4, START_COL, "Sect");
 	for (i = 0; i < 6; i++) {
-	    printfield(4, band_cols[i], multscore[bi_normal[i]]);
+	    printfield(4, band_cols[i], multscore[bi_array[i]]);
 	}
 
     } else if (CONTEST_IS(CQWW)) {
 
 	mvaddstr(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
-	    printfield(3, band_cols[i], countryscore[bi_normal[i]]);
+	    printfield(3, band_cols[i], countryscore[bi_array[i]]);
 	}
 
 	mvaddstr(4, START_COL, "Zone ");
 	for (i = 0; i < 6; i++) {
-	    printfield(4, band_cols[i], zonescore[bi_normal[i]]);
+	    printfield(4, band_cols[i], zonescore[bi_array[i]]);
 	}
 
     } else if (CONTEST_IS(ARRLDX_USA)) {
 
 	mvaddstr(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
-	    printfield(3, band_cols[i], countryscore[bi_normal[i]]);
+	    printfield(3, band_cols[i], countryscore[bi_array[i]]);
 	}
 
     } else if (iscontest && country_mult) {
 
 	mvaddstr(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
-	    printfield(3, band_cols[i], countryscore[bi_normal[i]]);
+	    printfield(3, band_cols[i], countryscore[bi_array[i]]);
 	}
 
     } else if (CONTEST_IS(PACC_PA)) {
 
 	mvaddstr(3, START_COL, "Cty  ");
 	for (i = 0; i < 6; i++) {
-	    printfield(3, band_cols[i], countryscore[bi_normal[i]]);
+	    printfield(3, band_cols[i], countryscore[bi_array[i]]);
 	}
     }
 


### PR DESCRIPTION
When switching to a WARC band the score summary keeps showing the multiplier count from the corresponding contest band. QSO counts are displayed correctly.
Caused by not using `bi_warc` while showing mult info.

Example: 
score as visible when on 40 m -
![image](https://github.com/Tlf/tlf/assets/15141948/bd34f84f-bdd6-492d-80ea-0018eb0d528d)
after switching to 30 m: QSO count is zero, but mults are kept from the normal display -
![image](https://github.com/Tlf/tlf/assets/15141948/37627f16-a7c4-4dfc-a0da-59e64b0accc3)
fixed display, with 60 m in place of 40 m when on a WARC band  -
![image](https://github.com/Tlf/tlf/assets/15141948/6820bc2d-4db1-4498-9028-7c4f1d62b013)

Of course due to the limited amount of columns the displayed score does not add up when on a WARC band.
