### PR TITLE
Fix missing files in rules subdir that are not distributed

### DIFF
--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -1157,12 +1157,21 @@ the moment there are at least three different versions:
 Q: The generated ADIF file misses some entries, e.g. the CONTEST_ID which is
 used by my log program during import. Any idea to work around it?
 
-A: You can use 'adifmerg' from OH7BF for it. It allows to post process the
+A: You can use [adifmerg](https://github.com/oh7bf/adifmerg) from OH7BF for it.
+It allows to post process the
 ADIF file. For instance you can add the missing CONTEST_ID with:
 
-```
+```sh
 adifmerg -f qso.adi -A CONTEST_ID=<my contest name> -o > file.adi
 ```
+
+With the [ADIF Multitool](https://github.com/flwyd/adif-multitool) from WT0RJ,
+you can do it (and more!) with:
+
+```sh
+adifmt edit --add 'contest_id=<my contest name>' mylog.adi > file.adi
+```
+
 Have a look at [www.adif.org]() for the already standardized contest IDs.
 
 Q: I am using TLF in an XTerm. How can I configure used colors, fonts and

--- a/rules/Makefile.am
+++ b/rules/Makefile.am
@@ -3,7 +3,22 @@ RULES_FILES = arrl10m_dx arrl160m_usa arrldx_dx arrldx_usa arrlfd arrlss \
 	      dxped eusprint focmarathon lzdx pacc_pa pacc_dx \
 	      okom qso spdx_dx spdx_sp ssa_mt stewperry template \
 	      wpx waedc_dx waedc_eu waedc_dx_rtty waedc_eu_rtty \
-	      aadx_dx aadx_as
+	      aadx_dx aadx_as raem tesla tesla.py raem.py \
+	      cqww160/cqww160 cqww160/cqww160.py cqww160/cqww160.txt \
+	      hskc/hskc.py hskc/hskc \
+	      ukeidx/ukeidx.py ukeidx/ukeidx \
+	      mwc/mwc mwc/mwc.py \
+	      eakingofspain/eakingofspain eakingofspain/eakingofspain.py \
+	      iota/iota iota/iota.py \
+	      ksqp/ksqp ksqp/ksqp.py \
+	      hadx/hadx hadx/hadx.py \
+	      cqp/cqp_ca_mults cqp/cqp_ca \
+	      mcd/mcd.py mcd/mcd mcd/mcd.txt \
+	      mst/mst \
+	      naqp/naqp.py naqp/naqp \
+	      neqp/neqp_mults neqp/neqp neqp/neqp_mults_outside \
+	      eudx/eudx.py eudx/eudx
+
 SUBDIRS =
 
 rulesdir = $(pkgdatadir)/rules

--- a/rules/iota/iota
+++ b/rules/iota/iota
@@ -12,6 +12,7 @@ CONTEST_MODE
 GENERIC_MULT = BAND
 
 # scoring and mults handled by iota.py
+# Island stations shall specify their reference via PLUGIN_CONFIG=CC-NNN
 
 CABRILLO=UNIVERSAL
 CABRILLO-CONTEST=RSGB-IOTA

--- a/rules/iota/iota.py
+++ b/rules/iota/iota.py
@@ -75,6 +75,8 @@ def check_exchange(qso):
 
     mult = ''
 
+    # As per-mode (CW/SSB) multipliers are not supported yet
+    # it is worked around by appending c/s to the multiplier value.
     xchg = f'{serial:03}'
     if ref:
         xchg += ' ' + ref


### PR DESCRIPTION
Some files in the `rules` subdir are not making it into the dist tar ball.

This PR also add some precious hints for the iota rule, gleaned from a past PR.
Not really related, it also documents of a precious tool for handling Cbr and ADIF.