### PR TITLE
Grab spot nearest to current frequency

### DIFF
--- a/src/bandmap.c
+++ b/src/bandmap.c
@@ -969,38 +969,43 @@ spot *copy_spot(spot *data) {
 
 /** Search partialcall in filtered bandmap
  *
- * Lookup given partial call in the list of filtered bandmap spots.
- * Return a copy of the first entry found (means with the lowest frequency).
+ * Look up given partial call in the list of filtered bandmap spots.
+ * Return a copy of the entry found closest to the specified frequency.
  *
  * \param 	partialcall - part of call to look up
+ * \param 	freq - frequency of center of interest
  * \return 	spot * structure with a copy of the found spot
  * 		or NULL if not found (You have to free the structure
  * 		after use).
  */
-spot *bandmap_lookup(char *partialcall) {
+spot *bandmap_lookup(char *partialcall, freq_t freq) {
     spot *result = NULL;
 
     if ((*partialcall != '\0') && (spots->len > 0)) {
-	int i;
+	int index = -1;
+	freq_t min_df = GHz(1);
 
 	pthread_mutex_lock(&bm_mutex);
 
-	for (i = 0; i < spots->len; i++) {
-	    spot *data;
-	    data = g_ptr_array_index(spots, i);
+	for (int i = 0; i < spots->len; i++) {
+	    spot *data = g_ptr_array_index(spots, i);
+	    freq_t df = DISTANCE(data->freq, freq);
 
-	    if (strstr(data->call, partialcall) != NULL) {
-
-		/* copy data into a new Spot structure */
-		result = copy_spot(data);
-
-		break;
+	    if (df < min_df && strstr(data->call, partialcall) != NULL) {
+		min_df = df;
+		index = i;
 	    }
 	}
 
-	pthread_mutex_unlock(&bm_mutex);
+	if (index >= 0) {
+	    /* copy data into a new Spot structure */
+	    spot *data = g_ptr_array_index(spots, index);
+	    result = copy_spot(data);
+	}
 
+	pthread_mutex_unlock(&bm_mutex);
     }
+
     return result;
 }
 

--- a/src/bandmap.h
+++ b/src/bandmap.h
@@ -135,7 +135,7 @@ void bandmap_show();
  * - 'B', 'D', 'M' switches filtering for band, dupes and mode on or off.
  */
 
-spot *bandmap_lookup(char *partialcall);
+spot *bandmap_lookup(char *partialcall, freq_t freq);
 
 spot *bandmap_next(bool upwards, freq_t freq);
 

--- a/src/grabspot.c
+++ b/src/grabspot.c
@@ -47,7 +47,7 @@ freq_t grabspot(void) {
 	return 0;   // call input is empty
     }
 
-    spot *data = bandmap_lookup(current_qso.call);
+    spot *data = bandmap_lookup(current_qso.call, freq);
 
     if (data == NULL) {
 	return 0;   // no spot found

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1341,10 +1341,11 @@ Enter QSO edit mode.
 .
 .TP
 .B Alt-G
-Grab first spot from bandmap which has the characters in the call input field
-in its call.
+Selects (grabs) the entry from the bandmap whose callsign contains
+the characters entered in the call input field and
+which is located closest to the current operating frequency.
 .
-Allows the operator to selectively grab a specific call from the bandmap.
+Allows the operator to selectively switch to a specific call from the bandmap.
 .
 .TP
 .B Alt-H


### PR DESCRIPTION
This fix addresses the issue that grab can lead to unexpected result, especially when the bandmap is full during a contest.
An example situation is as follows:
- on a full bandmap a rare station appears (say a VK)
- one grabs VK
- rig switches to another unrelated station containing VK in its callsign lower the band

By looking for a match closest to the current frequency such issues can be at least reduced. 