### PR TITLE
Make Enter and similar keys keep working when editing call and exchange

### DIFF
--- a/src/calledit.c
+++ b/src/calledit.c
@@ -37,11 +37,11 @@
 #include "ui_utils.h"
 
 
-void calledit(void) {
+int calledit(void) {
 
     int i = 0, l, b;
     int j = 0;
-    int x = 0;
+    int x = -1;
     int cnt = 0, insertflg = 0;
     char call1[30], call2[10];
 
@@ -79,7 +79,7 @@ void calledit(void) {
 	// Ctrl-A (^A) or <Home>, move to head of callsign field.
 	if (i == CTRL_A || i == KEY_HOME) {
 	    b = 0;
-	    x = 0;
+	    i = 0;
 	}
 
 	// Ctrl-E (^E) or <End>, move to end of callsign field, exit edit mode.
@@ -140,6 +140,13 @@ void calledit(void) {
 	    else
 		insertflg = 0;
 
+	    // these keys terminate the callinput() loop so they should also
+	    // terminate calledit(); pass them through
+	} else if (i == '\n' || i == KEY_ENTER || i == SPACE || i == TAB
+		   || i == CTRL_K || i == ',' || i == BACKSLASH) {
+	    x = i;
+	    break;
+
 	    // Any character left other than <Escape>.
 	} else if (i != ESCAPE) {
 
@@ -177,7 +184,7 @@ void calledit(void) {
 
 		searchlog();
 
-	    } else if (x != 0)
+	    } else if (i != 0)
 		i = ESCAPE;
 
 	} else
@@ -194,6 +201,8 @@ void calledit(void) {
 
     attron(A_STANDOUT);
     searchlog();
+
+    return x;
 }
 
 int insert_char(int curposition) {

--- a/src/calledit.h
+++ b/src/calledit.h
@@ -21,7 +21,7 @@
 #ifndef CALLEDIT_H
 #define CALLEDIT_H
 
-void calledit(void);
+int calledit(void);
 int insert_char(int);
 
 #endif /* CALLEDIT_H */

--- a/src/callinput.c
+++ b/src/callinput.c
@@ -312,7 +312,7 @@ int callinput(void) {
 	    // <Home>, enter call edit when call field is not empty.
 	    case KEY_HOME: {
 		if ((*current_qso.call != '\0') && (ungetch(x) == OK)) {
-		    calledit();
+		    x = calledit(); // pass through KEY_ENTER and friends from editing
 		}
 
 		break;
@@ -321,7 +321,7 @@ int callinput(void) {
 	    // Left Arrow, enter call edit when call field is not empty, or band down.
 	    case KEY_LEFT: {
 		if (*current_qso.call != '\0') {
-		    calledit();
+		    x = calledit(); // pass through KEY_ENTER and friends from editing
 		} else {
 		    handle_bandswitch(BAND_DOWN);
 		}
@@ -827,6 +827,8 @@ int callinput(void) {
 	    }
 	}
 
+	/* end call input */
+	/* keep this list of keys in sync with the list in calledit() */
 	if (x == '\n' || x == KEY_ENTER || x == SPACE || x == TAB
 		|| x == CTRL_K || x == ',' || x == BACKSLASH) {
 	    break;


### PR DESCRIPTION
When editing the call field, Enter didn't anything. When editing the exchange field, Enter at least exited the edit mode, but did not log the QSO.

Make Enter, Backslash, Tab and similar keys exit editing, and perform their normal function so QSOs can be logged faster.

This also fixes the bug that editing the call did not terminate on unhandled keys (like End in that context).