### PR TITLE
Allow logging of hamlib debug output

### DIFF
--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -252,7 +252,7 @@ extern bool qso_once;
 extern bool leading_zeros_serial;
 extern bool ignoredupe;
 extern bool continentlist_only;
-extern bool debugflag;
+extern int debuglevel;
 extern bool trx_control;
 extern bool nopacket;
 extern bool verbose;

--- a/src/main.c
+++ b/src/main.c
@@ -88,7 +88,7 @@ int tlfcolors[8][2] = { {COLOR_BLACK, COLOR_WHITE},
     {COLOR_BLUE, COLOR_YELLOW},
     {COLOR_WHITE, COLOR_BLACK}
 };
-bool debugflag = false;
+int debuglevel = 0;
 char *editor_cmd = NULL;
 int tune_val = 0;
 int use_bandoutput = 0;
@@ -450,7 +450,7 @@ static const struct argp_option options[] = {
     {"no-rig",      'r', 0, 0,  "Start without radio control" },
     {"list",	    'l', 0, 0,  "List built-in contests" },
     {"sync",        's', "URL", 0,  "Synchronize log with other node" },
-    {"debug",       'd', 0, 0,  "Debug mode" },
+    {"debug",       'd', "LEVEL (0..3)", 0,  "Debug rig communiction (Off, Error, Warn, Info)" },
     {"verbose",     'v', 0, 0,  "Produce verbose output" },
     { 0 }
 };
@@ -486,7 +486,9 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 	    strcpy(synclogfile, arg);
 	    break;
 	case 'd':		// debug rigctl
