### PR TITLE
Fix RST after rig mode change

### DIFF
--- a/src/change_rst.c
+++ b/src/change_rst.c
@@ -84,6 +84,10 @@ void rst_reset(void) {
 
 /* initialize 'my_rst' and 'his_rst' */
 void rst_set_strings() {
+    if (no_rst) {
+	return;
+    }
+
     memcpy(recvd_rst, g_ptr_array_index(rst_recv.array, rst_recv.index), 2);
     memcpy(sent_rst, g_ptr_array_index(rst_sent.array, rst_sent.index), 2);
     if (trxmode != SSBMODE) {

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -34,6 +34,7 @@
 #include "audio.h"
 #include "cqww_simulator.h"
 #include "changepars.h"
+#include "change_rst.h"
 #include "clear_display.h"
 #include "dxcc.h"
 #include "editlog.h"
@@ -107,6 +108,7 @@ static void change_autosend() {
 void set_trxmode_internally(int mode) {
 
     trxmode = mode;
+    rst_set_strings();
 
     if (trxmode == CWMODE) {
 	if (cwkeyer == MFJ1278_KEYER) {

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -173,14 +173,8 @@ void clear_display(void) {
     qsonr_to_str(qsonrstr, qsonum);
     mvaddstr(12, 23, qsonrstr);
 
-    if (no_rst) {
-	mvaddstr(12, 44, "   ");
-	mvaddstr(12, 49, "   ");
-    } else {
-	rst_set_strings();
-	mvaddstr(12, 44, sent_rst);
-	mvaddstr(12, 49, recvd_rst);
-    }
+    rst_set_strings();
+    update_line_rst();
 
     if (searchflg)
 	searchlog();

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -38,6 +38,7 @@
 #include "sendbuf.h"
 #include "speedupndown.h"
 #include "stoptx.h"
+#include "time_update.h"
 #include "tlf.h"
 #include "tlf_panel.h"
 #include "ui_utils.h"
@@ -149,9 +150,7 @@ int handle_common_key(int key) {
 
 		rst_sent_up();
 
-		if (!no_rst)
-		    mvaddstr(12, 44, sent_rst);
-		mvaddstr(12, 29, current_qso.call);
+		update_line_rst();
 
 	    } else {	// change cw speed
 		speedup();
@@ -181,9 +180,7 @@ int handle_common_key(int key) {
 
 		rst_sent_down();
 
-		if (!no_rst)
-		    mvaddstr(12, 44, sent_rst);
-		mvaddstr(12, 29, current_qso.call);
+		update_line_rst();
 
 	    } else {
 

--- a/src/log_to_disk.c
+++ b/src/log_to_disk.c
@@ -40,6 +40,7 @@
 #include "score.h"
 #include "store_qso.h"
 #include "setcontest.h"
+#include "time_update.h"
 #include "tlf_curses.h"
 #include "ui_utils.h"
 #include "cleanup.h"
@@ -159,13 +160,7 @@ void log_to_disk(int from_lan) {
 
     mvaddstr(12, 23, qsonrstr);
 
-    if (no_rst) {
-	mvaddstr(12, 44, "   ");
-	mvaddstr(12, 49, "   ");
-    } else {
-	mvaddstr(12, 44, sent_rst);
-	mvaddstr(12, 49, recvd_rst);
-    }
+    update_line_rst();
 
     sync();
 

--- a/src/time_update.c
+++ b/src/time_update.c
@@ -80,6 +80,19 @@ void update_line(const char *timestr) {
     mvaddstr(12, 7, timestr);
 }
 
+void update_line_rst() {
+
+    attron(COLOR_PAIR(C_WINDOW) | A_STANDOUT);
+
+    if (no_rst) {
+	mvaddstr(12, 44, "   ");
+	mvaddstr(12, 49, "   ");
+    } else {
+	mvaddstr(12, 44, sent_rst);
+	mvaddstr(12, 49, recvd_rst);
+    }
+}
+
 const char *FREQ_DISPLAY_FORMAT = " %s: %7.1f";
 
 bool force_show_freq = false;
@@ -128,6 +141,7 @@ void time_update(void) {
     if (trxmode != old_trxmode) {
 	old_trxmode = trxmode;
 	update_line(time_buf);
+	update_line_rst();
     }
 
     if (force_show_freq) {

--- a/src/time_update.h
+++ b/src/time_update.h
@@ -26,6 +26,7 @@
 extern bool force_show_freq;
 
 void update_line(const char *timebuf);
+void update_line_rst();
 void time_update(void);
 
 #endif /* TIME_UPDATE_H */


### PR DESCRIPTION
Fixing an issue related to #458: after switching to SSB the next was logged with 599. Subsequent or CW QSOs have the right RST as `clear_display()` updates RST according to the mode.

After rig mode switch to SSB:
![image](https://github.com/user-attachments/assets/43665bbc-fa3f-4567-bbe5-1953761c3d98)

First QSO logged:
![image](https://github.com/user-attachments/assets/18517bd2-00f7-4bd7-8087-6c4b57f1716d)
note that after logging the QSO the RST of the next one is correct

Moved the implicit setting of RST out of `clear_display()` into ` rst_set_strings()` and separated the logic and the UI part (`update_line_rst()`).