### PR TITLE
Fix crash at startup on terminal resize

### DIFF
--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -169,6 +169,7 @@ extern bool demode;
 extern bool ctcomp;
 extern bool show_time;
 extern bool use_rxvt;
+extern bool tlf_initialized;
 extern bool time_master;
 extern bool noautocq;
 extern bool no_arrows;

--- a/src/main.c
+++ b/src/main.c
@@ -78,6 +78,7 @@ int portnum = 0;
 
 bool use_rxvt = false;
 bool use_xterm = false;
+bool tlf_initialized = false;   // true: everything has been set up
 
 int tlfcolors[8][2] = { {COLOR_BLACK, COLOR_WHITE},
     {COLOR_GREEN, COLOR_YELLOW},
@@ -1139,6 +1140,9 @@ int main(int argc, char *argv[]) {
 	endwin();
 	exit(EXIT_FAILURE);
     }
+
+    tlf_initialized = true;
+
 
     /* now start logging  !! Does never return */
     logit();

--- a/test/data.c
+++ b/test/data.c
@@ -37,6 +37,8 @@ char pr_hostaddress[48] = "111.222.111.222";
 char *config_file = NULL;
 int portnum = 0;
 
+bool tlf_initialized = false;
+
 bool use_rxvt = false;
 int use_xterm = 0;
 int tlfcolors[8][2] = { {COLOR_BLACK, COLOR_WHITE},


### PR DESCRIPTION
To reproduce the issue

1.  start TLF in a resizable terminal with size smaller than 22x80
2. at the "Continue anyway?" prompt resize the terminal
3. get a segfault
![image](https://github.com/user-attachments/assets/5930fd58-62aa-4983-909f-ac0d6ff2c291)

The issue is caused by `resize_layout()` trying to access not yet initialized variables (rst arrays).

Solved by introducing variable `tlf_initialized` that is set to true only when all has been set up, just before calling `logit()`.
While `tlf_initialized` is false, resizing now just stores the terminal size.

A related issue has also popped up: resizing "keypress" is treated as an actual one, causing misfunction at some "Y/N" or "press any key" prompts.
Terminal resize is now not propagated to the caller of `key_get()`/`key_poll()`.
