### PR TITLE
Fix search panel size

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -559,9 +559,6 @@ static void ui_init() {
 	exit(EXIT_FAILURE);
     }
 
-    InitSearchPanel();	/* at least one panel has to be defined
-				   for refreshp() to work */
-
     getmaxyx(stdscr, ymax, xmax);
     if ((ymax < 22) || (xmax < 80)) {
 	char c;

--- a/src/showmsg.c
+++ b/src/showmsg.c
@@ -30,7 +30,7 @@ static int linectr = 0;
 void clearmsg() {
     clear();
     linectr = 0;
-    refreshp();
+    refresh();
 }
 
 
@@ -41,7 +41,6 @@ void clearmsg_wait(void) {
 	mvaddstr(LINES - 2, 0, "Press any key to continue!");
 	move(LINES - 1, 0);
 	clrtoeol();
-	refreshp();
 	IGNORE(key_get());
     } else {
 	sleep(1);
@@ -50,11 +49,11 @@ void clearmsg_wait(void) {
 }
 
 
-static int has_room_for_message() {
+static bool has_room_for_message() {
     if (linectr < LINES - 3)
-	return 1;
+	return true;
     else
-	return 0;
+	return false;
 }
 
 void show_formatted(char *fmt, ...) {
@@ -68,7 +67,7 @@ void show_formatted(char *fmt, ...) {
     va_end(args);
     mvaddstr(linectr, 0, str);
     g_free(str);
-    refreshp();
+    refresh();
     linectr++;
 }
 

--- a/src/showmsg.h
+++ b/src/showmsg.h
@@ -21,6 +21,11 @@
 #ifndef STARTMSG_H
 #define STARTMSG_H
 
+/*
+ * These functions provide progress and error reporting at start-up phase
+ * !!! Do not call them after switching to the main screen !!!
+ * For runtime notifications use TLF_SHOW_* macros instead
+ */
 
 void clearmsg(void);
 void clearmsg_wait(void);


### PR DESCRIPTION
#459 brought up a hidden issue: in order to everything work correctly search panel was initialized twice. First to ensure that the startup messages are shown and then according to the actual CONTEST_MODE configuration.

The second initialization has been suppressed, so we were left with the 9-band non-contest search panel.
![image](https://github.com/user-attachments/assets/44271a8f-a33f-4c32-8dff-f20bf63580a0)
And there is no way to get it reduced to 6. :CONtest command merely switches `iscontest`, doesn't resize the panel.

The solution is to drop the early initialization and call ncurses' plain `refresh()` in showmsg.c. There are no panels at this point yet, so no use calling out `refreshp()` (=update_panel() + co).

Getting back to :CONtest - it still can't switch panel size according to `iscontest`.
My view is that this feature is not needed: one shall not switch contest mode while already running TLF. This is a task to be done when configuring a contest or simple QSO setup, _before_ starting TLF.

Taking it one step further, :CFG/:SET shall also be removed (see the long runner #233). As I see we have practically no chance to cleanly restart the program as there is a number of allocated data structures, TCP and serial connections, etc. to be (really) correctly freed and set up anew. User shall simply restart TLF on such configuration changes. It takes just 1 second. (ok, plus the 3 seconds cluster wait, but that's another story...)


