### PR TITLE
Simplify keyer activation

### DIFF
--- a/src/callinput.c
+++ b/src/callinput.c
@@ -884,8 +884,9 @@ int callinput(void) {
 	    }
 	}
 
+	// leave callinput() function
 	if (x == '\n' || x == KEY_ENTER || x == SPACE || x == TAB
-		|| x == CTRL_K || x == ',' || x == BACKSLASH) {
+		|| x == BACKSLASH) {
 	    break;
 	}
 

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -340,9 +340,9 @@ int getexchange(void) {
 	    }
 	}
 
-	/* <Enter>, <Tab>, Ctl-K, '\' */
+	/* <Enter>, <Tab>, '\' */
 	if (x == '\n' || x == KEY_ENTER || x == TAB
-		|| x == CTRL_K || x == BACKSLASH) {
+		|| x == BACKSLASH) {
 
 	    if ((contest->exchange_serial && current_qso.comment[0] >= '0'
 		    && current_qso.comment[0] <= '9')) {	/* align serial nr. */

--- a/src/getexchange.c
+++ b/src/getexchange.c
@@ -310,13 +310,6 @@ int getexchange(void) {
 		break;
 	    }
 
-	    case ',':		// Keyboard Morse
-	    case CTRL_K: {	// Ctrl-K
-		move(5, 0);
-		keyer();
-		x = 0;
-		break;
-	    }
 	    case '\n':
 	    case KEY_ENTER: {
 		/* log QSO immediately if CT compatible

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -95,7 +95,7 @@ static void tune() {
 
 //
 // handle common keys
-// F1..F11, Alt-0..9, _ (underscore), PgUp, PgDn, Alt-W, Alt-T
+// F1..F11, Alt-0..9, _ (underscore), PgUp, PgDn, Alt-W, Alt-T, Ctrl-K, ','
 //
 // returns 0:   if the key was handled
 //         key: if the key was not handled
@@ -288,11 +288,11 @@ int handle_common_key(int key) {
 	    break;
 	}
 
-	// Ctrl-K, ',' activate keyer
-	case ',':		// Keyboard Morse
-	case CTRL_K: {	// Ctrl-K
-	    move(5, 0);
+	// Ctrl-K, ',' - activate keyboard keyer
+	case ',':
+	case CTRL_K: {
 	    keyer();
+
 	    break;
 	}
 
@@ -328,7 +328,7 @@ void keyer(void) {
     attron(COLOR_PAIR(C_LOG) | A_STANDOUT);
 
     if (panel == NULL) {
-	win = newwin(KEYER_WIN_HEIGHT, KEYER_WIN_WIDTH, KEYER_Y, KEYER_Y);
+	win = newwin(KEYER_WIN_HEIGHT, KEYER_WIN_WIDTH, KEYER_Y, KEYER_X);
 	if (win == NULL)
 	    return;
 	panel = new_panel(win);
@@ -411,7 +411,10 @@ void keyer(void) {
 	    }
 	}
 
-	x = handle_common_key(x);
+	if (x != ',') {
+	    // ',' should be handled as normal character inside keyboard keyer
+	    x = handle_common_key(x);
+	}
 
 	x = toupper(x);
 

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -33,6 +33,7 @@
 #include "clear_display.h"
 #include "globalvars.h"
 #include "keystroke_names.h"
+#include "keyer.h"
 #include "netkeyer.h"
 #include "nicebox.h"		// Includes curses.h
 #include "sendbuf.h"
@@ -284,6 +285,14 @@ int handle_common_key(int key) {
 		mvprintw(0, 19, "%-2i", cqdelay);
 	    }
 
+	    break;
+	}
+
+	// Ctrl-K, ',' activate keyer
+	case ',':		// Keyboard Morse
+	case CTRL_K: {	// Ctrl-K
+	    move(5, 0);
+	    keyer();
 	    break;
 	}
 

--- a/src/logit.c
+++ b/src/logit.c
@@ -33,7 +33,6 @@
 #include "clear_display.h"
 #include "getexchange.h"
 #include "globalvars.h"
-#include "keyer.h"
 #include "keystroke_names.h"
 #include "log_to_disk.h"
 #include "printcall.h"
@@ -69,7 +68,6 @@ void logit(void) {
     extern int defer_store;
 
     int callreturn = 0;
-    int cury, curx;
 
     cleanup();
     clear_display();
@@ -192,14 +190,6 @@ void logit(void) {
 
 	    log_qso();
 	}
-
-	if (callreturn == CTRL_K || callreturn == 44) {	/*  CTRL K  */
-	    getyx(stdscr, cury, curx);
-	    move(5, 0);
-	    keyer();
-	    move(cury, curx);
-	}
-
     }
 }
 


### PR DESCRIPTION
As discussed in PR #532 this is a rework of Ctrl-K and ',' handling in callinput() and getexchange().

It is handled now in one place - handle_common_keys().
Ctrl-K or ',' no longer leaves the according input loops.