### PR TITLE
Fix digi messages

### DIFF
--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -198,6 +198,14 @@ void ExpandRst(char rst[4]) {
     replace_all(buffer, BUFSIZE, "[", rst_out);   /* his RST */
 }
 
+static void expand_pipe_char() {
+    if (trxmode == DIGIMODE)
+	replace_all(buffer, BUFSIZE, "|", "\r");    /* CR */
+    else
+	replace_all(buffer, BUFSIZE, "|", "");	    /* drop it */
+}
+
+
 void ExpandMacro_CurrentQso(void) {
 
     replace_all(buffer, BUFSIZE, "%", my.call);   /* mycall */
@@ -229,10 +237,7 @@ void ExpandMacro_CurrentQso(void) {
 
     replace_all(buffer, BUFSIZE, "!", current_qso.comment);
 
-    if (trxmode == DIGIMODE)
-	replace_all(buffer, BUFSIZE, "|", "\r");    /* CR */
-    else
-	replace_all(buffer, BUFSIZE, "|", "");	    /* drop it */
+    expand_pipe_char();
 }
 
 struct qso_t *get_previous_qso() {
@@ -269,6 +274,8 @@ void ExpandMacro_PreviousQso(void) {
 	ExpandQsoNumber(prevnr);
 	g_free(prevnr);
     }
+
+    expand_pipe_char();
 }
 
 


### PR DESCRIPTION
Pipe character standing for new line was not replaced for F2-F12 messages leading to unexpected text like
![image](https://github.com/user-attachments/assets/d626e0be-bcb4-46da-beaa-84801e56aaac)

If call input field is empty then these messages are expanded using `ExpandMacro_PreviousQso()` and it was missing the last step of substituting the pipe present in `ExpandMacro_CurrentQso()`.
Moved pipe substitution to a separate function called from both expanders.