### PR TITLE
Set speed for serial rigs only

### DIFF
--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -124,16 +124,18 @@ int init_tlf_rig(void) {
 	return -1;
     }
 
-    snprintf(speed_string, sizeof speed_string, "%d", serial_rate);
-    retcode = rig_set_conf(my_rig, rig_token_lookup(my_rig, "serial_speed"),
-			   speed_string);
-
-    if (retcode != RIG_OK) {
-	showmsg("Speed not accepted!");
-	return -1;
-    }
-
     caps = my_rig->caps;
+
+    if (caps->port_type == RIG_PORT_SERIAL) {
+	snprintf(speed_string, sizeof speed_string, "%d", serial_rate);
+	retcode = rig_set_conf(my_rig, rig_token_lookup(my_rig, "serial_speed"),
+			       speed_string);
+
+	if (retcode != RIG_OK) {
+	    showmsg("Speed not accepted!");
+	    return -1;
+	}
+    }
 
     can_send_morse = caps->send_morse != NULL;
 #if HAMLIB_VERSION >= 400


### PR DESCRIPTION
Follow-up to #480: setting of serial speed for non-serial rigs fails due to internal checks in Hamlib function.
```
Rig model number is 2
Rig speed is 2400
Trying to start rig control
Speed not accepted!
```
Previously (when using low-level direct field setting) the value was simply unused and ignored. (2400 is the default speed in TLF)

The fix checks if we have a serial rig before setting the speed.
Inspired by Hamlib's `src/conf.c`:
```
...
    case TOK_SERIAL_SPEED:
        if (rp->type.rig != RIG_PORT_SERIAL)
        {
            return -RIG_EINVAL;
        }
...
```