### PR TITLE
Fix python regexps

### DIFF
--- a/rules/cqww160/cqww160.py
+++ b/rules/cqww160/cqww160.py
@@ -28,7 +28,7 @@ def init(cfg):
 
     # read initial exchange file
     global K_VE_EXCHANGES
-    comment = re.compile("(^#|^$)") # starts with a hash or empty
+    comment = re.compile(r"(^#|^$)") # starts with a hash or empty
     with open(cfg) as file:
         for line in file:
             line = line.strip()

--- a/rules/eudx/eudx.py
+++ b/rules/eudx/eudx.py
@@ -8,7 +8,7 @@ MY_COUNTRY = None
 MY_PREFIX = None
 MY_CONTINENT = None
 
-EU_REGION_PATTERN = re.compile('([A-Z]{2})\d{2}')  # two letters and two numbers
+EU_REGION_PATTERN = re.compile(r'([A-Z]{2})\d{2}')  # two letters and two numbers
 
 EU_COUNTRIES = ['AT', 'BE', 'BG', 'CZ', 'CY', 'HR', 'DK', 'EE',
                 'FI', 'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV',

--- a/rules/mcd/mcd.py
+++ b/rules/mcd/mcd.py
@@ -10,7 +10,7 @@ MEMBERS = {}
 def init(cfg):
     # read initial exchange file
     global MEMBERS
-    comment = re.compile("(^#|^$)") # starts with a hash or empty
+    comment = re.compile(r"(^#|^$)") # starts with a hash or empty
     with open(cfg) as file:
         for line in file:
             line = line.strip()

--- a/rules/mwc/mwc.py
+++ b/rules/mwc/mwc.py
@@ -6,7 +6,7 @@ https://memorial-ok1wc.cz/index.php?page=rules2l
 import re
 
 # match trailing call modifier (e.g. /8, /P, /MM, /QRP, etc.)
-MODIFIER_PATTERN = re.compile('/(\d|[A-Z]+)$')
+MODIFIER_PATTERN = re.compile(r'/(\d|[A-Z]+)$')
 
 def check_exchange(qso):
     call = MODIFIER_PATTERN.sub('', qso.call)   # remove modifier

--- a/rules/raem.py
+++ b/rules/raem.py
@@ -1,7 +1,7 @@
 import re
 
 # e.g. 001 57n85o
-XCHG_PATTERN = re.compile('\d+\s+(\d+)\s*([NS])\s*(\d+)\s*([OW])')
+XCHG_PATTERN = re.compile(r'\d+\s+(\d+)\s*([NS])\s*(\d+)\s*([OW])')
 
 def setup():
     return None

--- a/rules/tesla.py
+++ b/rules/tesla.py
@@ -1,7 +1,7 @@
 import re
 
 # e.g. 023 KN03
-XCHG_PATTERN = re.compile('\d+\s*(\w{2}\d{2})')
+XCHG_PATTERN = re.compile(r'\d+\s*(\w{2}\d{2})')
 
 def setup():
     return None

--- a/rules/ukeidx/ukeidx.py
+++ b/rules/ukeidx/ukeidx.py
@@ -38,7 +38,7 @@ UKEI_DISTRICTS = {
     'GW': ['CF','LD','LL','NP','SA']
 }
 
-DISTRICT_PATTERN = re.compile('[A-Z]+$')    # last block of alphabetics
+DISTRICT_PATTERN = re.compile(r'[A-Z]+$')    # last block of alphabetics
 
 def get_location(dxcc):
     if dxcc.main_prefix in UKEI_DISTRICTS:

--- a/test/rules/cqp_dx/rules/cqp.py
+++ b/test/rules/cqp_dx/rules/cqp.py
@@ -24,7 +24,7 @@ STATES = ['AL', 'AK', 'AZ', 'AR',
 'AB', 'BC', 'MB', 'NB', 'NL', 'NT', 'NS', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'
 ]
 
-MULT_PATTERN = re.compile('[A-Z\s]+$')  # trailing block of letters and spaces
+MULT_PATTERN = re.compile(r'[A-Z\s]+$')  # trailing block of letters and spaces
 
 def init(cfg):
     global MY_STATE


### PR DESCRIPTION
Current python version (3.13) is more strict about escape codes. The _SyntaxWarning: invalid escape sequence ..._ message is fixed by properly defining regexps as raw strings (r"").

To trigger the warning:
```
$ python3
Python 3.13.5 (main, Jun 25 2025, 18:55:22) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> print('\sa\db\w')
<python-input-0>:1: SyntaxWarning: invalid escape sequence '\s'
\sa\db\w
```
The string is interpreted correctly (at least for the moment).
see also https://stackoverflow.com/questions/79275524/invalid-escape-sequences-in-python-3-12-in-a-docker-image