### PR TITLE
Hamlib rotator support

### DIFF
--- a/share/logcfg.dat
+++ b/share/logcfg.dat
@@ -142,6 +142,19 @@ CWTONE=800
 #
 #################################
 #                               #
+#  ROTATOR CONTROL              #
+# (comment out if not present)  #
+# Rigmodel = Hamlib index, here #
+#           for Yaesu GS-232B   #
+#################################
+#
+#ROTATOR_CONTROL
+#ROTMODEL=603
+#ROTSPEED=9600
+#ROTPORT=/dev/ttyUSB3
+#
+#################################
+#                               #
 #  INFORMATION WINDOWS          #
 #                               #
 #################################

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -60,6 +60,7 @@
 #include "nicebox.h"		// Includes curses.h
 #include "note.h"
 #include "printcall.h"
+#include "qrb.h"
 #include "qtcvars.h"		// Includes globalvars.h
 #include "qtcwin.h"
 #include "rtty.h"
@@ -709,6 +710,13 @@ int callinput(void) {
 		if (!nopacket && packetinterface > 0) {
 		    add_cluster_spot();
 		}
+
+		break;
+	    }
+
+	    // Ctrl-D (^D), rotate antenna "d"irection.
+	    case CTRL_D: {
+		rotate_to_qrb();
 
 		break;
 	    }

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -1,6 +1,7 @@
 
 #include <glib.h>
 #include <hamlib/rig.h>
+#include <hamlib/rotator.h>
 #include <stdbool.h>
 
 #include <config.h>
@@ -108,10 +109,13 @@ extern int highqsonr;
 
 
 extern RIG *my_rig;
+extern ROT *my_rot;
 extern pthread_mutex_t tlf_rig_mutex;
+extern pthread_mutex_t tlf_rot_mutex;
 extern cqmode_t cqmode;
 extern int trxmode;
 extern int myrig_model;
+extern int myrot_model;
 extern rmode_t rigmode;
 extern freq_t freq;
 extern char lastqsonr[];
@@ -184,6 +188,7 @@ extern bool keyer_backspace;
 extern int netkeyer_port;
 extern int cqdelay;
 extern int serial_rate;
+extern int rot_serial_rate;
 extern int tnc_serial_rate;
 extern int countrylist_points;
 extern int my_country_points;
@@ -218,6 +223,7 @@ extern char modem_mode[];
 extern char sc_volume[];
 extern char clusterlogin[];
 extern char rigconf[];
+extern char rotconf[];
 extern char keyer_device[10];
 extern char netkeyer_hostaddress[];
 extern char pr_hostaddress[];
@@ -233,6 +239,7 @@ extern char fldigi_url[50];
 extern char *cabrillo;
 extern char *editor_cmd;
 extern char *rigportname;
+extern char *rotportname;
 extern char *config_file;
 #ifdef HAVE_PYTHON
 extern char *plugin_config;
@@ -254,6 +261,7 @@ extern bool ignoredupe;
 extern bool continentlist_only;
 extern bool debugflag;
 extern bool trx_control;
+extern bool rot_control;
 extern bool nopacket;
 extern bool verbose;
 

--- a/src/keystroke_names.h
+++ b/src/keystroke_names.h
@@ -26,6 +26,7 @@
 
 #define CTRL_A    1
 #define CTRL_B    2
+#define CTRL_D    4
 #define CTRL_E    5
 #define CTRL_F    6
 #define CTRL_G    7             /* Bell */

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,7 @@
 #include <argp.h>
 #include <ctype.h>
 #include <hamlib/rig.h>
+#include <hamlib/rotator.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,6 +51,7 @@
 #include "netkeyer.h"
 #include "parse_logcfg.h"
 #include "plugin.h"
+#include "qrb.h"
 #include "qtcvars.h"		// Includes globalvars.h
 #include "readctydata.h"
 #include "readcalls.h"
@@ -331,13 +333,13 @@ int nr_of_spots;			/* Anzahl Lines in spot_ptr array */
 int packetinterface = 0;
 int fdSertnc = 0;
 char tncportname[40];
