### PR TITLE
Add NODE_X syntax to specify network nodes

### DIFF
--- a/share/logcfg.dat
+++ b/share/logcfg.dat
@@ -68,8 +68,8 @@ TIME_MASTER
 #################################
 #  use 'addnode' only for OTHER nodes !!
 #
-#ADDNODE=10.0.0.115
-#ADDNODE=192.168.1.2
+#NODE_B=10.0.0.115
+#NODE_C=192.168.1.2
 #
 THISNODE=A
 #

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -689,38 +689,56 @@ void networkinfo(void) {
 
     wipe_display();
 
-    if (lan_active)
+    int n_nodes = 0;
+
+    if (lan_active) {
 	mvprintw(1, 10, "Network status: on   Node: %c", thisnode);
-    else
+	mvprintw(3, 32, "Total packets rcvd: %d | %d", recv_packets, recv_error);
+
+	for (int i = 0; i < nodes; i++) {
+	    if (*bc_hostaddress[i] == 0) {
+		continue;
+	    }
+	    GString *info = g_string_new(NULL);
+	    int column = 10;
+	    if (using_named_nodes) {
+		char *id = g_strdup_printf("%c%c) ",
+					   (i == thisnode - 'A' ? '*' : ' '),
+					   'A' + i
+					  );
+		g_string_append(info, id);
+		g_free(id);
+		column -= 4;
+	    }
+	    g_string_append(info, bc_hostaddress[i]);
+	    if (*bc_hostservice[i]) {
+		g_string_append(info, ":");
+		g_string_append(info, bc_hostservice[i]);
+	    }
+	    char *s = g_string_free(info, FALSE);
+	    mvaddstr(4 + n_nodes, column, s);
+	    g_free(s);
+
+	    mvprintw(4 + n_nodes, 38, "Packets sent: %d | %d ",
+		     send_packets[i], send_error[i]);
+	    ++n_nodes;
+	}
+    } else {
 	mvaddstr(1, 10, "Network status: off");
-
-    mvprintw(3, 22, "Total packets rcvd: %d | %d", recv_packets, recv_error);
-
-    for (int i = 0; i < nodes; i++) {
-	mvaddstr(4 + i, 10, bc_hostaddress[i]);
-	mvprintw(4 + i, 28, "Packets sent: %d | %d ",
-		 send_packets[i], send_error[i]);
     }
 
-    if (strlen(config_file) > 0)
-	mvprintw(6 + nodes, 10, "Config file: %s", config_file);
-    else
-	mvprintw(6 + nodes, 10,
-		 "Config file: /usr/local/share/tlf/logcfg.dat");//FIXME
-    mvprintw(7 + nodes, 10, "Contest    : %s", whichcontest);
-    mvprintw(8 + nodes, 10, "Logfile    : %s", logfile);
+    mvprintw(6 + n_nodes, 10, "Config file: %s", config_file);
+    mvprintw(7 + n_nodes, 10, "Contest    : %s", whichcontest);
+    mvprintw(8 + n_nodes, 10, "Logfile    : %s", logfile);
 
-    mvprintw(9 + nodes, 10, "Cluster    : %s", pr_hostaddress);
-    mvprintw(10 + nodes, 10, "TNCport    : %s", tncportname);
-    mvprintw(11 + nodes, 10, "RIGport    : %s", rigportname);
-    if (use_bandoutput == 1)
-	mvaddstr(12 + nodes, 10, "Band output: on");
-    else
-	mvaddstr(12 + nodes, 10, "Band output: off");
-
-    mvprintw(13 + nodes, 10, "callmaster : %s",
+    mvprintw(9 + n_nodes, 10, "Cluster    : %s", pr_hostaddress);
+    mvprintw(10 + n_nodes, 10, "TNCport    : %s", tncportname);
+    mvprintw(11 + n_nodes, 10, "RIGport    : %s", rigportname);
+    mvprintw(12 + n_nodes, 10, "Band output: %s",
+	     (use_bandoutput ? "on" : "off"));
+    mvprintw(13 + n_nodes, 10, "callmaster : %s",
 	     (callmaster_version[0] != 0 ? callmaster_version : "n/a"));
-    mvprintw(14 + nodes, 10, "cty.dat    : %s",
+    mvprintw(14 + n_nodes, 10, "cty.dat    : %s",
 	     (cty_dat_version[0] != 0 ? cty_dat_version : "n/a"));
 
     refreshp();

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -711,9 +711,10 @@ void networkinfo(void) {
 		column -= 4;
 	    }
 	    g_string_append(info, bc_hostaddress[i]);
-	    if (*bc_hostservice[i]) {
-		g_string_append(info, ":");
-		g_string_append(info, bc_hostservice[i]);
+	    if (bc_hostport[i] > 0) {
+		char *port = g_strdup_printf(":%d", bc_hostport[i]);
+		g_string_append(info, port);
+		g_free(port);
 	    }
 	    char *s = g_string_free(info, FALSE);
 	    mvaddstr(4 + n_nodes, column, s);

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -140,7 +140,7 @@ extern int continentlist_points;
 extern int dx_cont_points;
 extern int my_cont_points;
 extern int packetinterface;
-extern int use_bandoutput;
+extern bool use_bandoutput;
 extern int cluster;
 extern int nodes;
 extern bool using_named_nodes;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -143,6 +143,7 @@ extern int packetinterface;
 extern int use_bandoutput;
 extern int cluster;
 extern int nodes;
+extern bool using_named_nodes;
 extern int multlist;
 extern int xplanet;
 extern int cwkeyer;

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -82,10 +82,13 @@ int lan_recv_init(void) {
     if (!lan_active)
 	return 0;
 
+    int node = thisnode - 'A';
+    int port = (bc_hostport[node] > 0 ? bc_hostport[node] : lan_port);
+
     bzero(&lan_sin, sizeof(lan_sin));
     lan_sin.sin_family = AF_INET;
     lan_sin.sin_addr.s_addr = htonl(INADDR_ANY);
-    lan_sin.sin_port = htons(lan_port);
+    lan_sin.sin_port = htons(port);
 
     lan_socket_descriptor = socket(AF_INET, SOCK_DGRAM, 0);
     if (lan_socket_descriptor == -1) {

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -53,6 +53,7 @@ char bc_hostservice[MAXNODES][16] = {
     [0 ... MAXNODES - 1] = { [0 ... 15] = 0 }
 };
 int nodes = 0;
+bool using_named_nodes;
 //--------------------------------------
 /* default port to listen for incoming packets and to send packet to */
 char default_lan_service[16] = "6788";
@@ -186,6 +187,12 @@ int lan_send_init(void) {
 	return 0;
 
     for (int node = 0; node < nodes; node++) {
+	if (*bc_hostaddress[node] == 0) {
+	    continue;
+	}
+	if (using_named_nodes && node == thisnode - 'A') {
+	    continue;   // skip ourserlves
+	}
 
 	bc_hostbyname[node] = gethostbyname(bc_hostaddress[node]);
 	if (bc_hostbyname[node] == NULL) {
@@ -246,6 +253,12 @@ static int lan_send(char *lanbuffer) {
     }
 
     for (int node = 0; node < nodes; node++) {
+	if (*bc_hostaddress[node] == 0) {
+	    continue;
+	}
+	if (using_named_nodes && node == thisnode - 'A') {
+	    continue;   // skip ourserlves
+	}
 
 	bc_sendto_rc = sendto(bc_socket_descriptor[node],
 			      lanbuffer, strlen(lanbuffer),

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -49,16 +49,13 @@ bool cl_send_inhibit = false;
 struct sockaddr_in bc_address[MAXNODES];
 /* host names and UDP ports to send notifications to */
 char bc_hostaddress[MAXNODES][16];
-char bc_hostservice[MAXNODES][16] = {
-    [0 ... MAXNODES - 1] = { [0 ... 15] = 0 }
-};
+int bc_hostport[MAXNODES];
 int nodes = 0;
 bool using_named_nodes;
 //--------------------------------------
 /* default port to listen for incoming packets and to send packet to */
-char default_lan_service[16] = "6788";
-/* lan port parsed from config */
-int lan_port = 6788;
+/* can be changed using LAN_PORT config */
+int lan_port;
 
 bool lan_active = false;
 int send_error[MAXNODES];
@@ -77,21 +74,6 @@ char thisnode = 'A'; 		/*  start with 'A' if not defined in
 
 //---------------------end lan globals --------------
 
-int resolveService(const char *service) {
-    struct servent *service_ent;
-    service_ent = getservbyname(service, "udp");
-    int port = 0;
-    if (service_ent != NULL) {
-	port = ntohs(service_ent->s_port);
-    } else if (strlen(service) > 0) {
-	port = atoi(service);
-    }
-    if (port == 0) {
-	port = atoi(default_lan_service);
-    }
-    return port;
-}
-
 int lan_recv_init(void) {
     int lan_bind_rc;
     long lan_save_file_flags;
@@ -100,11 +82,10 @@ int lan_recv_init(void) {
     if (!lan_active)
 	return 0;
 
-    sprintf(default_lan_service, "%d", lan_port);
     bzero(&lan_sin, sizeof(lan_sin));
     lan_sin.sin_family = AF_INET;
     lan_sin.sin_addr.s_addr = htonl(INADDR_ANY);
-    lan_sin.sin_port = htons(resolveService(default_lan_service));
+    lan_sin.sin_port = htons(lan_port);
 
     lan_socket_descriptor = socket(AF_INET, SOCK_DGRAM, 0);
     if (lan_socket_descriptor == -1) {
@@ -205,7 +186,8 @@ int lan_send_init(void) {
 	memcpy(&bc_address[node].sin_addr.s_addr, bc_hostbyname[node]->h_addr,
 	       sizeof(bc_address[node].sin_addr.s_addr));
 
-	bc_address[node].sin_port = htons(resolveService(bc_hostservice[node]));
+	int port = (bc_hostport[node] > 0 ? bc_hostport[node] : lan_port);
+	bc_address[node].sin_port = htons(port);
 
 	syslog(LOG_INFO, "open socket: to %d.%d.%d.%d:%d\n",
 	       (ntohl(bc_address[node].sin_addr.s_addr) & 0xff000000) >> 24,

--- a/src/lancode.h
+++ b/src/lancode.h
@@ -84,7 +84,7 @@
 #include <hamlib/rig.h>
 
 extern char bc_hostaddress[MAXNODES][16];
-extern char bc_hostservice[MAXNODES][16];
+extern int bc_hostport[MAXNODES];
 extern char talkarray[5][62];
 extern char thisnode;
 extern char lan_message[256];

--- a/src/main.c
+++ b/src/main.c
@@ -661,7 +661,7 @@ static void init_variables() {
     thisnode = 'A';
     lan_port = 6788;
     bzero(bc_hostaddress, sizeof(bc_hostaddress));
-    bzero(bc_hostservice, sizeof(bc_hostservice));
+    bzero(bc_hostport, sizeof(bc_hostport));
     time_master = false;
 
     g_free(current_qso.call);

--- a/src/main.c
+++ b/src/main.c
@@ -644,6 +644,7 @@ static void init_variables() {
     portnum = 0;
     packetinterface = 0;
     nodes = 0;
+    using_named_nodes = false;
     shortqsonr = 0;
     tune_seconds = 6;   /* tune up for 6 s */
     unique_call_multi = MULT_NONE;
@@ -655,6 +656,13 @@ static void init_variables() {
     resend_call = RESEND_NOT_SET;
     cwstart = 0;    // off
     rig_mode_sync = true;
+
+    lan_active = false;
+    thisnode = 'A';
+    lan_port = 6788;
+    bzero(bc_hostaddress, sizeof(bc_hostaddress));
+    bzero(bc_hostservice, sizeof(bc_hostservice));
+    time_master = false;
 
     g_free(current_qso.call);
     current_qso.call = g_malloc0(CALL_SIZE);

--- a/src/main.c
+++ b/src/main.c
@@ -91,7 +91,7 @@ int tlfcolors[8][2] = { {COLOR_BLACK, COLOR_WHITE},
 bool debugflag = false;
 char *editor_cmd = NULL;
 int tune_val = 0;
-int use_bandoutput = 0;
+bool use_bandoutput = false;
 bool no_arrows = false;
 int bandindexarray[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 bool cqwwm2 = false;
@@ -656,6 +656,7 @@ static void init_variables() {
     resend_call = RESEND_NOT_SET;
     cwstart = 0;    // off
     rig_mode_sync = true;
+    use_bandoutput = false;
 
     lan_active = false;
     thisnode = 'A';

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -474,7 +474,7 @@ static int cfg_bandoutput(const cfg_arg_t arg) {
 
     if (g_regex_match_simple("^\\d{10}$", str, G_REGEX_CASELESS,
 			     (GRegexMatchFlags)0)) {
-	use_bandoutput = 1;
+	use_bandoutput = true;
 	for (int i = 0; i <= 9; i++) {	// 10x
 	    bandindexarray[i] = str[i] - '0';
 	}

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -612,26 +612,59 @@ static int cfg_tncport(const cfg_arg_t arg) {
     return PARSE_OK;
 }
 
-static int cfg_addnode(const cfg_arg_t arg) {
-    if (nodes >= MAXNODES) {
-	error_details = g_strdup_printf("max %d nodes allowed", MAXNODES);
-	return PARSE_WRONG_PARAMETER;
-    }
+static void parse_node(int index) {
     /* split host name and port number, separated by colon */
     char **an_fields;
     an_fields = g_strsplit(parameter, ":", 2);
     /* copy host name */
-    g_strlcpy(bc_hostaddress[nodes], g_strchomp(an_fields[0]),
+    g_strlcpy(bc_hostaddress[index], g_strchomp(an_fields[0]),
 	      sizeof(bc_hostaddress[0]));
     if (an_fields[1] != NULL) {
 	/* copy host port, if found */
-	g_strlcpy(bc_hostservice[nodes], g_strchomp(an_fields[1]),
+	g_strlcpy(bc_hostservice[index], g_strchomp(an_fields[1]),
 		  sizeof(bc_hostservice[0]));
     }
     g_strfreev(an_fields);
 
-    nodes++;
     lan_active = true;
+}
+
+static int cfg_addnode(const cfg_arg_t arg) {
+    if (using_named_nodes) {
+	error_details = g_strdup("already using named nodes");
+	return PARSE_WRONG_PARAMETER;
+    }
+    if (nodes >= MAXNODES) {
+	error_details = g_strdup_printf("max %d nodes allowed", MAXNODES);
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    parse_node(nodes);
+    nodes++;
+
+    return PARSE_OK;
+}
+
+static int cfg_node_x(const cfg_arg_t arg) {
+    gchar *x = g_match_info_fetch(match_info, 1);
+    int index = *x - 'A';
+    g_free(x);
+
+    if (index >= MAXNODES) {
+	error_details = g_strdup_printf("name is A..%c", 'A' + MAXNODES - 1);
+	return PARSE_WRONG_PARAMETER;
+    }
+    if (!using_named_nodes && nodes > 0) {
+	error_details = g_strdup("already using unnamed nodes");
+	return PARSE_WRONG_PARAMETER;
+    }
+
+    using_named_nodes = true;
+
+    parse_node(index);
+    if (index + 1 > nodes) {
+	nodes = index + 1;
+    }
 
     return PARSE_OK;
 }
@@ -1409,6 +1442,7 @@ static config_t logcfg_configs[] = {
     {"SFI",             NEED_PARAM, cfg_sfi},
     {"TNCPORT",         NEED_PARAM, cfg_tncport},
     {"ADDNODE",         NEED_PARAM, cfg_addnode},
+    {"NODE_([A-Z])",    NEED_PARAM, cfg_node_x},
     {"THISNODE",        NEED_PARAM, cfg_thisnode},
     {"MULT_LIST",       NEED_PARAM, cfg_mult_list},
     {"MARKER(|DOT|CALL)S",  NEED_PARAM, cfg_markers},

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -621,8 +621,7 @@ static void parse_node(int index) {
 	      sizeof(bc_hostaddress[0]));
     if (an_fields[1] != NULL) {
 	/* copy host port, if found */
-	g_strlcpy(bc_hostservice[index], g_strchomp(an_fields[1]),
-		  sizeof(bc_hostservice[0]));
+	bc_hostport[index] = atoi(an_fields[1]);
     }
     g_strfreev(an_fields);
 

--- a/test/data.c
+++ b/test/data.c
@@ -54,7 +54,7 @@ bool debugflag = false;
 char *editor_cmd = NULL;
 char rttyoutput[120];
 int tune_val = 0;
-int use_bandoutput = 0;
+bool use_bandoutput = false;
 bool no_arrows = false;
 int bandindexarray[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 bool cqwwm2 = false;

--- a/test/test_lancode.c
+++ b/test/test_lancode.c
@@ -23,6 +23,8 @@ int setup_default(void **state) {
     trx_control = true;
     nodes = 1;
     lan_active = true;
+    using_named_nodes = false;
+    strcpy(bc_hostaddress[0], "host0");
 
     sendto_call_count = 0;
     FREE_DYNAMIC_STRING(sendto_last_message);

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -40,6 +40,7 @@ int nodes = 0;
 struct sockaddr_in bc_address[MAXNODES];
 int lan_port = 6788;
 bool lan_active;
+bool using_named_nodes;
 bool landebug = false;
 char thisnode = 'A';
 bool time_master;
@@ -174,6 +175,8 @@ int setup_default(void **state) {
     use_bandoutput = 0;
     thisnode = 'A';
     nodes = 0;
+    lan_active = false;
+    using_named_nodes = false;
     xplanet = MARKER_NONE;
     dx_arrlsections = false;
     mult_side = false;
@@ -1048,9 +1051,20 @@ void test_addnode(void **state) {
     int rc = call_parse_logcfg("ADDNODE=hostx:1234\n");
     assert_int_equal(rc, PARSE_OK);
     assert_int_equal(lan_active, true);
+    assert_int_equal(using_named_nodes, false);
     assert_int_equal(nodes, 1);
     assert_string_equal(bc_hostaddress[0], "hostx");
     assert_string_equal(bc_hostservice[0], "1234");
+}
+
+void test_node_x(void **state) {
+    int rc = call_parse_logcfg("NODE_C=hostx:1234\n");
+    assert_int_equal(rc, PARSE_OK);
+    assert_int_equal(lan_active, true);
+    assert_int_equal(using_named_nodes, true);
+    assert_int_equal(nodes, 3);
+    assert_string_equal(bc_hostaddress[2], "hostx");
+    assert_string_equal(bc_hostservice[2], "1234");
 }
 
 void test_thisnode(void **state) {

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -45,9 +45,7 @@ bool landebug = false;
 char thisnode = 'A';
 bool time_master;
 char bc_hostaddress[MAXNODES][16];
-char bc_hostservice[MAXNODES][16] = {
-    [0 ... MAXNODES - 1] = { [0 ... 15] = 0 }
-};
+int bc_hostport[MAXNODES];
 
 
 char netkeyer_hostaddress[16] = "127.0.0.1";
@@ -233,7 +231,7 @@ int setup_default(void **state) {
     }
     for (int i = 0; i < MAXNODES; ++i) {
 	bc_hostaddress[i][0] = 0;
-	bc_hostservice[i][0] = 0;
+	bc_hostport[i] = 0;
     }
     for (int i = 0; i < 255; ++i) {
 	countrylist[i][0] = 0;
@@ -1054,7 +1052,7 @@ void test_addnode(void **state) {
     assert_int_equal(using_named_nodes, false);
     assert_int_equal(nodes, 1);
     assert_string_equal(bc_hostaddress[0], "hostx");
-    assert_string_equal(bc_hostservice[0], "1234");
+    assert_int_equal(bc_hostport[0], 1234);
 }
 
 void test_node_x(void **state) {
@@ -1064,7 +1062,7 @@ void test_node_x(void **state) {
     assert_int_equal(using_named_nodes, true);
     assert_int_equal(nodes, 3);
     assert_string_equal(bc_hostaddress[2], "hostx");
-    assert_string_equal(bc_hostservice[2], "1234");
+    assert_int_equal(bc_hostport[2], 1234);
 }
 
 void test_thisnode(void **state) {

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -170,7 +170,7 @@ int setup_default(void **state) {
     ssbpoints = 1;
     cwpoints = 1;
     trxmode = CWMODE;
-    use_bandoutput = 0;
+    use_bandoutput = false;
     thisnode = 'A';
     nodes = 0;
     lan_active = false;
@@ -961,7 +961,7 @@ void test_rules(void **state) {
 void test_bandoutput(void **state) {
     int rc = call_parse_logcfg("BANDOUTPUT=9876543210\n");
     assert_int_equal(rc, PARSE_OK);
-    assert_int_equal(use_bandoutput, 1);
+    assert_true(use_bandoutput);
     for (int i = 0; i <= 9; ++i) {
 	assert_int_equal(bandindexarray[i], 9 - i);
     }

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1684,10 +1684,9 @@ Range: 0\(en23.
 This node transmits the time over the network (only one master allowed!).
 .
 .TP
-\fBADDNODE\fR=\fINode_address\fR[\fI:Port_number\fR]
+\fBNODE_\fIX\fR=\fINode_address\fR[\fI:Port_number\fR]
 Adds an IP address (and optionally a port number) to which we broadcast stuff.
-.RB ( WARNING :
-Only add addresses of other nodes).
+\fIX\fR is the node designator, possible values are A\(enH.
 .
 .TP
 \fBTHISNODE\fR=\fIA\fR


### PR DESCRIPTION
As discussed in #444 this PR introduces a new way of specifying network nodes. 
Originally one had to ensure that own node is _not_ added using ADDNODE. As nodes were anonymous there was no easy way to tell which node has issues when checking the :INFo screen.

The NODE_X syntax is an alternative to ADDNODE. If fact the two are exclusive: either only ADDNODEs (the old way) or only NODE_X statements can be used. Mixing them results in an error message.

A typical setup would look like
```
NODE_A=biggun1
NODE_B=biggun2
NODE_C=rxonly
THISNODE=B
```

An example :INFo screen with all 8 nodes (A-H) defined. Note that to packets are send to our own node (C).
 ![image](https://github.com/user-attachments/assets/ddd79c44-78fb-4424-8e75-6780f6a1ccd6)

The value of `using_named_nodes` controls whether the original (false) or the new approach (true) is used.
It is derived during loading logcf.dat.
The named nodes occupy an entry in `bc_hostaddress[]`corresponding to their node name. The node ids doesn't have to be continuous, there can be missing nodes.

Although ADDNODE still works as before the man page documents NODE_X only in order not to create too much confusion and to favor the usage of the new syntax.

