### PR TITLE
Fix showing generic multipliers on bandmap

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt-get install -y libhamlib-dev libxmlrpc-core-c3-dev libcmocka-dev python3-pexpect python3-dev astyle
+        sudo apt-get install -y libhamlib-dev libxmlrpc-core-c3-dev libglib2.0-dev libcmocka-dev python3-pexpect python3-dev astyle
     - name: Set up datadir
       run: mkdir datadir && ln -s $PWD/share datadir/tlf
     - name: Check source formatting


### PR DESCRIPTION
In PR #442 the check-only mode for generic mutlipliers got broken as `remember_generic_mult()` has been declared as `void`.

![image](https://github.com/user-attachments/assets/80df219f-df48-4c0f-b9b3-4713187f3e4b)

This caused potential new multipliers not marked on the bandmap.