-char rigconf[80];
 int tnc_serial_rate = 2400;
 char clusterlogin[80] = "";
 bool bmautoadd = false;
 bool bmautograb = false;
 
 /*-------------------------------------rigctl-------------------------------*/
+char rigconf[80];
 int myrig_model = 0;            /* unset */
 RIG *my_rig;			/* handle to rig (instance) */
 pthread_mutex_t tlf_rig_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -352,6 +354,18 @@ char *rigportname;
 int rignumber = 0;
 int rig_comm_error = 0;
 int rig_comm_success = 0;
+
+/*-------------------------------------rotctl-------------------------------*/
+bool rot_control = false;
+int myrot_model = 0;            /* unset */
+char rotconf[80];
+ROT *my_rot;			/* handle to rotator (instance) */
+pthread_mutex_t tlf_rot_mutex = PTHREAD_MUTEX_INITIALIZER;
+int rot_serial_rate = 2400;
+char *rotportname;
+int rotnumber = 0;
+int rot_comm_error = 0;
+int rot_comm_success = 0;
 
 /*----------------------------------fldigi---------------------------------*/
 char fldigi_url[50] = "http://localhost:7362/RPC2";
@@ -418,6 +432,7 @@ char itustr[3];
 
 bool nopacket = false;		/* set if tlf is called with '-n' */
 bool trx_control_disabled = false;	/* set if tlf is called with '-r' */
+bool rot_control_disabled = false;	/* set if tlf is called with '-R' */
 bool convert_cabrillo = false;  /* set if the arg input is a cabrillo */
 
 int bandweight_points[NBANDS] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0};
@@ -448,6 +463,7 @@ static const struct argp_option options[] = {
     {"import",      'i', 0, 0,  "Import Cabrillo file to Tlf format"},
     {"no-cluster",  'n', 0, 0,  "Start without cluster hookup" },
     {"no-rig",      'r', 0, 0,  "Start without radio control" },
+    {"no-rotator",  'R', 0, 0,  "Start without radio control" },
     {"list",	    'l', 0, 0,  "List built-in contests" },
     {"sync",        's', "URL", 0,  "Synchronize log with other node" },
     {"debug",       'd', 0, 0,  "Debug mode" },
@@ -470,6 +486,9 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 	    break;
 	case 'r':
 	    trx_control_disabled = true; // disable radio control
+	    break;
+	case 'R':
+	    rot_control_disabled = true; // disable rotator control
 	    break;
 	case 'i':
 	    convert_cabrillo = true;
@@ -788,6 +807,36 @@ static void hamlib_init() {
     }
 }
 
