### PR TITLE
Update workflow to use latest action/checkout

### DIFF
--- a/.github/workflows/ci-build-ubuntu-22.yml
+++ b/.github/workflows/ci-build-ubuntu-22.yml
@@ -16,7 +16,7 @@ jobs:
       AM_COLOR_TESTS: always
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@main
     - name: Show OS info
       run: cat /etc/os-release
     - name: Install dependencies

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,7 +16,7 @@ jobs:
       AM_COLOR_TESTS: always
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@main
     - name: Show OS info
       run: cat /etc/os-release
     - name: Install dependencies


### PR DESCRIPTION
Action runs get this warning (see https://github.com/zcsahok/tlf/actions/runs/28259700334)

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

We had a similar one in #432 where the version of _actions/checkout_ (https://github.com/actions/checkout) was bumped.
Let's try now to use the latest version of it and hope that it always takes the current Node version.
