### PR TITLE
Fix info page

### DIFF
--- a/src/callinput.c
+++ b/src/callinput.c
@@ -419,8 +419,9 @@ int callinput(void) {
 
 	    // Colon, prefix for entering commands or changing parameters.
 	    case ':': {
-		changepars();
 		current_qso.call[0] = '\0';
+		HideSearchPanel();
+		changepars();
 		x = 0;
 		clear_display();
 		attron(COLOR_PAIR(C_LOG) | A_STANDOUT);

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -136,7 +136,7 @@ void set_trxmode(int mode) {
 }
 
 
-int changepars(void) {
+void changepars(void) {
 
     char parameterstring[20] = "";
     char parameters[52][19];
@@ -673,16 +673,6 @@ int changepars(void) {
 	    packet();
     }
 
-    refreshp();
-
-    attron(modify_attr(COLOR_PAIR(NORMCOLOR)));
-
-    mvaddstr(12, 29, "            ");
-    move(12, 29);
-    refreshp();
-    current_qso.call[0] = '\0';
-
-    return (0);
 }
 
 /* -------------------------------------------------------------- */

--- a/src/changepars.c
+++ b/src/changepars.c
@@ -726,7 +726,8 @@ void networkinfo(void) {
 
     mvprintw(9 + n_nodes, 10, "Cluster    : %s", pr_hostaddress);
     mvprintw(10 + n_nodes, 10, "TNCport    : %s", tncportname);
-    mvprintw(11 + n_nodes, 10, "RIGport    : %s", rigportname);
+    mvprintw(11 + n_nodes, 10, "RIGport    : %s",
+	     (rigportname != NULL ? rigportname : "n/a"));
     mvprintw(12 + n_nodes, 10, "Band output: %s",
 	     (use_bandoutput ? "on" : "off"));
     mvprintw(13 + n_nodes, 10, "callmaster : %s",

--- a/src/changepars.h
+++ b/src/changepars.h
@@ -23,7 +23,7 @@
 
 
 void set_trxmode_internally(int mode);
-int changepars(void);
+void changepars(void);
 void networkinfo(void);
 void multiplierinfo(void);
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1434,7 +1434,7 @@ static config_t logcfg_configs[] = {
     {"PLUGIN_CONFIG",      CFG_STRING(plugin_config)},
 #endif
 
-    {"RIGPORT",         CFG_STRING_NOCHOMP(rigportname)},
+    {"RIGPORT",         CFG_STRING(rigportname)},
     {"ROTPORT",         CFG_STRING(rotportname)},
     {"CLUSTERLOGIN",    CFG_STRING_STATIC_NOCHOMP(clusterlogin, 80)},
 

--- a/src/parse_logcfg.h
+++ b/src/parse_logcfg.h
@@ -120,9 +120,5 @@ typedef struct {
         (cfg_arg_t){.char_p=var, .size=bufsize, \
                     .string_type=STATIC}
 
-#define CFG_STRING_NOCHOMP(var) NEED_PARAM, cfg_string, \
-        (cfg_arg_t){.char_pp=&var, \
-                    .string_type=DYNAMIC}
-
 
 #endif // PARSE_LOGCFG_H

--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -104,6 +104,9 @@ void ShowSearchPanel(void) {
 }
 
 void HideSearchPanel(void) {
+    if (!initialized) {
+	return;
+    }
     hide_panel(search_panel);
 }
 

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -119,7 +119,6 @@ int init_tlf_rig(void) {
 	return -1;
     }
 
-    g_strchomp(rigportname);	// remove trailing '\n'
     retcode = rig_set_conf(my_rig, rig_token_lookup(my_rig, "rig_pathname"),
 			   rigportname);
 

--- a/test/test_parse_logcfg.c
+++ b/test/test_parse_logcfg.c
@@ -858,7 +858,7 @@ void test_rigport(void **state) {
     int rc = call_parse_logcfg("RIGPORT = /dev/rigport \r\n");
     assert_int_equal(rc, PARSE_OK);
     assert_non_null(rigportname);
-    assert_string_equal(rigportname, "/dev/rigport \r\n");  // FIXME...
+    assert_string_equal(rigportname, "/dev/rigport");
 }
 
 void test_rotport(void **state) {


### PR DESCRIPTION
Fixing two minor issues with the info page:

1. search panel stays open
2. rig port name has a black tail when TLF was called without rig control

The screenshot below shows what I mean. To reproduce it

- start with rig control disabled (`-r` option)
- enter a callsign
- type `:inf`

<img width="731" height="449" alt="image" src="https://github.com/user-attachments/assets/1de75ee8-eb7d-42d5-b996-5bd6b0442c6e" />


The first commit addresses the search panel issue.

It is now explicitly hidden before calling `changepars()`. As the search panel is triggered from `callinput()`, the hiding of it is also done there.
Removed the extra clearing stuff from the end of `changepars()` as this is anyway done in the `callinput()` loop.
Moved resetting of the current callsign before the call of `changepars()`, so that does have to bother with it.
Made `changepars()` void, as the return value had no meaning.
`HideSearchPanel()` does nothing in case the search panel hasn't been initialized yet.

