### PR TITLE
Fix restoring of call input field by Ctrl-U

### DIFF
--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -48,7 +48,7 @@ void cleanup_comment(void) {
 /* restore comment */
 void restore_comment(void) {
     if (comment_backup) {
-	g_strlcpy(current_qso.comment, comment_backup, sizeof(current_qso.comment));
+	g_strlcpy(current_qso.comment, comment_backup, COMMENT_SIZE);
 	g_free(comment_backup);
 	comment_backup = NULL;
     }

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -67,7 +67,7 @@ void cleanup_hiscall(void) {
 /* restore call */
 void restore_hiscall(void) {
     if (call_backup) {
-	g_strlcpy(current_qso.call, call_backup, sizeof(current_qso.call));
+	g_strlcpy(current_qso.call, call_backup, MAX_CALL_LENGTH + 1);
 	g_free(call_backup);
 	call_backup = NULL;
     }


### PR DESCRIPTION
Fixing the truncation of the call when restoring it using Ctrl-U. (feature introduced with #369)

To reproduce the issue enter a call longer than 7 characters, say HB9ASDFGHJ.
Then press Ctrl-U twice -- first to clean, then to restore the call field.
The resulting callsign will be

- on a 32-bit system: HB9
- on a 64-bit system: HB9ASDF

Caused by using `sizeof(current_qso.call)` as the size of the call buffer. `current_qso.call` is in fact a pointer initialized in `main.c` as
```
    current_qso.call = g_malloc0(CALL_SIZE);
```
hence only the first 3 or 7 characters are restored.

Changed buffer size to its effective value: `MAX_CALL_LENGTH + 1`

Note that `CALL_SIZE` (=20) has -- incorrectly -- no direct relation to `MAX_CALL_LENGTH` (=13 < 20, so OK). 