### PR TITLE
Show autosend configuration after change

### DIFF
--- a/src/changepars.c
+++ b/src/changepars.c
@@ -73,34 +73,35 @@ void wipe_display();
 static void change_autosend() {
     mvaddstr(13, 29, "Autosend: (0, 2..5, m)?");
     refreshp();
-    int x = 1;
+    int x;
 
-    /* wait for correct input or ESC */
-    while ((x != 0) && !((x >= 2) && (x <= 5)) && !(x == 'm' - '0')) {
+    /* wait for valid input or ESC */
+    do {
 	x = key_get();
 	if (x == ESCAPE)
-	    break;
-	x = x - '0';
-    }
+	    return;
+    } while (!(x == '0' || (x >= '2' && x <= '5') || x == 'm'));
 
     /* remember new setting */
-    if (x != ESCAPE) {
-	if (x == 0 || (x >= 2 && x <= 5))
-	    cwstart = x;
-	else
-	    cwstart = -1;
+    if (x == '0' || (x >= '2' && x <= '5'))
+	cwstart = x - '0';
+    else
+	cwstart = -1;   // manual mode
+
+    char *status;
+    if (cwstart > 0) {
+	status = g_strdup_printf("%d", cwstart);
+    } else if (cwstart < 0) {
+	status = g_strdup("Manual");
+    } else {
+	status = g_strdup("OFF");
     }
 
-    if (cwstart > 0)
-	mvprintw(13, 29, "Autosend now: %1d        ",
-		 cwstart);
-    else {
-	if (cwstart < 0)
-	    mvaddstr(13, 29, "Autosend now: Manual   ");
-	else
-	    mvaddstr(13, 29, "Autosend now: OFF      ");
-    }
+    mvprintw(13, 29, "Autosend now: %-9s", status);
+    g_free(status);
+
     refreshp();
+    sleep(1);
 }
 
 

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -70,6 +70,40 @@ void center_fkey_header();
 
 void wipe_display();
 
+static void change_autosend() {
+    mvaddstr(13, 29, "Autosend: (0, 2..5, m)?");
+    refreshp();
+    int x = 1;
+
+    /* wait for correct input or ESC */
+    while ((x != 0) && !((x >= 2) && (x <= 5)) && !(x == 'm' - '0')) {
+	x = key_get();
+	if (x == ESCAPE)
+	    break;
+	x = x - '0';
+    }
+
+    /* remember new setting */
+    if (x != ESCAPE) {
+	if (x == 0 || (x >= 2 && x <= 5))
+	    cwstart = x;
+	else
+	    cwstart = -1;
+    }
+
+    if (cwstart > 0)
+	mvprintw(13, 29, "Autosend now: %1d        ",
+		 cwstart);
+    else {
+	if (cwstart < 0)
+	    mvaddstr(13, 29, "Autosend now: Manual   ");
+	else
+	    mvaddstr(13, 29, "Autosend now: OFF      ");
+    }
+    refreshp();
+}
+
+
 int changepars(void) {
 
     char parameterstring[20] = "";
@@ -589,36 +623,7 @@ int changepars(void) {
 	    break;
 	}
 	case 50: {		/* CHARS */
-	    mvaddstr(13, 29, "Autosend: (0, 2..5, m)?");
-	    refreshp();
-	    x = 1;
-
-	    /* wait for correct input or ESC */
-	    while ((x != 0) && !((x >= 2) && (x <= 5)) && !(x == 'm' - '0')) {
-		x = key_get();
-		if (x == ESCAPE)
-		    break;
-		x = x - '0';
-	    }
-
-	    /* remember new setting */
-	    if (x != ESCAPE) {
-		if (x == 0 || (x >= 2 && x <= 5))
-		    cwstart = x;
-		else
-		    cwstart = -1;
-	    }
-
-	    if (cwstart > 0)
-		mvprintw(13, 29, "Autosend now: %1d        ",
-			 cwstart);
-	    else {
-		if (cwstart < 0)
-		    mvaddstr(13, 29, "Autosend now: Manual   ");
-		else
-		    mvaddstr(13, 29, "Autosend now: OFF      ");
-	    }
-	    refreshp();
+	    change_autosend();
 	    break;
 
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -652,6 +652,7 @@ static void init_variables() {
     leading_zeros_serial = true;
     ctcomp = false;
     resend_call = RESEND_NOT_SET;
+    cwstart = 0;    // off
 
     g_free(current_qso.call);
     current_qso.call = g_malloc0(CALL_SIZE);

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -449,8 +449,8 @@ static int cfg_autosend(const cfg_arg_t arg) {
     g_strstrip(str);
 
     // see also change_autosend() for valid values
-    if (g_regex_match_simple("^[02345]$", str, G_REGEX_DEFAULT,
-			     G_REGEX_MATCH_DEFAULT)) {
+    if (g_regex_match_simple("^[02345]$", str,
+			     (GRegexCompileFlags)0, (GRegexMatchFlags)0)) {
 	cwstart = atoi(str);
     } else if (strcmp(str, "OFF") == 0) {
 	cwstart = 0;

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -444,6 +444,28 @@ static int cfg_operating_mode(const cfg_arg_t arg) {
     return PARSE_OK;
 }
 
+static int cfg_autosend(const cfg_arg_t arg) {
+    char *str = g_ascii_strup(parameter, -1);
+    g_strstrip(str);
+
+    // see also change_autosend() for valid values
+    if (g_regex_match_simple("^[02345]$", str, G_REGEX_DEFAULT,
+			     G_REGEX_MATCH_DEFAULT)) {
+	cwstart = atoi(str);
+    } else if (strcmp(str, "OFF") == 0) {
+	cwstart = 0;
+    } else if (strcmp(str, "M") == 0 || strcmp(str, "MANUAL") == 0) {
+	cwstart = -1;
+    } else {
+	g_free(str);
+	error_details = g_strdup("must be 0, OFF, 2, 3, 4, 5, M or MANUAL");
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    g_free(str);
+    return PARSE_OK;
+}
+
 static int cfg_bandoutput(const cfg_arg_t arg) {
     char *str = g_strdup(parameter);
     g_strstrip(str);
@@ -1414,6 +1436,7 @@ static config_t logcfg_configs[] = {
     {"RESEND_CALL",         NEED_PARAM, cfg_resend_call},
     {"GENERIC_MULT",        NEED_PARAM, cfg_generic_mult},
     {"OPERATING_MODE",      NEED_PARAM, cfg_operating_mode},
+    {"AUTOSEND",            NEED_PARAM, cfg_autosend},
 
     {NULL}  // end marker
 };

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -920,6 +920,12 @@ void test_operating_mode(void **state) {
     assert_int_equal(cqmode, S_P);
 }
 
+void test_autosend(void **state) {
+    int rc = call_parse_logcfg("AUTOSEND=4\n");
+    assert_int_equal(rc, 0);
+    assert_int_equal(cwstart, 4);
+}
+
 // TLFCOLOR1..6
 void test_tlfcolorn(void **state) {
     char line[80];

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -2526,6 +2526,15 @@ pass another value (in seconds) after the \(oq=\(cq sign.
 .IP
 There must be an integral number of time sections per hour!
 .
+.TP
+\fBAUTOSEND\fR=<\fI0\fR|\fIOFF\fR|\fI2\fR..\fI5\fR|\fIM\fR|\fIMANUAL\fR>
+Set the number of characters for CW auto-start or ‘M’ for manual start.
+Default value is OFF.
+.
+For details see
+.BR :CHA r
+command.
+.
 .SS CW, Digimode and Voice Keyer Macros
 .
 The following parameters configure the CW, Digimode and voice mode keyer


### PR DESCRIPTION
After changing autosend configuration (`cwstart`) the usual 1 sec delay was missing, causing the information immediately cleared and thus not actually showing.

Extracted the functionality from the switch statement into a separate function.

Pressing ESC immediately exits the function without showing the current setting. Note: the original intention was to show the setting even in this case. I find it more logical not to bug the user with the 1 sec delay if they wanted to abort the change.