### PR TITLE
Fix storing of lan log segfault

### DIFF
--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -92,6 +92,8 @@ struct qso_t *parse_qso(char *buffer) {
 
     ptr = g_malloc0(sizeof(struct qso_t));
 
+    gchar *tbuffer = g_strdup(buffer);
+
     /* remember whole line */
     ptr->logline = g_strdup(buffer);
     ptr->qsots = 0;
@@ -103,7 +105,7 @@ struct qso_t *parse_qso(char *buffer) {
 
     /* split buffer into parts for linedata_t record and parse
      * them accordingly */
-    tmp = strtok_r(buffer, " \t", &sp);
+    tmp = strtok_r(tbuffer, " \t", &sp);
 
     /* band */
     ptr->band = atoi(tmp);
@@ -144,15 +146,19 @@ struct qso_t *parse_qso(char *buffer) {
     ptr->rst_r = atoi(strtok_r(NULL, " \t", &sp));
 
     /* comment (exchange) */
-    ptr->comment = g_strndup(buffer + 54, contest->exchange_width);
+    ptr->comment = g_strndup(tbuffer + 54, contest->exchange_width);
 
     /* tx */
-    ptr->tx = (buffer[79] == '*') ? 1 : 0;
+    ptr->tx = (tbuffer[79] == '*') ? 1 : 0;
 
     /* frequency (kHz) */
-    ptr->freq = atof(buffer + 80) * 1000.0;
+    ptr->freq = atof(tbuffer + 80) * 1000.0;
     if (freq2bandindex(ptr->freq) == BANDINDEX_OOB) {
 	ptr->freq = 0.;
+    }
+
+    if (tbuffer != NULL) {
+        g_free(tbuffer);
     }
 
     return ptr;

--- a/src/log_utils.c
+++ b/src/log_utils.c
@@ -158,7 +158,7 @@ struct qso_t *parse_qso(char *buffer) {
     }
 
     if (tbuffer != NULL) {
-        g_free(tbuffer);
+	g_free(tbuffer);
     }
 
     return ptr;


### PR DESCRIPTION
There is a bug report in e-mail (via [mailing list](https://lists.nongnu.org/archive/html/tlf-devel/2024-08/msg00003.html)), where the reporter explained the situation: if he uses Tlf on two nodes then when he enter a QSO the receiver node exists with SEGFAULT.

The problem is that the function [parse_qso()](https://github.com/Tlf/tlf/blob/master/src/log_utils.c#L87) is called two times, and it uses the `char *buffer` variable directly. When the function is called first time, the used `strtok_r()` chain "eats" the buffer, and at the second call it uses an empty buffer.

Here are the traces:
* 1st call
  * background_process.c:165
  * log_to_disk.c:121
  * log_utils.c:87
* 2nd call
  * log_to_disk.c:123
  * addcall.c:233
  * log_utils.c:87

Both calls are necessary for a complete log, so I think the best solution is to copy the original buffer and operate with that.