### PR TITLE
Allw logging of debug information

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,7 +10,7 @@ tlf_SOURCES = \
 	change_rst.c checklogfile.c checkqtclogfile.c \
 	cleanup.c clear_display.c clusterinfo.c \
         cqww_simulator.c cw_utils.c \
-	dxcc.c deleteqso.c \
+	debug.c	dxcc.c deleteqso.c \
 	edit_last.c editlog.c err_utils.c \
 	fldigixmlrpc.c freq_display.c focm.c \
 	genqtclist.c \
@@ -47,7 +47,7 @@ noinst_HEADERS = \
 	change_rst.h checklogfile.h checkqtclogfile.h \
 	cleanup.h clear_display.h clusterinfo.h \
 	cqww_simulator.h cw_utils.h \
-	dxcc.h deleteqso.h \
+	debug.h dxcc.h deleteqso.h \
 	edit_last.h editlog.h  err_utils.h \
 	fldigixmlrpc.h freq_display.h focm.h \
 	genqtclist.h \

--- a/src/audio.c
+++ b/src/audio.c
@@ -459,7 +459,7 @@ void vk_play_file(char *audiofile) {
     }
 
     if (access(audiofile, R_OK) != 0) {
-	TLF_LOG_INFO("cannot open sound file %s!", audiofile);
+	TLF_SHOW_INFO("cannot open sound file %s!", audiofile);
 	return;
     }
 
@@ -468,7 +468,7 @@ void vk_play_file(char *audiofile) {
     /* play sound in separate thread so it can be killed from the main one */
     if (pthread_create(&vk_thread, NULL, play_thread, (void *)file) != 0) {
 	g_free(file);
-	TLF_LOG_INFO("could not start sound thread!");
+	TLF_SHOW_INFO("could not start sound thread!");
     }
 }
 

