### PR TITLE
Fix handling of range of allowed TLF nodes

### DIFF
--- a/src/background_process.c
+++ b/src/background_process.c
@@ -209,7 +209,7 @@ void *background_process(void *ptr) {
 			break;
 		    case FREQMSG:
 			if ((lan_message[0] >= 'A')
-				&& (lan_message[0] <= 'A' + MAXNODES)) {
+				&& (lan_message[0] < 'A' + MAXNODES)) {
 			    node_frequencies[lan_message[0] - 'A'] =
 				atof(lan_message + 2) * 1000.0;
 			    break;
@@ -229,7 +229,7 @@ void *background_process(void *ptr) {
 
 		    case TIMESYNC:
 			if ((lan_message[0] >= 'A')
-				&& (lan_message[0] <= 'A' + MAXNODES)) {
+				&& (lan_message[0] < 'A' + MAXNODES)) {
 			    time_t lantime = atoi(lan_message + 2);
 
 			    time_t delta = lantime - (get_time() - timecorr);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -618,7 +618,7 @@ static int cfg_thisnode(const cfg_arg_t arg) {
     char *str = g_ascii_strup(parameter, -1);
     g_strstrip(str);
 
-    if (strlen(str) != 1 || str[0] < 'A' || str[0] > 'A' + MAXNODES) {
+    if (strlen(str) != 1 || str[0] < 'A' || str[0] >= 'A' + MAXNODES) {
 	g_free(str);
 	error_details = g_strdup_printf("name is A..%c", 'A' + MAXNODES - 1);
 	return PARSE_WRONG_PARAMETER;


### PR DESCRIPTION
According to man page only nodes A..H are allowed. That corresponds with the defined number of nodes MAXNODES = 8.

The patch fixes the check for allowed NODE numbers to respect this setting.