### PR TITLE
fix: set correct argument of prototypes

### DIFF
--- a/src/focm.c
+++ b/src/focm.c
@@ -30,10 +30,8 @@
 #include "tlf_curses.h"
 #include "ui_utils.h"
 #include "bands.h"
+#include "setcontest.h"
 
-bool no_multi(spot *s) {
-    return false;
-}
 
 struct pos {
     int column;

--- a/src/focm.c
+++ b/src/focm.c
@@ -31,7 +31,7 @@
 #include "ui_utils.h"
 #include "bands.h"
 
-bool no_multi(spot * s) {
+bool no_multi(spot *s) {
     return false;
 }
 

--- a/src/focm.c
+++ b/src/focm.c
@@ -31,7 +31,7 @@
 #include "ui_utils.h"
 #include "bands.h"
 
-bool no_multi() {
+bool no_multi(spot * s) {
     return false;
 }
 

--- a/src/score.h
+++ b/src/score.h
@@ -24,11 +24,11 @@
 #include <stdbool.h>
 #include "tlf.h"
 
-int score_wpx();
-int score_cqww();
-int score_arrlfd();
-int score_arrldx_usa();
-int score_stewperry();
+int score_wpx(struct qso_t * qso);
+int score_cqww(struct qso_t * qso);
+int score_arrlfd(struct qso_t * qso);
+int score_arrldx_usa(struct qso_t * qso);
+int score_stewperry(struct qso_t * qso);
 int score(struct qso_t *qso);
 void score_qso(struct qso_t *qso);
 int score2(char *line);

--- a/src/score.h
+++ b/src/score.h
@@ -24,11 +24,11 @@
 #include <stdbool.h>
 #include "tlf.h"
 
-int score_wpx(struct qso_t * qso);
-int score_cqww(struct qso_t * qso);
-int score_arrlfd(struct qso_t * qso);
-int score_arrldx_usa(struct qso_t * qso);
-int score_stewperry(struct qso_t * qso);
+int score_wpx(struct qso_t *qso);
+int score_cqww(struct qso_t *qso);
+int score_arrlfd(struct qso_t *qso);
+int score_arrldx_usa(struct qso_t *qso);
+int score_stewperry(struct qso_t *qso);
 int score(struct qso_t *qso);
 void score_qso(struct qso_t *qso);
 int score2(char *line);

--- a/src/setcontest.c
+++ b/src/setcontest.c
@@ -54,7 +54,7 @@ static struct qso_t *qso_from_spot(spot *data) {
 
 /* No Multiplier mark in bandmap for multis determined from comment field;
  * Code works also for modes with no multiplier at all */
-static bool no_multi(spot *data) {
+bool no_multi(spot *data) {
     return false;
 }
 

--- a/src/setcontest.h
+++ b/src/setcontest.h
@@ -33,5 +33,6 @@ bool general_ismulti(spot *data);
 contest_config_t *lookup_contest(char *name);
 void list_contests();
 void setcontest(char *name);
+bool no_multi(spot *data);
 
 #endif /* SETCONTEST_H */


### PR DESCRIPTION
There is an [FTBFS](https://wiki.debian.org/FTBFS) bug in Debian, see [#1098006](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1098006) with [gcc-15](https://gcc.gnu.org/gcc-15/porting_to.html).

This PR solves the problems.