### PR TITLE
Fix DXCC lookup

### DIFF
--- a/src/dxcc.c
+++ b/src/dxcc.c
@@ -33,7 +33,7 @@
 GPtrArray *dxcc;
 GPtrArray *prefix;
 GHashTable *hashed_prefix;
-int two_char_prefix_index[36 * 36];
+static int two_char_prefix_index[36 * 36];
 bool have_exact_matches;
 char cty_dat_version[12];   // VERyyyymmdd
 
@@ -259,10 +259,11 @@ void prefix_add(char *pfxstr) {
 			GINT_TO_POINTER(index));
 
     /* build 2-char prefix hash */
-    if (strlen(pfxstr) >= 2) {
+    int pfxlen = strlen(pfxstr);
+    if (pfxlen >= 2) {
 	int key = prefix_hash_key(pfxstr);
-	if (two_char_prefix_index[key] == TCPI_NONE) {
-	    two_char_prefix_index[key] = index;     // first one
+	if (two_char_prefix_index[key] == TCPI_NONE && pfxlen == 2) {
+	    two_char_prefix_index[key] = index;     // unique 2-char prefix
 	} else {
 	    two_char_prefix_index[key] = TCPI_AMB;  // ambiguous
 	}

--- a/test/test_getctydata.c
+++ b/test/test_getctydata.c
@@ -145,6 +145,10 @@ void test_best_match(void **state) {
     assert_string_equal(best_prefix("W3A"), "W");
     assert_string_equal(best_prefix("KL7ND"), "KL");
     assert_string_equal(best_prefix("G8AAA"), "G");
+    assert_string_equal(best_prefix("IT9X"), "IT9");
+    assert_string_equal(best_prefix("IT1X"), "I");
+    assert_string_equal(best_prefix("FG9X"), "FG");
+    assert_string_equal(best_prefix("F1X"), "F");
 }
 
 void test_location_known(void **state) {


### PR DESCRIPTION
DXCC lookup uses a cache for 2-character prefixes. It has an issue as all IT calls resolved as Sicily (IT9).
It is caused by too greedy caching: prefixes from more that 2-char calls shall not be cached, just used for marking the prefix as ambiguous.

Current implementation:
IT -> IT9

Should be:
IT -> ambiguous (as it could be a IT9 or any other ITx)

First added tests to reproduce the issue.