-	    debugflag = true;
+	    debuglevel = atoi(arg);
+	    if (debuglevel < 0) debuglevel = 0;
+	    if (debuglevel > 3) debuglevel = 3;
 	    break;
 	case 'v':		// verbose startup
 	    verbose = true;

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -112,11 +112,11 @@ int rig_debug_cb(enum rig_debug_level_e lvl,
 
     switch (lvl) {
 	case 2: fputs("ERR ", fp);
-		break;
+	    break;
 	case 3: fputs("WRN ", fp);
-		break;
+	    break;
 	case 4: fputs("INF ", fp);
-		break;
+	    break;
 	default: break;
     }
 
@@ -138,8 +138,8 @@ int init_tlf_rig(void) {
 
     if (debuglevel) {
 	/* set hamlib debug level and install callback */
-	rig_set_debug(debuglevel + 1);	// RIG_DEBUG_ERROR == 2, .._WARN == 3,
-					// .._VERBOSE=4
+	rig_set_debug(debuglevel + 1);	/* RIG_DEBUG_ERROR == 2, .._WARN == 3,
+					   .._VERBOSE == 4 */
 	rig_set_debug_callback(rig_debug_cb, (rig_ptr_t)NULL);
 
 	/* write start entry into debug log */

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -85,6 +85,13 @@ bool sendqrg(void) {
 
 /**************************************************************************/
 
+void show_rigerror(char *message, int errcode) {
+	char *str = g_strdup_printf("%s: %s", message, rigerror2(errcode));
+	showmsg(str);
+	g_free(str);
+}
+
+
 int init_tlf_rig(void) {
     freq_t rigfreq;		/* frequency  */
     vfo_t vfo;
@@ -133,14 +140,14 @@ int init_tlf_rig(void) {
 	    showmsg("Controlling PTT via Hamlib is not supported for that rig!");
 	}
     }
-
+// drop following lines
     if (dcd_type != RIG_DCD_NONE)
 	my_rig->state.dcdport.type.dcd = dcd_type;
     if (ptt_file)
 	strncpy(my_rig->state.pttport.pathname, ptt_file, TLFFILPATHLEN);
     if (dcd_file)
 	strncpy(my_rig->state.dcdport.pathname, dcd_file, TLFFILPATHLEN);
-
+// until here
     my_rig->state.rigport.parm.serial.rate = serial_rate;
 
     // parse RIGCONF parameters
@@ -151,7 +158,7 @@ int init_tlf_rig(void) {
     retcode = rig_open(my_rig);
 
     if (retcode != RIG_OK) {
-	TLF_LOG_WARN("rig_open: %s", rigerror(retcode));
+	show_rigerror("rig_open", retcode);
 	return -1;
     }
 
@@ -162,7 +169,7 @@ int init_tlf_rig(void) {
 	retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);
 
     if (retcode != RIG_OK) {
-	TLF_LOG_WARN("Problem with rig link: %s", rigerror(retcode));
+	show_rigerror("Problem with rig link", retcode);
 	if (!debugflag)
 	    return -1;
     }
@@ -177,7 +184,7 @@ int init_tlf_rig(void) {
 	    shownr("CW speed = ", rig_cwspeed);
 	    speed = rig_cwspeed;
 	} else {
-	    TLF_LOG_WARN("Could not read CW speed from rig: %s", rigerror(retcode));
+	    show_rigerror("Could not read CW speed from rig", retcode);
 	    if (!debugflag)
 		return -1;
 	}
@@ -268,7 +275,7 @@ static void debug_tlf_rig() {
     pthread_mutex_unlock(&tlf_rig_mutex);
 
     if (retcode != RIG_OK) {
-	TLF_LOG_WARN("Problem with rig get freq: %s", rigerror(retcode));
+	show_rigerror("Problem with rig get freq", retcode);
     } else {
 	shownr("freq =", (int) rigfreq);
     }
@@ -281,7 +288,7 @@ static void debug_tlf_rig() {
     pthread_mutex_unlock(&tlf_rig_mutex);
 
     if (retcode != RIG_OK) {
-	TLF_LOG_WARN("Problem with rig set freq: %s", rigerror(retcode));
+	show_rigerror("Problem with rig set freq", retcode);
     } else {
 	showmsg("Rig set freq ok!");
     }
@@ -291,7 +298,7 @@ static void debug_tlf_rig() {
     pthread_mutex_unlock(&tlf_rig_mutex);
 
     if (retcode != RIG_OK) {
-	TLF_LOG_WARN("Problem with rig get freq: %s", rigerror(retcode));
+	show_rigerror("Problem with rig get freq", retcode);
     } else {
 	shownr("freq =", (int) rigfreq);
 	if (rigfreq != testfreq) {

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -35,7 +35,7 @@
 #include "bands.h"
 #include "globalvars.h"
 
-#define RIG_DEBUG_LOG "rig.dbg"
+#define RIG_DEBUG_LOG "riglog.txt"
 
 static bool init_called = false;
 static bool can_send_morse = false;
@@ -109,6 +109,17 @@ int rig_debug_cb(enum rig_debug_level_e lvl,
     format_time(debugbuffer, sizeof(debugbuffer), "%H:%M:%S ");
     char *msg = g_strdup_vprintf(fmt, ap);
     fputs(debugbuffer, fp);
+
+    switch (lvl) {
+	case 2: fputs("ERR ", fp);
+		break;
+	case 3: fputs("WRN ", fp);
+		break;
+	case 4: fputs("INF ", fp);
+		break;
+	default: break;
+    }
+
     fputs(msg, fp);
     g_free(msg);
     fclose(fp);
@@ -125,9 +136,10 @@ int init_tlf_rig(void) {
     int rig_cwspeed;
     char debugbuffer[160];
 
-    if (debugflag) {
+    if (debuglevel) {
 	/* set hamlib debug level and install callback */
-	rig_set_debug(RIG_DEBUG_WARN);
+	rig_set_debug(debuglevel + 1);	// RIG_DEBUG_ERROR == 2, .._WARN == 3,
+					// .._VERBOSE=4
 	rig_set_debug_callback(rig_debug_cb, (rig_ptr_t)NULL);
 
 	/* write start entry into debug log */

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -212,13 +212,10 @@ int init_tlf_rig(void) {
 }
 
 void close_tlf_rig(RIG *my_rig) {
-
     pthread_mutex_lock(&tlf_rig_mutex);
     rig_close(my_rig);		/* close port */
     rig_cleanup(my_rig);	/* if you care about memory */
     pthread_mutex_unlock(&tlf_rig_mutex);
-
-    printf("Rig port %s closed\n", rigportname);
 }
 
 static int parse_rigconf() {

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -97,9 +97,6 @@ int init_tlf_rig(void) {
     vfo_t vfo;
     int retcode;		/* generic return code from functions */
 
-    const char *ptt_file = NULL, *dcd_file = NULL;
-    dcd_type_t dcd_type = RIG_DCD_NONE;
-
     const struct rig_caps *caps;
     int rig_cwspeed;
 
@@ -118,9 +115,11 @@ int init_tlf_rig(void) {
 	return -1;
     }
 
-    rigportname[strlen(rigportname) - 1] = '\0';	// remove '\n'
+    g_strchomp(rigportname);	// remove trailing '\n'
     strncpy(my_rig->state.rigport.pathname, rigportname,
 	    TLFFILPATHLEN - 1);
+
+    my_rig->state.rigport.parm.serial.rate = serial_rate;
 
     caps = my_rig->caps;
 
@@ -140,15 +139,6 @@ int init_tlf_rig(void) {
 	    showmsg("Controlling PTT via Hamlib is not supported for that rig!");
 	}
     }
-// drop following lines
-    if (dcd_type != RIG_DCD_NONE)
-	my_rig->state.dcdport.type.dcd = dcd_type;
-    if (ptt_file)
-	strncpy(my_rig->state.pttport.pathname, ptt_file, TLFFILPATHLEN);
-    if (dcd_file)
-	strncpy(my_rig->state.dcdport.pathname, dcd_file, TLFFILPATHLEN);
-// until here
-    my_rig->state.rigport.parm.serial.rate = serial_rate;
 
     // parse RIGCONF parameters
     if (parse_rigconf() < 0) {
@@ -303,5 +293,4 @@ static void debug_tlf_rig() {
 	}
     }
     sleep(10);
-
 }

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -88,7 +88,11 @@ bool sendqrg(void) {
 /**************************************************************************/
 
 void show_rigerror(char *message, int errcode) {
+#if HAMLIB_VERSION >= 450
     char *str = g_strdup_printf("%s: %s", message, rigerror2(errcode));
+#else
+    char *str = g_strdup_printf("%s: %s", message, rigerror(errcode));
+#endif
     showmsg(str);
     g_free(str);
 }

--- a/test/data.c
+++ b/test/data.c
@@ -50,7 +50,7 @@ int tlfcolors[8][2] = { {COLOR_BLACK, COLOR_WHITE},
 };
 
 
-bool debugflag = false;
+int debuglevel = 0;
 char *editor_cmd = NULL;
 char rttyoutput[120];
 int tune_val = 0;

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -35,7 +35,7 @@
 .
 .
 .\" Update the date when this page is committed.
-.TH TLF 1 "@PACKAGE_NAME@ @VERSION@, 2022-09-18" TLF "Ham radio"
+.TH TLF 1 "@PACKAGE_NAME@ @VERSION@, 2025-01-23" TLF "Ham radio"
 .
 .
 .SH NAME
@@ -46,10 +46,11 @@
 .SH SYNOPSIS
 .
 .SY @PACKAGE@
-.OP \-?dilnrvV
+.OP \-?ilnrvV
+.OP \-d level
 .OP \-f config_file
 .OP \-s user:password@host/dir/logfilename
-.OP \-\-debug
+.OP \-\-debug=\fIlevel\fP
 .OP \-\-config=\fIconfig_file\fP
 .OP \-\-import
 .OP \-\-list
@@ -152,6 +153,18 @@ Options given to @PACKAGE_NAME@ on the command line.
 Print a summary of options to the screen and exit.
 .
 .TP
+.BI \-d\  debug_level
+.TQ
+.BI \-\-debug=  debug_level
+Activate debug output for Hamlib rig communication. Output will be added to 
+.I riglog.txt 
+file in actual directory.
+.
+.IP
+Allowed values with rising verbosity are 0 (Off), 1 (Error) , 2 (Warn) or 3
+(Verbose)
+.
+.TP
 .BI \-f\  config_file
 .TQ
 .BI \-\-config= config_file
@@ -219,11 +232,6 @@ will be created.
 .TP
 .BR \-v , \ \-\-verbose
 Verbose startup.
-.
-.TP
-.BR \-d , \ \-\-debug
-Debug
-.BR rigctld (1).
 .
 .TP
 .BR \-V , \ \-\-version


### PR DESCRIPTION
* Fix display of errors during rig initialization and cleanup init_tlf_rig() function.
* Allow control of debug output verbosity via '-d lvl' switch during startup.
* Record selected Hamlib debug output into 'riglog.txt' file.