+static void hamlib_rot_init() {
+
+    if (rot_control_disabled) {
+	rot_control = false;
+    }
+
+    if (!rot_control) {
+	return;
+    }
+
+    shownr("Rotator model number is", myrot_model);
+    shownr("Rotator speed is", rot_serial_rate);
+
+    showmsg("Trying to start rotator control");
+
+    int status = init_tlf_rot();
+
+    if (status != 0) {
+	showmsg("Continue without rotator control Y/(N)?");
+	if (toupper(key_get()) != 'Y') {
+	    endwin();
+	    exit(1);
+	}
+	trx_control = false;
+	trx_control_disabled = true;
+	showmsg("Disabling rotator control!");
+	sleep(1);
+    }
+}
+
 static void fldigi_init() {
 #ifdef HAVE_LIBXMLRPC
     int status;
@@ -979,6 +1028,10 @@ static void tlf_cleanup() {
 	close_tlf_rig(my_rig);
     }
 
+    if (my_rot) {
+	close_tlf_rot(my_rot);
+    }
+
 #ifdef HAVE_LIBXMLRPC
     if (digikeyer == FLDIGI) {
 	fldigi_xmlrpc_cleanup();
@@ -1086,6 +1139,7 @@ int main(int argc, char *argv[]) {
 //                      synclog(synclogfile);
 
     hamlib_init();
+    hamlib_rot_init();
     fldigi_init();
     lan_init();
     keyer_init();

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1243,6 +1243,7 @@ static config_t logcfg_configs[] = {
     {"IGNOREDUPE",          CFG_BOOL(ignoredupe)},
     {"USE_CONTINENTLIST_ONLY",  CFG_BOOL(continentlist_only)},
     {"RADIO_CONTROL",           CFG_BOOL(trx_control)},
+    {"ROTATOR_CONTROL",     CFG_BOOL(rot_control)},
     {"PORTABLE_MULT_2",     CFG_BOOL(portable_x2)},
 
     {"USEPARTIALS",	    CFG_BOOL(use_part)},
@@ -1326,6 +1327,7 @@ static config_t logcfg_configs[] = {
     {"NETKEYERPORT",    CFG_INT(netkeyer_port, 1, INT32_MAX)},
     {"TNCSPEED",        CFG_INT(tnc_serial_rate, 0, INT32_MAX)},
     {"RIGSPEED",        CFG_INT(serial_rate, 0, INT32_MAX)},
+    {"ROTSPEED",        CFG_INT(rot_serial_rate, 0, INT32_MAX)},
     {"CQDELAY",         CFG_INT(cqdelay, 3, 60)},
     {"SSBPOINTS",       CFG_INT(ssbpoints, 0, INT32_MAX)},
     {"CWPOINTS",        CFG_INT(cwpoints, 0, INT32_MAX)},
@@ -1333,6 +1335,7 @@ static config_t logcfg_configs[] = {
     {"TXDELAY",         CFG_INT(txdelay, 0, 50)},
     {"TUNE_SECONDS",    CFG_INT(tune_seconds, 1, 100)},
     {"RIGMODEL",        CFG_INT(myrig_model, 0, 99999)},
+    {"ROTMODEL",        CFG_INT(myrot_model, 0, 99999)},
     {"COUNTRY_LIST_POINTS", CFG_INT(countrylist_points, 0, INT32_MAX)},
     {"MY_COUNTRY_POINTS",   CFG_INT(my_country_points, 0, INT32_MAX)},
     {"MY_CONTINENT_POINTS", CFG_INT(my_cont_points, 0, INT32_MAX)},
@@ -1349,6 +1352,7 @@ static config_t logcfg_configs[] = {
     {"RIGPTT",          CFG_INT_CONST(rigptt, CAT_PTT_WANTED)},
 
     {"RIGCONF",         CFG_STRING_STATIC(rigconf, 80)},
+    {"ROTCONF",         CFG_STRING_STATIC(rotconf, 80)},
     {"LOGFILE",         CFG_STRING_STATIC(logfile, 120)},
     {"KEYER_DEVICE",    CFG_STRING_STATIC(keyer_device, 10)},
     {"NETKEYERHOST",    CFG_STRING_STATIC(netkeyer_hostaddress, 16)},
@@ -1372,6 +1376,7 @@ static config_t logcfg_configs[] = {
 #endif
 
     {"RIGPORT",         CFG_STRING_NOCHOMP(rigportname)},
+    {"ROTPORT",         CFG_STRING_NOCHOMP(rotportname)},
     {"CLUSTERLOGIN",    CFG_STRING_STATIC_NOCHOMP(clusterlogin, 80)},
 
     {"CALL",            NEED_PARAM, cfg_call},

--- a/src/qrb.c
+++ b/src/qrb.c
@@ -19,10 +19,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <hamlib/rotator.h>
-
+#include "err_utils.h"
+#include "getctydata.h"
 #include "globalvars.h"
+#include "startmsg.h"
 #include "qrb.h"
+
+static int parse_rotconf();
 
 
 /* Compute the Bearing and Range */
@@ -52,4 +55,123 @@ bool get_qrb_for_locator(const char *locator, double *range, double *bearing) {
 
     return RIG_OK == qrb(my.Long, my.Lat, -dest_long, dest_lat,
 			 range, bearing);
+}
+
+
+/* Hamlib rotator control */
+
+int init_tlf_rot(void) {
+    int retcode;		/* generic return code from functions */
+
+    /*
+     * allocate memory, setup & open port
+     */
+    my_rot = rot_init((rot_model_t) myrot_model);
+
+    if (!my_rot) {
+	shownr("Unknown rotator model", myrot_model);
+	return -1;
+    }
+
+    if (rotportname == NULL || strlen(rotportname) == 0) {
+	showmsg("Missing rot port name!");
+	return -1;
+    }
+
+    rotportname[strlen(rotportname) - 1] = '\0';	// remove '\n'
+    strncpy(my_rot->state.rotport.pathname, rotportname,
+	    TLFFILPATHLEN - 1);
+
+    my_rot->state.rotport.parm.serial.rate = serial_rate;
+
+    // parse ROTCONF parameters
+    if (parse_rotconf() < 0) {
+	return -1;
+    }
+
+    retcode = rot_open(my_rot);
+
+    if (retcode != RIG_OK) {
+	TLF_LOG_WARN("rot_open: %s", rigerror(retcode));
+	return -1;
+    }
+
+    return 0;
+}
+
+void rotate_to_qrb() {
+    double bearing;
+    double range;
+    int retcode;		/* generic return code from functions */
+    int pfx_index = getctydata_pfx(current_qso.call);
+
+    prefix_data *pfx = prefix_by_index(pfx_index);
+
+    if (pfx->dxcc_ctynr > 0) {
+
+	if (pfx_index != my.countrynr && 0 == get_qrb(&range, &bearing)) {
+
+	    pthread_mutex_lock(&tlf_rot_mutex);
+	    retcode = rot_set_position(my_rot, bearing, 0.0); // azimuth, elevation
+	    pthread_mutex_unlock(&tlf_rot_mutex);
+
+	    if (retcode != RIG_OK) {
+		TLF_LOG_WARN("Problem with setting rotator position: %s", rigerror(retcode));
+	    } else {
+		showmsg("Rotator set position ok!");
+	    }
+	}
+    }
+}
+
+void close_tlf_rot(ROT *my_rot) {
+
+    pthread_mutex_lock(&tlf_rot_mutex);
+    rot_close(my_rot);		/* close port */
+    rot_cleanup(my_rot);	/* if you care about memory */
+    pthread_mutex_unlock(&tlf_rot_mutex);
+
+    printf("Rotator port %s closed\n", rotportname);
+}
+
+static int parse_rotconf() {
+    char *cnfparm, *cnfval;
+    const int rotconf_len = strlen(rotconf);
+    int i;
+    int retcode;
+
+    cnfparm = cnfval = rotconf;
+
+    for (i = 0; i < rotconf_len; i++) {
+	/* FIXME: left hand value of = cannot be null */
+	if (rotconf[i] == '=' && cnfval == cnfparm) {
+	    cnfval = rotconf + i + 1;
+	    rotconf[i] = '\0';
+	    continue;
+	}
+	if (rotconf[i] == ',' || i + 1 == rotconf_len) {
+	    if (cnfval <= cnfparm) {
+		showstring("Missing parm value in ROTCONF: ", rotconf);
+		return -1;
+	    }
+	    if (rotconf[i] == ',')
+		rotconf[i] = '\0';
+
+	    pthread_mutex_lock(&tlf_rot_mutex);
+	    retcode =
+		rot_set_conf(my_rot, rot_token_lookup(my_rot, cnfparm),
+			     cnfval);
+	    pthread_mutex_unlock(&tlf_rot_mutex);
+
+	    if (retcode != RIG_OK) {
+		showmsg("rot_set_conf: error  ");
+		return -1;
+	    }
+
+	    cnfparm = cnfval = rotconf + i + 1;
+	    continue;
+	}
+    }
+
+    return 0;
 }

--- a/src/qrb.h
+++ b/src/qrb.h
@@ -22,9 +22,14 @@
 #define QRB_H
 
 #include <stdbool.h>
+#include <hamlib/rotator.h>
 
 int get_qrb(double *range, double *bearing);
 
 bool get_qrb_for_locator(const char *locator, double *range, double *bearing);
+
+int init_tlf_rot(void);
+void rotate_to_qrb();
+void close_tlf_rot(ROT *my_rot);
 
 #endif /* end of include guard: QRB_H */

--- a/src/sendqrg.h
+++ b/src/sendqrg.h
@@ -24,16 +24,6 @@
 #include <hamlib/rig.h>
 #include <stdbool.h>
 
-#ifdef HAMLIB_FILPATHLEN
-#define TLFFILPATHLEN HAMLIB_FILPATHLEN
-#else
-#ifdef FILPATHLEN
-#define TLFFILPATHLEN FILPATHLEN
-#else
-#error "(HAMLIB_)FILPATHLEN macro not found"
-#endif
-#endif
-
 bool rig_has_send_morse();
 bool rig_has_stop_morse();
 

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -28,6 +28,16 @@
 #include "bandmap.h"
 #include "dxcc.h"
 
+#ifdef HAMLIB_FILPATHLEN
+#define TLFFILPATHLEN HAMLIB_FILPATHLEN
+#else
+#ifdef FILPATHLEN
+#define TLFFILPATHLEN FILPATHLEN
+#else
+#error "(HAMLIB_)FILPATHLEN macro not found"
+#endif
+#endif
+
 enum {
     NO_KEYER,
     NET_KEYER,

--- a/test/data.c
+++ b/test/data.c
@@ -304,6 +304,7 @@ bool bmautoadd = false;
 bool bmautograb = false;
 
 /*-------------------------------------rigctl-------------------------------*/
+char rotconf[80];
 #ifdef HAVE_LIBHAMLIB
 int myrig_model = 351;
 RIG *my_rig;			/* handle to rig (instance) */
@@ -323,6 +324,18 @@ int rignumber = 0;
 int rig_comm_error = 0;
 int rig_comm_success = 0;
 int rigptt = 0;
+
+/*-------------------------------------rotctl-------------------------------*/
+bool rot_control = false;
+#ifdef HAVE_LIBHAMLIB
+int myrot_model = 603;
+ROT *my_rot;			/* handle to rot (instance) */
+#endif
+int rot_serial_rate = 2400;
+char *rotportname;
+int rotnumber = 0;
+int rot_comm_error = 0;
+int rot_comm_success = 0;
 
 /*----------------------------the parsed log lines-------------------------*/
 // array of qso's

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -243,12 +243,14 @@ int setup_default(void **state) {
     }
 
     rigconf[0] = 0;
+    rotconf[0] = 0;
     pr_hostaddress[0] = 0;
 
     FREE_DYNAMIC_STRING(editor_cmd);
     FREE_DYNAMIC_STRING(cabrillo);
     FREE_DYNAMIC_STRING(callmaster_filename);
     FREE_DYNAMIC_STRING(rigportname);
+    FREE_DYNAMIC_STRING(rotportname);
     FREE_DYNAMIC_STRING(vk_play_cmd);
     FREE_DYNAMIC_STRING(vk_record_cmd);
     FREE_DYNAMIC_STRING(soundlog_play_cmd);
@@ -431,6 +433,7 @@ static bool_true_t bool_trues[] = {
     {"IGNOREDUPE", &ignoredupe},
     {"USE_CONTINENTLIST_ONLY", &continentlist_only},
     {"RADIO_CONTROL", &trx_control},
+    {"ROTATOR_CONTROL", &rot_control},
     {"PORTABLE_MULT_2", &portable_x2},
     {"WYSIWYG_MULTIBAND", &wysiwyg_multi},
     {"WYSIWYG_ONCE", &wysiwyg_once},
@@ -571,6 +574,12 @@ void test_rigconf(void **state) {
     int rc = call_parse_logcfg("RIGCONF= ABCD\n");
     assert_int_equal(rc, PARSE_OK);
     assert_string_equal(rigconf, "ABCD");
+}
+
+void test_rotconf(void **state) {
+    int rc = call_parse_logcfg("ROTCONF= ABCD\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_string_equal(rotconf, "ABCD");
 }
 
 void test_callmaster(void **state) {
@@ -840,6 +849,13 @@ void test_rigport(void **state) {
     assert_string_equal(rigportname, "/dev/rigport \r\n");  // FIXME...
 }
 
+void test_rotport(void **state) {
+    int rc = call_parse_logcfg("ROTPORT = /dev/rotport \r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_non_null(rotportname);
+    assert_string_equal(rotportname, "/dev/rotport \r\n");  // FIXME...
+}
+
 void test_tncspeed(void **state) {
     int rc = call_parse_logcfg("TNCSPEED = 1200\r\n");
     assert_int_equal(rc, PARSE_OK);
@@ -850,6 +866,12 @@ void test_rigspeed(void **state) {
     int rc = call_parse_logcfg("RIGSPEED = 38400\r\n");
     assert_int_equal(rc, PARSE_OK);
     assert_int_equal(serial_rate, 38400);
+}
+
+void test_rotspeed(void **state) {
+    int rc = call_parse_logcfg("ROTSPEED = 38400\r\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(rot_serial_rate, 38400);
 }
 
 void test_fifo_interface(void **state) {
@@ -1034,6 +1056,12 @@ void test_rigmodel(void **state) {
     int rc = call_parse_logcfg("RIGMODEL=123\n");
     assert_int_equal(rc, PARSE_OK);
     assert_int_equal(myrig_model, 123);
+}
+
+void test_rotmodel(void **state) {
+    int rc = call_parse_logcfg("ROTMODEL=123\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(myrot_model, 123);
 }
 
 void test_addnode(void **state) {

--- a/test/test_readcalls.c
+++ b/test/test_readcalls.c
@@ -80,7 +80,7 @@ void foc_show_scoring(int start_column) {}
 int foc_total_score() { return 0; }
 
 
-int qrb(double a, double b, double c, double d) {
+int qrb(double,  double,  double,  double,  double *, double *) {
     return 1;
 }
 

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -2083,6 +2083,48 @@ may be one of \(lqUSB\(rq, \(lqLSB\(rq, \(lqRTTY\(rq, or \(lqRTTYR\(rq.
 If this parameter is not set, \(lqUSB\(rq is used if the FLDIGI parameter is
 set else \(lqLSB\(rq is used.
 .
+.SS Rotator Control Commands
+.
+.TP
+\fBROTATOR_CONTROL\fR[=<\fION\fR|\fIOFF\fR>]
+Switches the Hamlib rotator interface on.
+.
+.TP
+\fBROTMODEL\fR=\fIrot_number\fR
+Look at the Hamlib documentation for the rot_number.
+.IP
+Hint:
+.B rotctl\ \-l
+and its manual page
+.RB ( rotctl (1)).
+.
+.TP
+\fBROTSPEED\fR=\fIserial_rate\fR
+Speed of the serial port for rotator control.
+.
+.TP
+\fBROTPORT\fR=\fIserial_port\fR
+You can use
+.IR /dev/ttyS0 ,
+.IR /dev/ttyUSB1 ,
+etc. anything that looks like a tty.
+.
+.IP
+For
+.BR rotctld (8)
+set
+\fBROTPORT\fR=\fIlocalhost\fR and \fBROTMODEL\fR=\fI2\fR.
+.
+In this case
+.B ROTSPEED
+is ignored.
+.
+.TP
+\fBROTCONF\fR=\fIrot_configuration_parameters\fR
+Send rot configuration parameters to Hamlib.
+.br
+e.g. \fBROTCONF\fR=\fIcivaddr=0x40,retry=3,rot_pathname=/dev/ttyS0\fR
+.
 .SS User Interface Commands
 .
 .TP


### PR DESCRIPTION
This adds Hamlib rotator support to tlf. When a call or prefix is entered, pressing Ctrl-D rotates the antenna to the calculated bearing.