### PR TITLE
Don't overflow callsign buffer in QTC parsing

### DIFF
--- a/src/qtcutil.c
+++ b/src/qtcutil.c
@@ -79,7 +79,7 @@ void qtc_meta_write() {
     g_list_free(qtc_key_list);
 }
 
-void qtc_inc(char callsign[15], int direction) {
+void qtc_inc(char callsign[QTC_CALL_SIZE], int direction) {
     struct t_qtc_store_obj *qtc_obj;
 
     qtc_obj = g_hash_table_lookup(qtc_store, callsign);
@@ -114,7 +114,7 @@ void qtc_inc(char callsign[15], int direction) {
     }
 }
 
-void qtc_dec(char callsign[15], int direction) {
+void qtc_dec(char callsign[QTC_CALL_SIZE], int direction) {
     struct t_qtc_store_obj *qtc_obj;
 
     qtc_obj = g_hash_table_lookup(qtc_store, callsign);
@@ -130,7 +130,7 @@ void qtc_dec(char callsign[15], int direction) {
 
 }
 
-struct t_qtc_store_obj *qtc_get(char callsign[15]) {
+struct t_qtc_store_obj *qtc_get(char callsign[QTC_CALL_SIZE]) {
 
     struct t_qtc_store_obj *qtc_obj;
 
@@ -146,15 +146,15 @@ struct t_qtc_store_obj *qtc_get(char callsign[15]) {
 
 }
 
-void parse_qtcline(char *logline, char callsign[15], int direction) {
+void parse_qtcline(char *logline, char callsign[QTC_CALL_SIZE], int direction) {
 
     int i = 0;
 
     if (direction == RECV) {
-	strncpy(callsign, logline + 30, 15);
+	strncpy(callsign, logline + 30, QTC_CALL_SIZE - 1);
     }
     if (direction == SEND) {
-	strncpy(callsign, logline + 35, 15);
+	strncpy(callsign, logline + 35, QTC_CALL_SIZE - 1);
     }
     while (callsign[i] != ' ') {
 	i++;
@@ -201,7 +201,7 @@ int parse_qtc_flagstr(char *lineptr, char *callsign, char *flag) {
 
 void parse_qtc_flagline(char *lineptr) {
     int rc;
-    char callsign[15], msg[18];
+    char callsign[QTC_CALL_SIZE], msg[18];
     char flag[2] = "";
 
     rc = parse_qtc_flagstr(lineptr, callsign, flag);

--- a/src/qtcutil.h
+++ b/src/qtcutil.h
@@ -21,6 +21,8 @@
 #ifndef QTCUTIL_H
 #define QTCUTIL_H
 
+#include "qtcvars.h"
+
 struct t_qtc_store_obj {
     int total;
     int received;
@@ -29,11 +31,11 @@ struct t_qtc_store_obj {
 };
 
 void qtc_init();
-void qtc_inc(char callsign[15], int direction);
-void qtc_dec(char callsign[15], int direction);
-struct t_qtc_store_obj *qtc_get(char callsign[15]);
+void qtc_inc(char callsign[QTC_CALL_SIZE], int direction);
+void qtc_dec(char callsign[QTC_CALL_SIZE], int direction);
+struct t_qtc_store_obj *qtc_get(char callsign[QTC_CALL_SIZE]);
 
-void parse_qtcline(char *logline, char callsign[15], int direction);
+void parse_qtcline(char *logline, char callsign[QTC_CALL_SIZE], int direction);
 char qtc_get_value(struct t_qtc_store_obj *qtc_obj);
 void parse_qtc_flagline(char *lineptr);
 int parse_qtc_flagstr(char *lineptr, char *callsign, char *flag);


### PR DESCRIPTION
strncpy must copy at most one less byte than what fits into the destination buffer, so we can properly NUL-terminate it.

While at it, introduce a proper constant for the size of the buffer.