### PR TITLE
Fix buffer overflow if 6 char locator is used for MYQRA

### DIFF
--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1009,7 +1009,8 @@ static int cfg_rttymode(const cfg_arg_t arg) {
 }
 
 static int cfg_myqra(const cfg_arg_t arg) {
-    strcpy(my.qra, parameter);
+    g_strlcpy(my.qra, parameter, sizeof(my.qra));
+    g_strchomp(my.qra);
 
     if (check_qra(my.qra) == 0) {
 	return PARSE_WRONG_PARAMETER;

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -1262,7 +1262,13 @@ void test_digimodem(void **state) {
 void test_myqra(void **state) {
     int rc = call_parse_logcfg("MYQRA=JN97\n");
     assert_int_equal(rc, PARSE_OK);
-    assert_string_equal(my.qra, "JN97\n");  // FIXME NL...
+    assert_string_equal(my.qra, "JN97");
+}
+
+void test_myqra2(void **state) {
+    int rc = call_parse_logcfg("MYQRA=JN97LA\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(my.qra, "JN97LA");
 }
 
 void test_powermult(void **state) {


### PR DESCRIPTION
* Furthermore drop trailing '\n'