### PR TITLE
Fix tests for >=cmocka-1.1.8

### DIFF
--- a/test/test.h
+++ b/test/test.h
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <string.h>
 #include <stdbool.h>


### PR DESCRIPTION
In 1.1.8 CMocka changed the list of required includes for tests. Without the patch it will complain about missing definitions for 'uintptr_t'.