### PR TITLE
Read supercheckpartial's MASTER.SCP version

### DIFF
--- a/src/searchlog.c
+++ b/src/searchlog.c
@@ -771,6 +771,11 @@ int load_callmaster(void) {
 	if (read > 0) {
 	    g_strstrip(s_inputbuffer);
 
+	    // # Release 2026.05.13
+	    if (strncmp(s_inputbuffer, "# Release ", 10) == 0) {
+		g_strlcpy(callmaster_version, s_inputbuffer + 10, sizeof(callmaster_version));
+	    }
+
 	    /* skip comment lines and calls shorter than 3 chars */
 	    if (s_inputbuffer[0] == '#' || strlen(s_inputbuffer) < 3) {
 		continue;
@@ -778,7 +783,7 @@ int load_callmaster(void) {
 
 	    /* store version */
 	    if (strlen(s_inputbuffer) == 11 && strncmp(s_inputbuffer, "VER", 3) == 0) {
-		strcpy(callmaster_version, s_inputbuffer);      // save it
+		g_strlcpy(callmaster_version, s_inputbuffer, sizeof(callmaster_version));
 	    }
 
 	    char *call = g_ascii_strup(s_inputbuffer, 11);


### PR DESCRIPTION
The _callmaster_ file previously maintained by K6TU included a VERyyyyddmm entry to indicate the version of the file.  
The current format (MASTER.SCP from  www.supercheckpartial.com) does not appear to contain a VER entry, but rather a comment line in the header that indicates the version
```
!!Order,1,1
#
# Super Check Partial
# Release 2026.08.14
# Generated by bb-scp
#
...
```

I tried to contact the developer at supercheckpartial to get an official statement about the format, but did not receive any response.

This code change still support the old version string. In fact it has precedence over the comment line.
Version is shown by ":INF" as
```
          callmaster : 2026.08.14                                               
          cty.dat    : VER20260814  
```