### PR TITLE
Remove references to internal Hamlib data

### DIFF
--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -120,8 +120,8 @@ int init_tlf_rig(void) {
 			   rigportname);
 
     if (retcode != RIG_OK) {
-        showmsg("Pathname not accepted!");
-        return -1;
+	showmsg("Pathname not accepted!");
+	return -1;
     }
 
     snprintf(speed_string, sizeof speed_string, "%d", serial_rate);
@@ -129,7 +129,7 @@ int init_tlf_rig(void) {
 			   speed_string);
 
     if (retcode != RIG_OK) {
-        showmsg("Speed not accepted!");
+	showmsg("Speed not accepted!");
 	return -1;
     }
 

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -94,6 +94,7 @@ void show_rigerror(char *message, int errcode) {
 int init_tlf_rig(void) {
     freq_t rigfreq;		/* frequency  */
     vfo_t vfo;
+    char speed_string[12];
     int retcode;		/* generic return code from functions */
 
     const struct rig_caps *caps;
@@ -115,10 +116,22 @@ int init_tlf_rig(void) {
     }
 
     g_strchomp(rigportname);	// remove trailing '\n'
-    strncpy(my_rig->state.rigport.pathname, rigportname,
-	    TLFFILPATHLEN - 1);
+    retcode = rig_set_conf(my_rig, rig_token_lookup(my_rig, "rig_pathname"),
+			   rigportname);
 
-    my_rig->state.rigport.parm.serial.rate = serial_rate;
+    if (retcode != RIG_OK) {
+        showmsg("Pathname not accepted!");
+        return -1;
+    }
+
+    snprintf(speed_string, sizeof speed_string, "%d", serial_rate);
+    retcode = rig_set_conf(my_rig, rig_token_lookup(my_rig, "serial_speed"),
+			   speed_string);
+
+    if (retcode != RIG_OK) {
+        showmsg("Speed not accepted!");
+	return -1;
+    }
 
     caps = my_rig->caps;
 

--- a/src/sendqrg.h
+++ b/src/sendqrg.h
@@ -24,16 +24,6 @@
 #include <hamlib/rig.h>
 #include <stdbool.h>
 
-#ifdef HAMLIB_FILPATHLEN
-#define TLFFILPATHLEN HAMLIB_FILPATHLEN
-#else
-#ifdef FILPATHLEN
-#define TLFFILPATHLEN FILPATHLEN
-#else
-#error "(HAMLIB_)FILPATHLEN macro not found"
-#endif
-#endif
-
 bool rig_has_send_morse();
 bool rig_has_stop_morse();
 


### PR DESCRIPTION
Hamlib 5.0 (late 2026) will rearrange its internal data layout, removing the structures-within-structures that have caused many past problems.

This removes the references to the internal port, and substitutes calls to the preferred methods of setting config parameters.

The new code also verifies that the speed is valid.
