### PR TITLE
Update ARRL sections to current list

### DIFF
--- a/share/arrlsections
+++ b/share/arrlsections
@@ -13,7 +13,7 @@ ENY
 EPA
 EWA
 GA
-GTA
+GH
 IA
 ID
 IL
@@ -22,7 +22,6 @@ KS
 KY
 LA
 LAX
-MAR
 MB
 MDC
 ME
@@ -31,6 +30,7 @@ MN
 MO
 MS
 MT
+NB
 NC
 ND
 NE
@@ -41,9 +41,9 @@ NLI
 NM
 NNJ
 NNY
+NS
 NTX
 NV
-NT
 OH
 OK
 ONE
@@ -68,6 +68,7 @@ SK
 SNJ
 STX
 SV
+TER
 TN
 UT
 VA


### PR DESCRIPTION
Per a post on the ADIF mialing list: https://groups.io/g/adifdev/message/9783 as of 01 Jan 2023 the RAC changed sections as follows:

GTA replaced by GH (Golden Horseshoe)
MAR replaced by NB and NS
NT replaced by TER

Per ARRL Web site, Territories includes Yukon (VY1), Northwest Territories (VE8), and Nunavut (VY0).