### PR TITLE
Disable man-db update triggers in workflows

### DIFF
--- a/.github/workflows/ci-build-ubuntu-22.yml
+++ b/.github/workflows/ci-build-ubuntu-22.yml
@@ -21,6 +21,10 @@ jobs:
       run: cat /etc/os-release
     - name: Install dependencies
       run: |
+        # first disable man-db update triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+        #
         sudo apt-get -qq update
         sudo apt-get install -y libhamlib-dev libxmlrpc-core-c3-dev libglib2.0-dev libcmocka-dev python3-pexpect python3-dev astyle
     - name: Set up datadir

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,6 +21,10 @@ jobs:
       run: cat /etc/os-release
     - name: Install dependencies
       run: |
+        # first disable man-db update triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+        #
         sudo apt-get -qq update
         sudo apt-get install -y libhamlib-dev libxmlrpc-core-c3-dev libglib2.0-dev libcmocka-dev python3-pexpect python3-dev astyle
     - name: Set up datadir


### PR DESCRIPTION
apt update in workflows triggers a potentially lengthy and completely useless man.db update.

A good run -- update was quick:
<img width="1496" height="341" alt="image" src="https://github.com/user-attachments/assets/235e2eca-37e1-415a-b1e8-27fd517ad99a" />

A bad run -- took twice as much time
<img width="1496" height="341" alt="image" src="https://github.com/user-attachments/assets/52cf04f9-03da-4c41-b2d8-acf92185843d" />

The fix disables man-db update upon installing packages.
(see also https://github.com/actions/runner-images/issues/10977)