### PR TITLE
Minor improvement of multi-node info

### DIFF
--- a/src/changepars.c
+++ b/src/changepars.c
@@ -665,11 +665,11 @@ void networkinfo(void) {
     wipe_display();
 
     if (lan_active)
-	mvaddstr(1, 10, "Network status: on");
+	mvprintw(1, 10, "Network status: on   Node: %c", thisnode);
     else
 	mvaddstr(1, 10, "Network status: off");
 
-    mvprintw(3, 28, "Packets rcvd: %d | %d", recv_packets, recv_error);
+    mvprintw(3, 22, "Total packets rcvd: %d | %d", recv_packets, recv_error);
 
     for (int i = 0; i < nodes; i++) {
 	mvaddstr(4 + i, 10, bc_hostaddress[i]);

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -87,8 +87,10 @@ void clusterinfo(void) {
 	    node_frequencies[thisnode - 'A'] = atof(band[bandinx]);
 
 	for (f = 0; f < MAXNODES; f++) {
+	    char node_id = 'A' + f;
 	    if (node_frequencies[f] != 0)
-		mvprintw(15 + f, 4, " Stn %c : %5.0f", 'A' + f,
+		mvprintw(15 + f, 4, "%cStn %c : %5.0f",
+			 (node_id == thisnode ? '*' : ' '), node_id,
 			 node_frequencies[f] / 1000.0);
 	}
 	nicebox(14, 3, 8, 27, "Frequencies");

--- a/test/test_clusterinfo.c
+++ b/test/test_clusterinfo.c
@@ -281,7 +281,7 @@ void test_freqwindow(void **state) {
     clusterinfo();
 
     // frequency shown rounded to kHz
-    check_mvprintw_output(0, 15, 4, " Stn A :  7124");
+    check_mvprintw_output(0, 15, 4, "*Stn A :  7124");
 
     assert_string_equal(nicebox_boxname, "Frequencies");
 


### PR DESCRIPTION
* mark own node on frequency display (Alt-J)
![image](https://github.com/user-attachments/assets/6dced1ff-794b-4a8e-b488-90b2e5315659)

* on :INFo panel add own node name if LAN is active. Added "Total" to the received stats to visually separate it from the per-node stats. 
![image](https://github.com/user-attachments/assets/9baef245-dca8-454f-bc35-86c693004803)

I see no way to correlate the host names to node ids due to way it's set up.
It would be maybe better to have a configuration like this
```
NODE_A=biggun1
NODE_B=biggun2
NODE_C=rxonly
THISNODE=B
```

Sending frequency info only each 2 minutes is also somewhat not optimal IMO.
