### PR TITLE
Remove INSTALL file from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ config.status
 config.sub
 configure
 depcomp
+INSTALL
 install-sh
 missing
 src/.deps

--- a/INSTALL
+++ b/INSTALL
@@ -1,3 +1,0 @@
-INSTALL
-
-Please see README.md for installation instructions.


### PR DESCRIPTION
The autoconf toolchain really likes to replace INSTALL with its own generic installation instructions, causing noise in the `git diff` output. Since the current file doesn't really have content, just remove it and add INSTALL to .gitignore.

This has been driving me crazy ever since Debian started automatic autoreconf'ing during package builds.

Plain `autoreconf -i` doesn't trigger it, but I do run into it all the time... please consider accepting this.