### PR TITLE
fix: eluminate 'double free' error at startup in case of QTC=BOTH

### DIFF
--- a/src/readqtccalls.c
+++ b/src/readqtccalls.c
@@ -99,6 +99,8 @@ int readqtccalls() {
 	}
 
 	free(inputbuffer);
+	inputbuffer = NULL;
+	inputbuffer_len = 0;
 
 	next_qtc_qso = last_qtc;
 
@@ -141,6 +143,7 @@ int readqtccalls() {
 
 	free(inputbuffer);
 	inputbuffer = NULL;
+	inputbuffer_len = 0;
 	fclose(fp);
     }
 
@@ -168,6 +171,7 @@ int readqtccalls() {
 
 	free(inputbuffer);
 	inputbuffer = NULL;
+	inputbuffer_len = 0;
 	fclose(fp);
     }
 
@@ -190,6 +194,8 @@ int readqtccalls() {
 	}
 
 	free(inputbuffer);
+	inputbuffer = NULL;
+	inputbuffer_len = 0;
 	fclose(fp);
     }
 


### PR DESCRIPTION
There is a double free error at startup if the `QTC=BOTH` settings in rule file.

The problem is that after reading the first file, the buffer is freed, and the code wants to use that and free it again. Set buffer to `NULL` and set `0` to the length after all free prevents this behavior.