--- a/src/background_process.c
+++ b/src/background_process.c
@@ -151,7 +151,7 @@ void *background_process(void *ptr) {
 		}
 	    }
 	    if ((*lan_message != '\0') && (lan_message[0] == thisnode)) {
-		TLF_LOG_WARN("%s", "Warning: NODE ID CONFLICT ?! You should use another ID! ");
+		TLF_SHOW_WARN("%s", "Warning: NODE ID CONFLICT ?! You should use another ID! ");
 	    }
 
 	    if ((*lan_message != '\0')
@@ -183,7 +183,7 @@ void *background_process(void *ptr) {
 		    case CLUSTERMSG:
 			prmessage = g_strndup(lan_message + 2, 80);
 			if (strstr(prmessage, my.call) != NULL) {	// alert for cluster messages
-			    TLF_LOG_INFO(prmessage);
+			    TLF_SHOW_INFO(prmessage);
 			}
 
 			addtext(prmessage);
@@ -205,7 +205,7 @@ void *background_process(void *ptr) {
 			talkarray[4][2] = '\0';
 			g_strlcat(talkarray[4], lan_message + 2,
 				  sizeof(talkarray[4]));
-			TLF_LOG_INFO(" MSG from %s", talkarray[4]);
+			TLF_SHOW_INFO(" MSG from %s", talkarray[4]);
 			break;
 		    case FREQMSG:
 			if ((lan_message[0] >= 'A')

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -380,7 +380,7 @@ int changepars(void) {
 
 	    read_logcfg();
 	    read_rules();	/* also reread rules file */
-	    TLF_LOG_INFO("Logcfg.dat loaded, parameters written.");
+	    TLF_SHOW_INFO("Logcfg.dat loaded, parameters written.");
 	    center_fkey_header();
 	    clear_display();
 	    break;
@@ -441,13 +441,13 @@ int changepars(void) {
 	}
 	case 34: {		/* SIMULATOR  */
 	    if (!CONTEST_IS(CQWW)) {
-		TLF_LOG_INFO(
+		TLF_SHOW_INFO(
 		    "Simulator mode is only supported for CQWW contest!");
 		break;
 	    }
 
 	    if (callmaster == NULL) {
-		TLF_LOG_INFO(
+		TLF_SHOW_INFO(
 		    "Simulator mode needs callmaster database");
 		break;
 	    }
@@ -457,7 +457,7 @@ int changepars(void) {
 		simulator = true;
 		cqmode = CQ;
 		if (ctcomp) {
-		    TLF_LOG_INFO(
+		    TLF_SHOW_INFO(
 			"The simulator only works in TRmode. Switching to TRmode");
 		    ctcomp = false;
 		} else {
@@ -469,7 +469,7 @@ int changepars(void) {
 		if (cwkeyer == NET_KEYER) {
 
 		    if (netkeyer(K_WORDMODE, NULL) < 0) {
-			TLF_LOG_INFO("keyer not active; switching to SSB");
+			TLF_SHOW_INFO("keyer not active; switching to SSB");
 			trxmode = SSBMODE;
 			clear_display();
 		    }
@@ -483,7 +483,7 @@ int changepars(void) {
 		if (cwkeyer == NET_KEYER) {
 
 		    if (netkeyer(K_RESET, NULL) < 0) {
-			TLF_LOG_INFO("keyer not active; switching to SSB");
+			TLF_SHOW_INFO("keyer not active; switching to SSB");
 			trxmode = SSBMODE;
 			clear_display();
 		    }

--- a/src/checklogfile.c
+++ b/src/checklogfile.c
@@ -255,7 +255,7 @@ void checklogfile(void) {
     FILE *fp;
 
     if ((fp = fopen(logfile, "a")) == NULL) {
-	TLF_LOG_WARN("I can not find the logfile ...");
+	TLF_SHOW_WARN("I can not find the logfile ...");
     } else {
 	fstat(fileno(fp), &statbuf);
 	fclose(fp);
@@ -264,11 +264,11 @@ void checklogfile(void) {
 
 	if ((qsobytes % LOGLINELEN) != 0) {
 	    if ((infile = fopen(logfile, "r")) == NULL) {
-		TLF_LOG_WARN("Unable to open logfile...");
+		TLF_SHOW_WARN("Unable to open logfile...");
 	    } else {
 		if ((outfile = fopen("./cpyfile", "w")) == NULL) {
 		    fclose(infile);
-		    TLF_LOG_WARN("Unable to open cpyfile...");
+		    TLF_SHOW_WARN("Unable to open cpyfile...");
 
 		} else {
 		    errno = 0;

--- a/src/clusterinfo.c
+++ b/src/clusterinfo.c
@@ -133,7 +133,7 @@ void clusterinfo(void) {
 		if (spotarray[k] >= 0 && spotarray[k] < MAX_SPOTS)
 		    g_strlcpy(inputbuffer, spot_ptr[spotarray[k]], 79);
 		else {
-		    TLF_LOG_INFO("error in packet table");
+		    TLF_SHOW_INFO("error in packet table");
 		}
 
 		if (strlen(inputbuffer) > 14) {
@@ -171,7 +171,7 @@ void show_xplanet() {
 
     /* prune markerfile by opening it for write */
     if ((fp = fopen(markerfile, "w")) == NULL) {
-	TLF_LOG_INFO("Opening marker file not possible.");
+	TLF_SHOW_INFO("Opening marker file not possible.");
 	nofile = true;		/* remember: no write possible */
 	return;
     }

--- a/src/debug.c
+++ b/src/debug.c
@@ -51,9 +51,9 @@ static bool needs_logging(enum debuglevel lvl) {
     return (lvl <= debuglevel);
 }
 
-void debug_log (enum debuglevel lvl,
-	const char *fmt,
-	...) {
+void debug_log(enum debuglevel lvl,
+	       const char *fmt,
+	       ...) {
 
     static pthread_mutex_t debug_mutex = PTHREAD_MUTEX_INITIALIZER;
     char debugbuffer[160];
@@ -68,8 +68,8 @@ void debug_log (enum debuglevel lvl,
 
     FILE *fp = fopen(DEBUG_LOG, "a");
     if (fp == NULL) {	    /* ignore failure to write debug log */
-	    pthread_mutex_unlock(&debug_mutex);
-	    return;	    /* to not disturb logging activity */
+	pthread_mutex_unlock(&debug_mutex);
+	return;	    /* to not disturb logging activity */
     }
 
     format_time(debugbuffer, sizeof(debugbuffer), "%H:%M:%S ");

--- a/src/debug.c
+++ b/src/debug.c
@@ -71,11 +71,11 @@ bool debug_init() {
 }
 
 /* check if message needs to be logged */
-static bool needs_logging(enum debuglevel lvl) {
+static bool needs_logging(enum tlf_debug_level lvl) {
     return (lvl <= debuglevel);
 }
 
-void debug_log(enum debuglevel lvl,
+void debug_log(enum tlf_debug_level lvl,
 	       const char *fmt,
 	       ...) {
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -18,4 +18,83 @@
  */
 
 #include "debug.h"
+#include "get_time.h"
+#include "globalvars.h"
+#include "pthread.h"
+#include "stdbool.h"
+
+/* check if any debug level is active */
+static int debug_is_active() {
+    return (debuglevel > 0);
+}
+
+bool debug_init() {
+    char debugbuffer[80];
+
+    if (debug_is_active()) {
+	/* write timestamp as start entry into debug log */
+	FILE *fp = fopen(DEBUG_LOG, "a");
+	if (fp == NULL) {
+	    return FALSE;
+	}
+
+	format_time(debugbuffer, sizeof(debugbuffer),
+		    "\nStarted %d/%m/%Y %H:%M\n");
+	fputs(debugbuffer, fp);
+	fclose(fp);
+    }
+    return TRUE;
+}
+
+/* check if message needs to be logged */
+static bool needs_logging(enum debuglevel lvl) {
+    return (lvl <= debuglevel);
+}
+
+void debug_log (enum debuglevel lvl,
+	const char *fmt,
+	...) {
+
+    static pthread_mutex_t debug_mutex = PTHREAD_MUTEX_INITIALIZER;
+    char debugbuffer[160];
+    va_list args;
+
+
+    if (!needs_logging(lvl)) {
+	return;
+    }
+
+    pthread_mutex_lock(&debug_mutex);
+
+    FILE *fp = fopen(DEBUG_LOG, "a");
+    if (fp == NULL) {	    /* ignore failure to write debug log */
+	    pthread_mutex_unlock(&debug_mutex);
+	    return;	    /* to not disturb logging activity */
+    }
+
+    format_time(debugbuffer, sizeof(debugbuffer), "%H:%M:%S ");
+    va_start(args, fmt);
+    char *msg = g_strdup_vprintf(fmt, args);
+    va_end(args);
+
+    fputs(debugbuffer, fp);
+    switch (lvl) {
+	case TLF_DBG_ERR: fputs("ERR ", fp);
+	    break;
+	case TLF_DBG_WARN: fputs("WRN ", fp);
+	    break;
+	case TLF_DBG_INFO: fputs("INF ", fp);
+	    break;
+	case TLF_DBG_DEBUG: fputs("DBG", fp);
+	    break;
+	default:
+	    break;
+    }
+    fputs(msg, fp);
+
+    g_free(msg);
+    fclose(fp);
+
+    pthread_mutex_unlock(&debug_mutex);
+}
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -24,7 +24,7 @@
 #include "stdbool.h"
 
 /* check if any debug level is active */
-static int debug_is_active() {
+bool debug_is_active() {
     return (debuglevel > 0);
 }
 
@@ -85,7 +85,7 @@ void debug_log (enum debuglevel lvl,
 	    break;
 	case TLF_DBG_INFO: fputs("INF ", fp);
 	    break;
-	case TLF_DBG_DEBUG: fputs("DBG", fp);
+	case TLF_DBG_DEBUG: fputs("DBG ", fp);
 	    break;
 	default:
 	    break;

--- a/src/debug.c
+++ b/src/debug.c
@@ -57,7 +57,7 @@ bool debug_init() {
 	}
 
 	format_time(debugbuffer, sizeof(debugbuffer),
-		    "\nStarted %Y%m%d");
+		    "\nStarted %Y%m%d ");
 	fputs(debugbuffer, fp);
 
 	char *ts = timestamp_utc();

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,21 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2025 Thomas Beierlein <tb@forth-ev.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include "debug.h"
+

--- a/src/debug.c
+++ b/src/debug.c
@@ -25,7 +25,7 @@
 
 /* check if any debug level is active */
 bool debug_is_active() {
-    return (debuglevel > 0);
+    return (debuglevel > TLF_DBG_NONE);
 }
 
 bool debug_init() {
@@ -74,7 +74,10 @@ void debug_log(enum debuglevel lvl,
 
     format_time(debugbuffer, sizeof(debugbuffer), "%H:%M:%S ");
     va_start(args, fmt);
+
+    /* drop trailing NL in case caller added one in fmt or varargs */
     char *msg = g_strdup_vprintf(fmt, args);
+    g_strchomp(msg);
     va_end(args);
 
     fputs(debugbuffer, fp);
@@ -91,6 +94,7 @@ void debug_log(enum debuglevel lvl,
 	    break;
     }
     fputs(msg, fp);
+    fputs("\n", fp);
 
     g_free(msg);
     fclose(fp);

--- a/src/debug.c
+++ b/src/debug.c
@@ -41,7 +41,7 @@ char *timestamp_utc() {
     gettimeofday(&current_time, NULL);
     strftime(timestamp, sizeof(timestamp), "%T",
 	     gmtime(&current_time.tv_sec));
-    return g_strdup_printf("%s.%03ld ", timestamp,
+    return g_strdup_printf("%s.%03ld", timestamp,
 			   current_time.tv_usec / 1000);
 }
 
@@ -104,6 +104,7 @@ void debug_log(enum debuglevel lvl,
 
     char *ts = timestamp_utc();
     fputs(ts, fp);
+    fputs(" ", fp);
     g_free(ts);
 
     switch (lvl) {

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,23 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2025 Thomas Beierlein <tb@forth-ev.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef DEBUG_H
+#define DEBUG_H
+
+#endif /* DEBUG_H */

--- a/src/debug.h
+++ b/src/debug.h
@@ -20,4 +20,22 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
+#include "stdarg.h"
+#include "stdbool.h"
+
+#define DEBUG_LOG "debug.txt"
+
+enum debuglevel {
+    TLF_DBG_NONE,
+    TLF_DBG_ERR,
+    TLF_DBG_WARN,
+    TLF_DBG_INFO,
+    TLF_DBG_DEBUG
+};
+
+bool debug_init();
+void debug_log (enum debuglevel lvl,
+	const char *fmt,
+	...);
+
 #endif /* DEBUG_H */

--- a/src/debug.h
+++ b/src/debug.h
@@ -49,8 +49,8 @@ enum debuglevel {
 
 bool debug_is_active();
 bool debug_init();
-void debug_log (enum debuglevel lvl,
-	const char *fmt,
-	...);
+void debug_log(enum debuglevel lvl,
+	       const char *fmt,
+	       ...);
 
 #endif /* DEBUG_H */

--- a/src/debug.h
+++ b/src/debug.h
@@ -33,6 +33,20 @@ enum debuglevel {
     TLF_DBG_DEBUG
 };
 
+/* Log Error, Warning, Info or Debug message to debuglog file if enabled */
+#define TLF_LOG_ERR(fmt, ...)  do { \
+	debug_log(TLF_DBG_ERR, fmt, ##__VA_ARGS__); \
+    } while(0)
+#define TLF_LOG_WARN(fmt, ...) do {\
+	debug_log(TLF_DBG_WARN, fmt, ##__VA_ARGS__); \
+    }while(0)
+#define TLF_LOG_INFO(fmt, ...) do {\
+	debug_log(TLF_DBG_INFO, fmt, ##__VA_ARGS__); \
+    }while(0)
+#define TLF_LOG_DEBUG(fmt, ...) do {\
+	debug_log(TLF_DBG_DEBUG, fmt, ##__VA_ARGS__); \
+    }while(0)
+
 bool debug_is_active();
 bool debug_init();
 void debug_log (enum debuglevel lvl,

--- a/src/debug.h
+++ b/src/debug.h
@@ -33,6 +33,7 @@ enum debuglevel {
     TLF_DBG_DEBUG
 };
 
+bool debug_is_active();
 bool debug_init();
 void debug_log (enum debuglevel lvl,
 	const char *fmt,

--- a/src/debug.h
+++ b/src/debug.h
@@ -25,7 +25,7 @@
 
 #define DEBUG_LOG "debug.txt"
 
-enum debuglevel {
+enum tlf_debug_level {
     TLF_DBG_NONE,
     TLF_DBG_ERR,
     TLF_DBG_WARN,
@@ -49,7 +49,7 @@ enum debuglevel {
 
 bool debug_is_active();
 bool debug_init();
-void debug_log(enum debuglevel lvl,
+void debug_log(enum tlf_debug_level lvl,
 	       const char *fmt,
 	       ...);
 

--- a/src/deleteqso.c
+++ b/src/deleteqso.c
@@ -146,7 +146,7 @@ void delete_qso(void) {
 
 	if ((lfile = open(logfile, O_RDWR)) < 0) {
 
-	    TLF_LOG_WARN("I can not find the logfile...");
+	    TLF_SHOW_WARN("I can not find the logfile...");
 	} else {
 
 	    fstat(lfile, &statbuf);

--- a/src/edit_last.c
+++ b/src/edit_last.c
@@ -143,7 +143,7 @@ static void putback_qso(int nr, char *buffer) {
     assert(nr < NR_QSOS);
 
     if ((fp = fopen(logfile, "r+")) == NULL) {
-	TLF_LOG_WARN("Can not open logfile...");
+	TLF_SHOW_WARN("Can not open logfile...");
     } else {
 	fseek(fp, (long)nr * LOGLINELEN, SEEK_SET);
 	fputs(buffer, fp);

--- a/src/editlog.c
+++ b/src/editlog.c
@@ -64,7 +64,7 @@ void edit(char *filename) {
     refreshp();
 
     if (WEXITSTATUS(retval) == 127) {
-	TLF_LOG_WARN("Can not start editor, check EDITOR= command");
+	TLF_SHOW_WARN("Can not start editor, check EDITOR= command");
     }
     g_free(cmdstr);
 }

--- a/src/err_utils.c
+++ b/src/err_utils.c
@@ -26,13 +26,11 @@
 #include "tlf_curses.h"
 #include "ui_utils.h"
 
-void handle_logging(enum log_lvl lvl, ...) {
-    char *fmt;
+void handle_logging(enum log_lvl lvl, char *fmt, ...) {
     char *str;
     va_list args;
 
-    va_start(args, lvl);
-    fmt = va_arg(args, char *);
+    va_start(args, fmt);
     str = g_strdup_vprintf(fmt, args);
     va_end(args);
 

--- a/src/err_utils.c
+++ b/src/err_utils.c
@@ -26,7 +26,7 @@
 #include "tlf_curses.h"
 #include "ui_utils.h"
 
-void handle_logging(enum debuglevel lvl, char *fmt, ...) {
+void handle_logging(enum tlf_debug_level lvl, char *fmt, ...) {
     char *str;
     va_list args;
 

--- a/src/err_utils.c
+++ b/src/err_utils.c
@@ -26,7 +26,7 @@
 #include "tlf_curses.h"
 #include "ui_utils.h"
 
-void handle_logging(enum log_lvl lvl, char *fmt, ...) {
+void handle_logging(enum debuglevel lvl, char *fmt, ...) {
     char *str;
     va_list args;
 
@@ -41,13 +41,13 @@ void handle_logging(enum log_lvl lvl, char *fmt, ...) {
     g_free(str);
 
     switch (lvl) {
-	case L_INFO:
+	case TLF_DBG_INFO:
 	    sleep(1);
 	    break;
-	case L_WARN:
+	case TLF_DBG_WARN:
 	    sleep(3);
 	    break;
-	case L_ERR:
+	case TLF_DBG_ERR:
 	    sleep(3);
 	    break;
 	default:

--- a/src/err_utils.h
+++ b/src/err_utils.h
@@ -25,24 +25,21 @@
 void handle_logging(enum debuglevel lvl, char *fmt, ...);
 
 
-/* show Error, Warning or similar to user, but write into debuglog if enabled
+/* show Error, Warning or Info message to user and write it into
+ * debuglog if enabled
  */
-#define TLF_LOG_ERR(fmt, ...)  do { \
+#define TLF_SHOW_ERR(fmt, ...)  do { \
 	debug_log(TLF_DBG_ERR, fmt, ##__VA_ARGS__); \
 	handle_logging(TLF_DBG_ERR, fmt, ##__VA_ARGS__); \
 	exit(EXIT_FAILURE); \
     } while(0)
-#define TLF_LOG_WARN(fmt, ...) do {\
+#define TLF_SHOW_WARN(fmt, ...) do {\
 	debug_log(TLF_DBG_WARN, fmt, ##__VA_ARGS__); \
 	handle_logging(TLF_DBG_WARN, fmt, ##__VA_ARGS__); \
     }while(0)
-#define TLF_LOG_INFO(fmt, ...) do {\
+#define TLF_SHOW_INFO(fmt, ...) do {\
 	debug_log(TLF_DBG_INFO, fmt, ##__VA_ARGS__); \
 	handle_logging(TLF_DBG_INFO, fmt, ##__VA_ARGS__); \
-    }while(0)
-#define TLF_LOG_DEBUG(fmt, ...) do {\
-	debug_log(TLF_DBG_DEBUG, fmt, ##__VA_ARGS__); \
-	handle_logging(TLF_DBG_DEBUG, fmt, ##__VA_ARGS__); \
     }while(0)
 
 

--- a/src/err_utils.h
+++ b/src/err_utils.h
@@ -21,21 +21,35 @@
 #define ERR_UTILS_H
 
 enum log_lvl {
-    L_DEBUG,
-    L_INFO,
+    L_NONE,
+    L_ERR,
     L_WARN,
-    L_ERR
+    L_INFO,
+    L_DEBUG
 };
 
-void handle_logging(enum log_lvl lvl, ...);
+void handle_logging(enum log_lvl lvl, char *fmt, ...);
 
-#define TLF_LOG_DEBUG(...) ( handle_logging(L_DEBUG, __VA_ARGS__) )
-#define TLF_LOG_INFO(...) ( handle_logging(L_INFO, __VA_ARGS__) )
-#define TLF_LOG_WARN(...) ( handle_logging(L_WARN, __VA_ARGS__) )
-#define TLF_LOG_ERR(...)  do { \
-	handle_logging(L_ERR, __VA_ARGS__); \
+
+/* show Error, Warning or similar to user, but write into debuglog if enabled
+ */
+#define TLF_LOG_ERR(fmt, ...)  do { \
+	debug_log(TLF_DBG_ERR, fmt, ##__VA_ARGS__); \
+	handle_logging(L_ERR, fmt, ##__VA_ARGS__); \
 	exit(EXIT_FAILURE); \
     } while(0)
+#define TLF_LOG_WARN(fmt, ...) do {\
+	debug_log(TLF_DBG_WARN, fmt, ##__VA_ARGS__); \
+	handle_logging(L_WARN, fmt, ##__VA_ARGS__); \
+    }while(0)
+#define TLF_LOG_INFO(fmt, ...) do {\
+	debug_log(TLF_DBG_INFO, fmt, ##__VA_ARGS__); \
+	handle_logging(L_INFO, fmt, ##__VA_ARGS__); \
+    }while(0)
+#define TLF_LOG_DEBUG(fmt, ...) do {\
+	debug_log(TLF_DBG_DEBUG, fmt, ##__VA_ARGS__); \
+	handle_logging(L_DEBUG, fmt, ##__VA_ARGS__); \
+    }while(0)
 
 
 #endif /* ERR_UTILS_H */

--- a/src/err_utils.h
+++ b/src/err_utils.h
@@ -22,7 +22,7 @@
 
 #include "debug.h"
 
-void handle_logging(enum debuglevel lvl, char *fmt, ...);
+void handle_logging(enum tlf_debug_level lvl, char *fmt, ...);
 
 
 /* show Error, Warning or Info message to user and write it into

--- a/src/err_utils.h
+++ b/src/err_utils.h
@@ -20,35 +20,29 @@
 #ifndef ERR_UTILS_H
 #define ERR_UTILS_H
 
-enum log_lvl {
-    L_NONE,
-    L_ERR,
-    L_WARN,
-    L_INFO,
-    L_DEBUG
-};
+#include "debug.h"
 
-void handle_logging(enum log_lvl lvl, char *fmt, ...);
+void handle_logging(enum debuglevel lvl, char *fmt, ...);
 
 
 /* show Error, Warning or similar to user, but write into debuglog if enabled
  */
 #define TLF_LOG_ERR(fmt, ...)  do { \
 	debug_log(TLF_DBG_ERR, fmt, ##__VA_ARGS__); \
-	handle_logging(L_ERR, fmt, ##__VA_ARGS__); \
+	handle_logging(TLF_DBG_ERR, fmt, ##__VA_ARGS__); \
 	exit(EXIT_FAILURE); \
     } while(0)
 #define TLF_LOG_WARN(fmt, ...) do {\
 	debug_log(TLF_DBG_WARN, fmt, ##__VA_ARGS__); \
-	handle_logging(L_WARN, fmt, ##__VA_ARGS__); \
+	handle_logging(TLF_DBG_WARN, fmt, ##__VA_ARGS__); \
     }while(0)
 #define TLF_LOG_INFO(fmt, ...) do {\
 	debug_log(TLF_DBG_INFO, fmt, ##__VA_ARGS__); \
-	handle_logging(L_INFO, fmt, ##__VA_ARGS__); \
+	handle_logging(TLF_DBG_INFO, fmt, ##__VA_ARGS__); \
     }while(0)
 #define TLF_LOG_DEBUG(fmt, ...) do {\
 	debug_log(TLF_DBG_DEBUG, fmt, ##__VA_ARGS__); \
-	handle_logging(L_DEBUG, fmt, ##__VA_ARGS__); \
+	handle_logging(TLF_DBG_DEBUG, fmt, ##__VA_ARGS__); \
     }while(0)
 
 

--- a/src/fldigixmlrpc.c
+++ b/src/fldigixmlrpc.c
@@ -210,7 +210,7 @@ int fldigi_xmlrpc_query(xmlrpc_res *local_result, xmlrpc_env *local_env,
     if (connerr && use_fldigi) {
 	if (connerrcnt == 10) {
 	    use_fldigi = false;
-	    TLF_LOG_WARN("Fldigi: lost connection!");
+	    TLF_SHOW_WARN("Fldigi: lost connection!");
 	} else {
 	    connerrcnt++;
 	}

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -192,7 +192,7 @@ static void poll_rig_state() {
 		mvprintw(0, 14, "%2u", speed);
 	    }
 	} else {
-	    TLF_LOG_WARN("Problem with rig link: %s", tlf_rigerror(retval));
+	    TLF_SHOW_WARN("Problem with rig link: %s", tlf_rigerror(retval));
 	}
     }
 
@@ -246,7 +246,7 @@ void gettxinfo(void) {
 	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval != RIG_OK) {
-	    TLF_LOG_WARN("Problem with rig link: %s", tlf_rigerror(retval));
+	    TLF_SHOW_WARN("Problem with rig link: %s", tlf_rigerror(retval));
 	}
 
     } else if (reqf == SETSSBMODE) {
@@ -257,7 +257,7 @@ void gettxinfo(void) {
 	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval != RIG_OK) {
-	    TLF_LOG_WARN("Problem with rig link: %s", tlf_rigerror(retval));
+	    TLF_SHOW_WARN("Problem with rig link: %s", tlf_rigerror(retval));
 	}
 
     } else if (reqf == SETDIGIMODE) {
@@ -274,7 +274,7 @@ void gettxinfo(void) {
 	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval != RIG_OK) {
-	    TLF_LOG_WARN("Problem with rig link: %s", tlf_rigerror(retval));
+	    TLF_SHOW_WARN("Problem with rig link: %s", tlf_rigerror(retval));
 	}
 
     } else if (reqf == RESETRIT) {
@@ -283,7 +283,7 @@ void gettxinfo(void) {
 	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval != RIG_OK) {
-	    TLF_LOG_WARN("Problem with rig link: %s", tlf_rigerror(retval));
+	    TLF_SHOW_WARN("Problem with rig link: %s", tlf_rigerror(retval));
 	}
 
     } else {
@@ -294,7 +294,7 @@ void gettxinfo(void) {
 	pthread_mutex_unlock(&tlf_rig_mutex);
 
 	if (retval != RIG_OK) {
-	    TLF_LOG_WARN("Problem with rig link: set frequency: %s", tlf_rigerror(retval));
+	    TLF_SHOW_WARN("Problem with rig link: set frequency: %s", tlf_rigerror(retval));
 	}
 
     }
@@ -341,7 +341,7 @@ static void handle_trx_bandswitch(const freq_t freq) {
     pthread_mutex_unlock(&tlf_rig_mutex);
 
     if (retval != RIG_OK) {
-	TLF_LOG_WARN("Problem with rig link: %s", tlf_rigerror(retval));
+	TLF_SHOW_WARN("Problem with rig link: %s", tlf_rigerror(retval));
     }
 }
 

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -254,7 +254,7 @@ extern bool qso_once;
 extern bool leading_zeros_serial;
 extern bool ignoredupe;
 extern bool continentlist_only;
-extern bool debugflag;
+extern int debuglevel;
 extern bool trx_control;
 extern bool nopacket;
 extern bool verbose;

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -192,11 +192,11 @@ int lan_send_init(void) {
 	bc_address[node].sin_port = htons(port);
 
 	TLF_LOG_INFO("LAN: open socket: to %d.%d.%d.%d:%d\n",
-	       (ntohl(bc_address[node].sin_addr.s_addr) & 0xff000000) >> 24,
-	       (ntohl(bc_address[node].sin_addr.s_addr) & 0x00ff0000) >> 16,
-	       (ntohl(bc_address[node].sin_addr.s_addr) & 0x0000ff00) >> 8,
-	       (ntohl(bc_address[node].sin_addr.s_addr) & 0x000000ff) >> 0,
-	       ntohs(bc_address[node].sin_port));
+		     (ntohl(bc_address[node].sin_addr.s_addr) & 0xff000000) >> 24,
+		     (ntohl(bc_address[node].sin_addr.s_addr) & 0x00ff0000) >> 16,
+		     (ntohl(bc_address[node].sin_addr.s_addr) & 0x0000ff00) >> 8,
+		     (ntohl(bc_address[node].sin_addr.s_addr) & 0x000000ff) >> 0,
+		     ntohs(bc_address[node].sin_port));
 
 	bc_socket_descriptor[node] = socket(AF_INET, SOCK_DGRAM, 0);
 

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -253,7 +253,7 @@ static int lan_send(char *lanbuffer) {
 
 	if (bc_sendto_rc == -1) {
 	    if (send_error[node] >= (send_error_limit[node] + 10)) {
-		TLF_LOG_INFO("LAN: send problem...!");
+		TLF_SHOW_INFO("LAN: send problem...!");
 		send_error_limit[node] += 10;
 	    } else
 		send_error[node]++;

--- a/src/lancode.c
+++ b/src/lancode.c
@@ -24,7 +24,6 @@
 #include <netdb.h>
 #include <stdlib.h>
 #include <string.h>
-#include <syslog.h>
 #include <time.h>
 #include <unistd.h>
 #include <arpa/inet.h>
@@ -92,7 +91,7 @@ int lan_recv_init(void) {
 
     lan_socket_descriptor = socket(AF_INET, SOCK_DGRAM, 0);
     if (lan_socket_descriptor == -1) {
-	syslog(LOG_ERR, "%s\n", "LAN: socket");
+	TLF_LOG_ERR("%s\n", "LAN: socket");
 	return -1;
     }
 
@@ -100,14 +99,14 @@ int lan_recv_init(void) {
 	bind(lan_socket_descriptor, (struct sockaddr *) &lan_sin,
 	     sizeof(lan_sin));
     if (lan_bind_rc == -1) {
-	syslog(LOG_ERR, "%s\n", "LAN: bind");
+	TLF_LOG_ERR("%s\n", "LAN: bind");
 	return -2;
     }
 
     lan_save_file_flags = fcntl(lan_socket_descriptor, F_GETFL);
     lan_save_file_flags |= O_NONBLOCK;
     if (fcntl(lan_socket_descriptor, F_SETFL, lan_save_file_flags) == -1) {
-	syslog(LOG_ERR, "%s\n", "trying non-blocking");
+	TLF_LOG_ERR("%s\n", "LAN: trying non-blocking");
 	return -3;
     }
     return 0;
@@ -121,7 +120,7 @@ int lan_recv_close(void) {
 
     lan_close_rc = close(lan_socket_descriptor);
     if (lan_close_rc == -1) {
-	syslog(LOG_ERR, "%s\n", "LAN: close call failed");
+	TLF_LOG_ERR("%s\n", "LAN: close call failed");
 	return errno;
     }
 
@@ -180,7 +179,7 @@ int lan_send_init(void) {
 
 	bc_hostbyname[node] = gethostbyname(bc_hostaddress[node]);
 	if (bc_hostbyname[node] == NULL) {
-	    syslog(LOG_ERR, "%s\n", "LAN: gethostbyname failed");
+	    TLF_LOG_ERR("%s\n", "LAN: gethostbyname failed");
 	    return -1;
 	}
 
@@ -192,7 +191,7 @@ int lan_send_init(void) {
 	int port = (bc_hostport[node] > 0 ? bc_hostport[node] : lan_port);
 	bc_address[node].sin_port = htons(port);
 
-	syslog(LOG_INFO, "open socket: to %d.%d.%d.%d:%d\n",
+	TLF_LOG_INFO("LAN: open socket: to %d.%d.%d.%d:%d\n",
 	       (ntohl(bc_address[node].sin_addr.s_addr) & 0xff000000) >> 24,
 	       (ntohl(bc_address[node].sin_addr.s_addr) & 0x00ff0000) >> 16,
 	       (ntohl(bc_address[node].sin_addr.s_addr) & 0x0000ff00) >> 8,
@@ -202,7 +201,7 @@ int lan_send_init(void) {
 	bc_socket_descriptor[node] = socket(AF_INET, SOCK_DGRAM, 0);
 
 	if (bc_socket_descriptor[node] == -1) {
-	    syslog(LOG_ERR, "%s\n", "LAN: socket call failed");
+	    TLF_LOG_ERR("%s\n", "LAN: socket call failed");
 	    return -1;
 	}
     }
@@ -220,7 +219,7 @@ int lan_send_close(void) {
 
 	bc_close_rc = close(bc_socket_descriptor[node]);
 	if (bc_close_rc == -1) {
-	    syslog(LOG_ERR, "%s\n", "LAN: close call failed");
+	    TLF_LOG_ERR("%s\n", "LAN: close call failed");
 	    return -1;
 	}
     }

--- a/src/main.c
+++ b/src/main.c
@@ -88,7 +88,7 @@ int tlfcolors[8][2] = { {COLOR_BLACK, COLOR_WHITE},
     {COLOR_BLUE, COLOR_YELLOW},
     {COLOR_WHITE, COLOR_BLACK}
 };
-bool debugflag = false;
+int debuglevel = 0;
 char *editor_cmd = NULL;
 int tune_val = 0;
 bool use_bandoutput = false;
@@ -451,7 +451,8 @@ static const struct argp_option options[] = {
     {"no-rig",      'r', 0, 0,  "Start without radio control" },
     {"list",	    'l', 0, 0,  "List built-in contests" },
     {"sync",        's', "URL", 0,  "Synchronize log with other node" },
-    {"debug",       'd', 0, 0,  "Debug mode" },
+    {"debug",       'd', "LEVEL (0..4)", 0,
+	"Debug level (Off, Error, Warn, Info, Debug)" },
     {"verbose",     'v', 0, 0,  "Produce verbose output" },
     { 0 }
 };
@@ -487,7 +488,9 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 	    strcpy(synclogfile, arg);
 	    break;
 	case 'd':		// debug rigctl
-	    debugflag = true;
+	    debuglevel = atoi(arg);
+	    if (debuglevel < 0) debuglevel = 0;
+	    if (debuglevel > 4) debuglevel = 4;
 	    break;
 	case 'v':		// verbose startup
 	    verbose = true;
@@ -1035,6 +1038,10 @@ int main(int argc, char *argv[]) {
     sprintf(welcome, "        Welcome to %s by PA0R!!", argp_program_version);
 
     argp_parse(&argp, argc, argv, 0, 0, NULL);  // parse options
+
+    if (!debug_init()) {
+	showmsg("Could not intialize debug logging");
+    }
 
     ui_init();
 

--- a/src/main.c
+++ b/src/main.c
@@ -452,8 +452,8 @@ static const struct argp_option options[] = {
     {"list",	    'l', 0, 0,  "List built-in contests" },
     {"sync",        's', "URL", 0,  "Synchronize log with other node" },
     {
-	"debug",       'd', "LEVEL (0..4)", 0,
-	"Debug level (Off, Error, Warn, Info, Debug)"
+	"debug",       'd', "LEVEL (1..4)", 0,
+	"Debug level (Error, Warn, Info, Debug)"
     },
     {"verbose",     'v', 0, 0,  "Produce verbose output" },
     { 0 }
@@ -492,8 +492,8 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 	case 'd':		// debug level
 	    debuglevel = arg[0] - '0';
 	    if ((strlen(arg) != 1)  || !isdigit(arg[0]) ||
-		    (debuglevel > 4)) {
-		fprintf(stderr, "Debuglevel should be 0..4\n");
+		    (debuglevel > 4) || (debuglevel == 0)) {
+		fprintf(stderr, "Debuglevel should be 1..4\n");
 		exit(EXIT_FAILURE);
 	    }
 	    break;

--- a/src/main.c
+++ b/src/main.c
@@ -783,6 +783,8 @@ static void hamlib_init() {
 	return;
     }
 
+    rig_debug_init();
+
     shownr("Rig model number is", myrig_model);
     shownr("Rig speed is", serial_rate);
 

--- a/src/main.c
+++ b/src/main.c
@@ -484,15 +484,18 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 	    break;
 	case 's':
 	    if (strlen(arg) >= 120) {
-		printf("Argument too long for sync\n");
+		fprintf(stderr, "Argument too long for sync\n");
 		exit(EXIT_FAILURE);
 	    }
 	    strcpy(synclogfile, arg);
 	    break;
-	case 'd':		// debug rigctl
-	    debuglevel = atoi(arg);
-	    if (debuglevel < 0) debuglevel = 0;
-	    if (debuglevel > 4) debuglevel = 4;
+	case 'd':		// debug level
+	    debuglevel = arg[0] - '0';
+	    if ((strlen(arg) != 1)  || !isdigit(arg[0]) ||
+		    (debuglevel > 4)) {
+		fprintf(stderr, "Debuglevel should be 0..4\n");
+		exit(EXIT_FAILURE);
+	    }
 	    break;
 	case 'v':		// verbose startup
 	    verbose = true;

--- a/src/main.c
+++ b/src/main.c
@@ -451,8 +451,10 @@ static const struct argp_option options[] = {
     {"no-rig",      'r', 0, 0,  "Start without radio control" },
     {"list",	    'l', 0, 0,  "List built-in contests" },
     {"sync",        's', "URL", 0,  "Synchronize log with other node" },
-    {"debug",       'd', "LEVEL (0..4)", 0,
-	"Debug level (Off, Error, Warn, Info, Debug)" },
+    {
+	"debug",       'd', "LEVEL (0..4)", 0,
+	"Debug level (Off, Error, Warn, Info, Debug)"
+    },
     {"verbose",     'v', 0, 0,  "Produce verbose output" },
     { 0 }
 };

--- a/src/netkeyer.c
+++ b/src/netkeyer.c
@@ -173,7 +173,7 @@ int netkeyer(int cw_op, char *cwmessage) {
 		       0, (struct sockaddr *) &address,
 		       sizeof(address));
     if (sendto_rc == -1) {
-	TLF_LOG_WARN("Keyer send failed...!");
+	TLF_SHOW_WARN("Keyer send failed...!");
 	return -1;
     }
 

--- a/src/rtty.c
+++ b/src/rtty.c
@@ -122,7 +122,7 @@ void ry_addchar(char c) {
 
     // write to log file
     if ((ry_fp = fopen("RTTYlog", "a")) == NULL) {
-	TLF_LOG_INFO("cannot open RTTYlog");
+	TLF_SHOW_INFO("cannot open RTTYlog");
 	return;
     }
     fputc(c, ry_fp);

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -755,7 +755,7 @@ int load_callmaster(void) {
 
     if ((cfp = fopen(callmaster_location, "r")) == NULL) {
 	g_free(callmaster_location);
-	TLF_LOG_WARN("Error opening callmaster file.");
+	TLF_SHOW_WARN("Error opening callmaster file.");
 	return 0;
     }
     g_free(callmaster_location);

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -51,7 +51,6 @@ bool rig_has_stop_morse() {
 void send_bandswitch(freq_t trxqrg);
 
 static int parse_rigconf();
-static void debug_tlf_rig();
 
 /* check if call input field contains a valid frequency and switch to it.
  * only integer kHz values are supported.
@@ -159,8 +158,7 @@ int init_tlf_rig(void) {
 
     if (retcode != RIG_OK) {
 	show_rigerror("Problem with rig link", retcode);
-	if (!debugflag)
-	    return -1;
+	return -1;
     }
 
     shownr("Freq =", (int) rigfreq);
@@ -174,13 +172,8 @@ int init_tlf_rig(void) {
 	    speed = rig_cwspeed;
 	} else {
 	    show_rigerror("Could not read CW speed from rig", retcode);
-	    if (!debugflag)
-		return -1;
+	    return -1;
 	}
-    }
-
-    if (debugflag) {	// debug rig control
-	debug_tlf_rig();
     }
 
     switch (trxmode) {
@@ -249,47 +242,3 @@ static int parse_rigconf() {
     return 0;
 }
 
-
-static void debug_tlf_rig() {
-    freq_t rigfreq;
-    int retcode;
-
-    sleep(10);
-
-    pthread_mutex_lock(&tlf_rig_mutex);
-    retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);
-    pthread_mutex_unlock(&tlf_rig_mutex);
-
-    if (retcode != RIG_OK) {
-	show_rigerror("Problem with rig get freq", retcode);
-    } else {
-	shownr("freq =", (int) rigfreq);
-    }
-    sleep(10);
-
-    const freq_t testfreq = 14000000;	// test set frequency
-
-    pthread_mutex_lock(&tlf_rig_mutex);
-    retcode = rig_set_freq(my_rig, RIG_VFO_CURR, testfreq);
-    pthread_mutex_unlock(&tlf_rig_mutex);
-
-    if (retcode != RIG_OK) {
-	show_rigerror("Problem with rig set freq", retcode);
-    } else {
-	showmsg("Rig set freq ok!");
-    }
-
-    pthread_mutex_lock(&tlf_rig_mutex);
-    retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);	// read qrg
-    pthread_mutex_unlock(&tlf_rig_mutex);
-
-    if (retcode != RIG_OK) {
-	show_rigerror("Problem with rig get freq", retcode);
-    } else {
-	shownr("freq =", (int) rigfreq);
-	if (rigfreq != testfreq) {
-	    showmsg("Failed to set rig freq!");
-	}
-    }
-    sleep(10);
-}

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -243,8 +243,8 @@ static int parse_rigconf() {
 }
 
 /* convert Hamlib debug levels into Tlfs ones */
-static enum debuglevel rig2tlf_debug(enum rig_debug_level_e lvl) {
-    enum debuglevel level;
+static enum tlf_debug_level rig2tlf_debug(enum rig_debug_level_e lvl) {
+    enum tlf_debug_level level;
     switch (lvl) {
 	case RIG_DEBUG_ERR:
 	    level = TLF_DBG_ERR;
@@ -265,8 +265,8 @@ static enum debuglevel rig2tlf_debug(enum rig_debug_level_e lvl) {
 }
 
 /* convert Tlf debug levels into Hamlib ones */
-static enum rig_debug_level_e tlf2rig_debug(enum debuglevel lvl) {
-    enum debuglevel level;
+static enum rig_debug_level_e tlf2rig_debug(enum tlf_debug_level lvl) {
+    enum tlf_debug_level level;
     switch (lvl) {
 	case TLF_DBG_ERR:
 	    level = RIG_DEBUG_ERR;

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -242,3 +242,47 @@ static int parse_rigconf() {
     return 0;
 }
 
+
+/* callback receiving hamlibs debug output */
+int rig_debug_cb(enum rig_debug_level_e lvl,
+		 rig_ptr_t user_data,
+		 const char *fmt,
+		 va_list ap) {
+
+    enum debuglevel level;
+
+    /* convert hamlib debug levels into Tlfs ones */
+    switch (lvl) {
+	case RIG_DEBUG_ERR:
+	    level = TLF_DBG_ERR;
+	    break;
+	case RIG_DEBUG_WARN:
+	    level = TLF_DBG_WARN;
+	    break;
+	case RIG_DEBUG_VERBOSE:
+	    level = TLF_DBG_INFO;
+	    break;
+	case RIG_DEBUG_TRACE:
+	    level = TLF_DBG_DEBUG;
+	    break;
+	default:
+	    level = TLF_DBG_NONE;
+    }
+
+    char *format = g_strdup_printf("Rig: %s", fmt);
+    char *msg = g_strdup_vprintf(format, ap);
+    debug_log(level, msg);
+    g_free(msg);
+    g_free(format);
+    return RIG_OK;
+}
+
+/* set hamlibs debug level and install callback if debug is active */
+void rig_debug_init() {
+    if (debug_is_active()) {
+	/* set hamlib debug level and install callback */
+	rig_set_debug(RIG_DEBUG_TRACE);
+	rig_set_debug_callback(rig_debug_cb, (rig_ptr_t)NULL);
+    }
+}
+

--- a/src/sendqrg.h
+++ b/src/sendqrg.h
@@ -39,6 +39,7 @@ bool rig_has_stop_morse();
 
 int init_tlf_rig(void);
 void close_tlf_rig(RIG *my_rig);
+void rig_debug_init();
 
 bool sendqrg(void);
 

--- a/src/set_tone.c
+++ b/src/set_tone.c
@@ -54,7 +54,7 @@ void set_tone(void) {
 void write_tone(void) {
 
     if (netkeyer(K_TONE, tonestr) < 0) {
-	TLF_LOG_INFO("keyer not active; switching to SSB");
+	TLF_SHOW_INFO("keyer not active; switching to SSB");
 	trxmode = SSBMODE;
     }
 

--- a/src/speedupndown.c
+++ b/src/speedupndown.c
@@ -54,7 +54,7 @@ static int setspeed(int cwspeed) {
 	if (retval >= 0) {
 	    speed = cwspeed;
 	} else {
-	    TLF_LOG_WARN("keyer not active");
+	    TLF_SHOW_WARN("keyer not active");
 //                      trxmode = SSBMODE;
 	    clear_display();
 	}
@@ -67,7 +67,7 @@ static int setspeed(int cwspeed) {
 	if (retval >= 0) {
 	    speed = cwspeed;
 	} else {
-	    TLF_LOG_WARN("Could not set CW speed: %s", tlf_rigerror(retval));
+	    TLF_SHOW_WARN("Could not set CW speed: %s", tlf_rigerror(retval));
 	    clear_display();
 	}
     }
@@ -131,7 +131,7 @@ int setweight(int weight) {
 	retval = netkeyer(K_WEIGHT, buff);
 
 	if (retval < 0) {
-	    TLF_LOG_INFO("keyer not active ?");
+	    TLF_SHOW_INFO("keyer not active ?");
 	    clear_display();
 	}
     }

--- a/src/splitscreen.c
+++ b/src/splitscreen.c
@@ -110,7 +110,7 @@ void addlog(char *s) {
 
 	if (clusterlog) {
 	    if ((fp = fopen("clusterlog", "a")) == NULL) {
-		TLF_LOG_INFO("Opening clusterlog not possible.");
+		TLF_SHOW_INFO("Opening clusterlog not possible.");
 	    } else {
 		if (strlen(lastmsg) > 20) {
 		    fputs(lastmsg, fp);

--- a/src/stoptx.c
+++ b/src/stoptx.c
@@ -43,7 +43,7 @@ int stoptx(void) {
 
 	    if (netkeyer(K_ABORT, NULL) < 0) {
 
-		TLF_LOG_WARN("keyer not active; switching to SSB");
+		TLF_SHOW_WARN("keyer not active; switching to SSB");
 		trxmode = SSBMODE;
 		clear_display();
 
@@ -52,7 +52,7 @@ int stoptx(void) {
 
 	    int error = hamlib_keyer_stop();
 	    if (error != RIG_OK) {
-		TLF_LOG_WARN("CW stop error: %s", tlf_rigerror(error));
+		TLF_SHOW_WARN("CW stop error: %s", tlf_rigerror(error));
 
 	    }
 	}

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -26,6 +26,7 @@
 
 #include "hamlib/rig.h"
 #include "bandmap.h"
+#include "debug.h"
 #include "dxcc.h"
 
 enum {

--- a/src/write_keyer.c
+++ b/src/write_keyer.c
@@ -107,11 +107,11 @@ void write_keyer(void) {
 
 	int error = hamlib_keyer_send(tosend);
 	if (error != RIG_OK) {
-	    TLF_LOG_WARN("CW send error: %s", tlf_rigerror(error));
+	    TLF_SHOW_WARN("CW send error: %s", tlf_rigerror(error));
 	}
     } else if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {
 	if ((bfp = fopen(controllerport, "a")) == NULL) {
-	    TLF_LOG_WARN("1278 not active. Switching to SSB mode.");
+	    TLF_SHOW_WARN("1278 not active. Switching to SSB mode.");
 	    trxmode = SSBMODE;
 	    clear_display();
 	} else {
@@ -121,7 +121,7 @@ void write_keyer(void) {
 
     } else if (digikeyer == GMFSK) {
 	if (strlen(rttyoutput) < 2) {
-	    TLF_LOG_WARN("No modem file specified!");
+	    TLF_SHOW_WARN("No modem file specified!");
 	}
 	// when GMFSK used (possible Fldigi interface), the trailing \n doesn't need
 	if (tosend[strlen(tosend) - 1] == '\n') {

--- a/test/data.c
+++ b/test/data.c
@@ -50,7 +50,7 @@ int tlfcolors[8][2] = { {COLOR_BLACK, COLOR_WHITE},
 };
 
 
-bool debugflag = false;
+int debuglevel = 0;
 char *editor_cmd = NULL;
 char rttyoutput[120];
 int tune_val = 0;

--- a/test/functions.c
+++ b/test/functions.c
@@ -1,6 +1,7 @@
 #include "test.h"
 
 #include "curses.h"
+#include "../src/debug.h"
 
 int __wrap_key_get() {
     return -1;
@@ -73,5 +74,11 @@ void showstring(char *message1, char *message2) {
 unsigned int __wrap_sleep(unsigned int seconds) {
     // no sleeping in tests
     return 0;
+}
+
+/* for now */
+void debug_log (enum debuglevel lvl,
+	const char *fmt,
+	...) {
 }
 

--- a/test/functions.c
+++ b/test/functions.c
@@ -77,7 +77,7 @@ unsigned int __wrap_sleep(unsigned int seconds) {
 }
 
 /* for now */
-void debug_log (enum debuglevel lvl,
+void debug_log (enum tlf_debug_level lvl,
 	const char *fmt,
 	...) {
 }

--- a/test/test_lancode.c
+++ b/test/test_lancode.c
@@ -8,7 +8,7 @@
 
 // OBJECT ../src/lancode.o
 
-void handle_logging(enum log_lvl lvl, ...) {
+void handle_logging(enum debuglevel lvl, char *fmt, ...) {
     // empty
 }
 

--- a/test/test_lancode.c
+++ b/test/test_lancode.c
@@ -8,7 +8,7 @@
 
 // OBJECT ../src/lancode.o
 
-void handle_logging(enum debuglevel lvl, char *fmt, ...) {
+void handle_logging(enum tlf_debug_level lvl, char *fmt, ...) {
     // empty
 }
 

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -136,7 +136,7 @@ void time_update(void) {
     // empty
 }
 
-void handle_logging(enum debuglevel lvl, char *fmt, ...) {
+void handle_logging(enum tlf_debug_level lvl, char *fmt, ...) {
     // empty
 }
 

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -136,7 +136,7 @@ void time_update(void) {
     // empty
 }
 
-void handle_logging(enum log_lvl lvl, ...) {
+void handle_logging(enum debuglevel lvl, char *fmt, ...) {
     // empty
 }
 

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -35,7 +35,7 @@
 .
 .
 .\" Update the date when this page is committed.
-.TH TLF 1 "@PACKAGE_NAME@ @VERSION@, 2022-09-18" TLF "Ham radio"
+.TH TLF 1 "@PACKAGE_NAME@ @VERSION@, 2025-01-23" TLF "Ham radio"
 .
 .
 .SH NAME
@@ -46,10 +46,11 @@
 .SH SYNOPSIS
 .
 .SY @PACKAGE@
-.OP \-?dilnrvV
+.OP \-?ilnrvV
+.OP \-d level
 .OP \-f config_file
 .OP \-s user:password@host/dir/logfilename
-.OP \-\-debug
+.OP \-\-debug=\fIlevel\fP
 .OP \-\-config=\fIconfig_file\fP
 .OP \-\-import
 .OP \-\-list
@@ -150,6 +151,18 @@ Options given to @PACKAGE_NAME@ on the command line.
 .TP
 .BR \-? , \ \-\-help
 Print a summary of options to the screen and exit.
+.
+.TP
+.BI \-d\  debug_level
+.TQ
+.BI \-\-debug=  debug_level
+Activate logging of debug output. Output will be added to
+.I debug.txt
+file in actual directory.
+.
+.IP
+Allowed values with rising verbosity are 0 (Off), 1 (Error) , 2 (Warn), 3
+(Info) or 4 (Debug)
 .
 .TP
 .BI \-f\  config_file

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -161,8 +161,7 @@ Activate logging of debug output. Output will be added to
 file in actual directory.
 .
 .IP
-Allowed values with rising verbosity are 0 (Off), 1 (Error) , 2 (Warn), 3
-(Info) or 4 (Debug)
+Allowed values with rising verbosity are 1 (Error) , 2 (Warn), 3 (Info) or 4 (Debug)
 .
 .TP
 .BI \-f\  config_file


### PR DESCRIPTION
* Add debug infrasturcture
* Allow control of debug output verbosity via '-d lvl' switch during startup.
* Record selected Hamlib debug output.
* Move TLF_LOG_... macros to TLF_SHOW_... 
  They show the message to the user and log it into debuglog.
* TLF_LOG_... macros to record error, warning, info and debug messages into debuglog file
* Move use of syslog to TLF_LOG_...