### PR TITLE
Drop now unused and undefined variable/type.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -348,7 +348,6 @@ pthread_mutex_t tlf_rig_mutex = PTHREAD_MUTEX_INITIALIZER;
 rmode_t rmode;			/* radio mode of operation */
 pbwidth_t width;
 vfo_t vfo;			/* vfo selection */
-port_t myport;
 int ssb_bandwidth = 3000;
 int cw_bandwidth = 0;
 int serial_rate = 2400;


### PR DESCRIPTION
Fix compilation error with latest Hamlib5.  Definition of hamlib_port_t was moved to a separate include file, so not defined.

This should have been is the first PR(#480) - sorry for the extra hassle.